### PR TITLE
feat: add `run` command for subprocess env injection

### DIFF
--- a/src/commands/env/print.ts
+++ b/src/commands/env/print.ts
@@ -5,6 +5,7 @@ import yamlLib from 'js-yaml';
 import { loadEnvironment } from '../../core/environment.js';
 import { loadConfig } from '../../core/config.js';
 import { resolve } from '../../core/resolver.js';
+import { replaceSecrets } from '../../core/env-vars.js';
 import { SecretRef } from '../../core/types.js';
 import { SecretProvider } from '../../providers/provider.js';
 import { resolveProvider } from '../../providers/index.js';
@@ -73,36 +74,6 @@ export default class EnvPrint extends Command {
                 this.log(yamlLib.dump(output).trimEnd());
         }
     }
-}
-
-async function replaceSecrets(
-    values: Record<string, unknown>,
-    env: string,
-    provider: SecretProvider,
-    mode: 'reveal' | 'ref'
-): Promise<Record<string, unknown>> {
-    const result: Record<string, unknown> = {};
-
-    for (const [key, value] of Object.entries(values)) {
-        if (value instanceof SecretRef) {
-            if (mode === 'reveal') {
-                result[key] = await provider.get(env, value.path);
-            } else {
-                result[key] = provider.ref(env, value.path);
-            }
-        } else if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
-            result[key] = await replaceSecrets(
-                value as Record<string, unknown>,
-                env,
-                provider,
-                mode
-            );
-        } else {
-            result[key] = value;
-        }
-    }
-
-    return result;
 }
 
 function flattenConfig(values: Record<string, unknown>, prefix = ''): Record<string, unknown> {

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,0 +1,58 @@
+import { Command, Flags } from '@oclif/core';
+import path from 'node:path';
+import os from 'node:os';
+import { spawnSync } from 'node:child_process';
+import { loadEnvironment } from '../core/environment.js';
+import { loadConfig } from '../core/config.js';
+import { resolve } from '../core/resolver.js';
+import { replaceSecrets, flattenToEnvRecord } from '../core/env-vars.js';
+import { resolveProvider } from '../providers/index.js';
+
+export default class Run extends Command {
+    static override description =
+        'Run a command with resolved environment config and secrets as env vars';
+
+    static override examples = [
+        '<%= config.bin %> run --env prod -- node server.js',
+        '<%= config.bin %> run --env dev -- docker compose up'
+    ];
+
+    static override strict = false;
+
+    static override flags = {
+        env: Flags.string({ description: 'Environment name', required: true }),
+        'config-dir': Flags.string({ description: 'Override config directory', hidden: true })
+    };
+
+    async run(): Promise<void> {
+        const { argv, flags } = await this.parse(Run);
+        const command = argv as string[];
+
+        if (command.length === 0) {
+            this.error('No command specified. Provide a command after "--".');
+        }
+
+        const cwd = process.cwd();
+        const envDef = await loadEnvironment(cwd, flags.env);
+        const resolved = await resolve(flags.env, (name) => loadEnvironment(cwd, name));
+        const config = loadConfig(cwd);
+        const configDirPath =
+            flags['config-dir'] ?? path.join(os.homedir(), '.config', 'keyshelf', config.name);
+        const provider = resolveProvider(envDef, config, configDirPath);
+
+        const replaced = await replaceSecrets(resolved.values, flags.env, provider, 'reveal');
+        const envRecord = flattenToEnvRecord(replaced);
+
+        const [cmd, ...args] = command;
+        const result = spawnSync(cmd, args, {
+            stdio: 'inherit',
+            env: { ...process.env, ...envRecord }
+        });
+
+        if (result.error) {
+            this.error(`Failed to run command: ${result.error.message}`);
+        }
+
+        this.exit(result.status ?? 1);
+    }
+}

--- a/src/core/env-vars.ts
+++ b/src/core/env-vars.ts
@@ -1,0 +1,51 @@
+import { SecretRef } from './types.js';
+import { SecretProvider } from '../providers/provider.js';
+
+/** Recursively walk values, resolving SecretRef via provider. */
+export async function replaceSecrets(
+    values: Record<string, unknown>,
+    env: string,
+    provider: SecretProvider,
+    mode: 'reveal' | 'ref'
+): Promise<Record<string, unknown>> {
+    const result: Record<string, unknown> = {};
+
+    for (const [key, value] of Object.entries(values)) {
+        if (value instanceof SecretRef) {
+            result[key] =
+                mode === 'reveal'
+                    ? await provider.get(env, value.path)
+                    : provider.ref(env, value.path);
+        } else if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+            result[key] = await replaceSecrets(
+                value as Record<string, unknown>,
+                env,
+                provider,
+                mode
+            );
+        } else {
+            result[key] = value;
+        }
+    }
+
+    return result;
+}
+
+/** Flatten a nested object to a flat Record<string, string> with uppercased, underscore-separated keys. */
+export function flattenToEnvRecord(
+    obj: Record<string, unknown>,
+    prefix = ''
+): Record<string, string> {
+    const result: Record<string, string> = {};
+
+    for (const [key, value] of Object.entries(obj)) {
+        const envKey = prefix ? `${prefix}_${key}` : key;
+        if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+            Object.assign(result, flattenToEnvRecord(value as Record<string, unknown>, envKey));
+        } else {
+            result[envKey.toUpperCase()] = String(value);
+        }
+    }
+
+    return result;
+}

--- a/test/commands/run.test.ts
+++ b/test/commands/run.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import yaml from 'js-yaml';
+import Run from '../../src/commands/run.js';
+import { saveEnvironment } from '../../src/core/environment.js';
+import { LocalProvider } from '../../src/providers/local.js';
+import { SecretRef } from '../../src/core/types.js';
+
+describe('run command', () => {
+    let tmpDir: string;
+    let origCwd: string;
+    let configDir: string;
+    let outFile: string;
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'keyshelf-run-'));
+        configDir = path.join(tmpDir, '.config');
+        outFile = path.join(tmpDir, 'output.txt');
+        origCwd = process.cwd();
+        process.chdir(tmpDir);
+        fs.mkdirSync(path.join(tmpDir, '.keyshelf', 'environments'), { recursive: true });
+        fs.writeFileSync(
+            path.join(tmpDir, 'keyshelf.yml'),
+            yaml.dump({ name: 'test-project', provider: { adapter: 'local' } })
+        );
+    });
+
+    afterEach(() => {
+        process.chdir(origCwd);
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+        vi.restoreAllMocks();
+    });
+
+    it('runs a command with resolved config values as env vars', async () => {
+        await saveEnvironment(tmpDir, 'dev', {
+            imports: [],
+            values: { database: { host: 'localhost', port: 5432 } }
+        });
+
+        const exitSpy = vi.spyOn(Run.prototype, 'exit').mockImplementation(() => {
+            throw new Error('EXIT');
+        });
+
+        const script = `require("fs").writeFileSync(${JSON.stringify(outFile)}, process.env.DATABASE_HOST + ":" + process.env.DATABASE_PORT)`;
+        await runAndCatch(['--env', 'dev', '--config-dir', configDir, '--', 'node', '-e', script]);
+
+        const output = fs.readFileSync(outFile, 'utf-8');
+        expect(output).toBe('localhost:5432');
+        expect(exitSpy).toHaveBeenCalledWith(0);
+    });
+
+    it('injects resolved secret values into env vars', async () => {
+        const provider = new LocalProvider(configDir);
+        await provider.set('prod', 'api/key', 'super-secret-key');
+        await saveEnvironment(tmpDir, 'prod', {
+            imports: [],
+            values: {
+                api: { key: new SecretRef('api/key'), url: 'https://api.example.com' }
+            }
+        });
+
+        const exitSpy = vi.spyOn(Run.prototype, 'exit').mockImplementation(() => {
+            throw new Error('EXIT');
+        });
+
+        const script = `require("fs").writeFileSync(${JSON.stringify(outFile)}, process.env.API_KEY + "|" + process.env.API_URL)`;
+        await runAndCatch(['--env', 'prod', '--config-dir', configDir, '--', 'node', '-e', script]);
+
+        const output = fs.readFileSync(outFile, 'utf-8');
+        expect(output).toBe('super-secret-key|https://api.example.com');
+        expect(exitSpy).toHaveBeenCalledWith(0);
+    });
+
+    it('merges with existing process.env', async () => {
+        await saveEnvironment(tmpDir, 'dev', {
+            imports: [],
+            values: { app: 'myapp' }
+        });
+
+        const exitSpy = vi.spyOn(Run.prototype, 'exit').mockImplementation(() => {
+            throw new Error('EXIT');
+        });
+
+        const script = `require("fs").writeFileSync(${JSON.stringify(outFile)}, (process.env.PATH ? "has_path" : "no_path") + "|" + process.env.APP)`;
+        await runAndCatch(['--env', 'dev', '--config-dir', configDir, '--', 'node', '-e', script]);
+
+        const output = fs.readFileSync(outFile, 'utf-8');
+        expect(output).toContain('has_path|myapp');
+        expect(exitSpy).toHaveBeenCalledWith(0);
+    });
+
+    it('forwards subprocess exit code', async () => {
+        await saveEnvironment(tmpDir, 'dev', {
+            imports: [],
+            values: { key: 'val' }
+        });
+
+        const exitSpy = vi.spyOn(Run.prototype, 'exit').mockImplementation(() => {
+            throw new Error('EXIT');
+        });
+
+        await runAndCatch([
+            '--env',
+            'dev',
+            '--config-dir',
+            configDir,
+            '--',
+            'node',
+            '-e',
+            'process.exit(42)'
+        ]);
+
+        expect(exitSpy).toHaveBeenCalledWith(42);
+    });
+
+    it('errors when no command is provided after --', async () => {
+        await saveEnvironment(tmpDir, 'dev', {
+            imports: [],
+            values: { key: 'val' }
+        });
+
+        await expect(Run.run(['--env', 'dev', '--config-dir', configDir])).rejects.toThrow(
+            /No command specified/
+        );
+    });
+
+    it('errors when environment does not exist', async () => {
+        await expect(
+            Run.run(['--env', 'nonexistent', '--config-dir', configDir, '--', 'echo', 'hi'])
+        ).rejects.toThrow(/Environment "nonexistent" not found/);
+    });
+
+    it('includes inherited values from imports', async () => {
+        await saveEnvironment(tmpDir, 'base', {
+            imports: [],
+            values: { shared: 'from-base' }
+        });
+        await saveEnvironment(tmpDir, 'dev', {
+            imports: ['base'],
+            values: { local: 'from-dev' }
+        });
+
+        const exitSpy = vi.spyOn(Run.prototype, 'exit').mockImplementation(() => {
+            throw new Error('EXIT');
+        });
+
+        const script = `require("fs").writeFileSync(${JSON.stringify(outFile)}, process.env.SHARED + "|" + process.env.LOCAL)`;
+        await runAndCatch(['--env', 'dev', '--config-dir', configDir, '--', 'node', '-e', script]);
+
+        const output = fs.readFileSync(outFile, 'utf-8');
+        expect(output).toBe('from-base|from-dev');
+        expect(exitSpy).toHaveBeenCalledWith(0);
+    });
+});
+
+async function runAndCatch(argv: string[]): Promise<void> {
+    try {
+        await Run.run(argv);
+    } catch {
+        // exit mock throws
+    }
+}

--- a/test/core/env-vars.test.ts
+++ b/test/core/env-vars.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi } from 'vitest';
+import { replaceSecrets, flattenToEnvRecord } from '../../src/core/env-vars.js';
+import { SecretRef } from '../../src/core/types.js';
+import { SecretProvider } from '../../src/providers/provider.js';
+
+function createMockProvider(secrets: Record<string, string>): SecretProvider {
+    return {
+        get: vi.fn(async (_env: string, path: string) => {
+            const value = secrets[path];
+            if (value === undefined) throw new Error(`Secret "${path}" not found`);
+            return value;
+        }),
+        set: vi.fn(),
+        delete: vi.fn(),
+        list: vi.fn(),
+        ref: vi.fn((_env: string, path: string) => path)
+    };
+}
+
+describe('replaceSecrets', () => {
+    it('resolves SecretRef to actual values in reveal mode', async () => {
+        const provider = createMockProvider({ 'db/password': 'hunter2' });
+        const values = { db: { password: new SecretRef('db/password') } };
+
+        const result = await replaceSecrets(values, 'prod', provider, 'reveal');
+
+        expect(result).toEqual({ db: { password: 'hunter2' } });
+        expect(provider.get).toHaveBeenCalledWith('prod', 'db/password');
+    });
+
+    it('resolves SecretRef to ref strings in ref mode', async () => {
+        const provider = createMockProvider({});
+        const values = { api: { key: new SecretRef('api/key') } };
+
+        const result = await replaceSecrets(values, 'dev', provider, 'ref');
+
+        expect(result).toEqual({ api: { key: 'api/key' } });
+        expect(provider.ref).toHaveBeenCalledWith('dev', 'api/key');
+    });
+
+    it('passes through plain values unchanged', async () => {
+        const provider = createMockProvider({});
+        const values = { host: 'localhost', port: 5432, enabled: true };
+
+        const result = await replaceSecrets(values, 'dev', provider, 'reveal');
+
+        expect(result).toEqual({ host: 'localhost', port: 5432, enabled: true });
+    });
+
+    it('handles deeply nested objects', async () => {
+        const provider = createMockProvider({ 'deep/secret': 'val' });
+        const values = {
+            a: { b: { c: { secret: new SecretRef('deep/secret'), plain: 'ok' } } }
+        };
+
+        const result = await replaceSecrets(values, 'prod', provider, 'reveal');
+
+        expect(result).toEqual({ a: { b: { c: { secret: 'val', plain: 'ok' } } } });
+    });
+});
+
+describe('flattenToEnvRecord', () => {
+    it('flattens nested objects with underscore separator and uppercased keys', () => {
+        const obj = { database: { host: 'localhost', port: 5432 } };
+
+        const result = flattenToEnvRecord(obj);
+
+        expect(result).toEqual({
+            DATABASE_HOST: 'localhost',
+            DATABASE_PORT: '5432'
+        });
+    });
+
+    it('handles flat objects', () => {
+        const obj = { name: 'myapp', version: '1.0' };
+
+        const result = flattenToEnvRecord(obj);
+
+        expect(result).toEqual({
+            NAME: 'myapp',
+            VERSION: '1.0'
+        });
+    });
+
+    it('handles deeply nested objects', () => {
+        const obj = { a: { b: { c: 'deep' } } };
+
+        const result = flattenToEnvRecord(obj);
+
+        expect(result).toEqual({ A_B_C: 'deep' });
+    });
+
+    it('converts all values to strings', () => {
+        const obj = { count: 42, enabled: true };
+
+        const result = flattenToEnvRecord(obj);
+
+        expect(result).toEqual({ COUNT: '42', ENABLED: 'true' });
+    });
+});


### PR DESCRIPTION
## Summary
- Extract shared helpers (`replaceSecrets`, `flattenToEnvRecord`) from `env:print` into `src/core/env-vars.ts` for reuse
- Add `keyshelf run --env <name> -- <command> [args...]` command that resolves an environment's config and secrets, then execs a subprocess with those values injected as uppercased, underscore-separated environment variables
- Subprocess inherits stdio and existing `process.env`; exit code is forwarded

## Test plan
- [x] `replaceSecrets` resolves SecretRef to actual values in reveal mode
- [x] `replaceSecrets` resolves SecretRef to ref strings in ref mode
- [x] `replaceSecrets` passes through plain values unchanged
- [x] `flattenToEnvRecord` flattens nested objects with `_` separator, uppercased keys
- [x] `flattenToEnvRecord` handles flat objects and converts values to strings
- [x] `run` injects resolved config values as env vars
- [x] `run` injects resolved secret values as env vars
- [x] `run` merges with existing `process.env` (PATH, HOME still available)
- [x] `run` forwards subprocess exit code
- [x] `run` errors when no command is provided after `--`
- [x] `run` errors when environment does not exist
- [x] `run` includes inherited values from imports
- [x] Existing `env:print` tests still pass (all 179 tests green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)