### PR TITLE
feat: add AWS Secrets Manager adapter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,794 @@
             },
             "engines": {
                 "node": ">=20"
+            },
+            "peerDependencies": {
+                "@aws-sdk/client-secrets-manager": "^3.1009.0",
+                "@aws-sdk/credential-providers": "^3.1009.0"
+            },
+            "peerDependenciesMeta": {
+                "@aws-sdk/client-secrets-manager": {
+                    "optional": true
+                },
+                "@aws-sdk/credential-providers": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@aws-crypto/sha256-browser": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+            "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@aws-crypto/sha256-js": "^5.2.0",
+                "@aws-crypto/supports-web-crypto": "^5.2.0",
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
+                "@aws-sdk/util-locate-window": "^3.0.0",
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+            "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+            "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@smithy/is-array-buffer": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+            "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-js": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+            "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/supports-web-crypto": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+            "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-crypto/util": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+            "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/types": "^3.222.0",
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+            "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+            "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@smithy/is-array-buffer": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+            "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity": {
+            "version": "3.1009.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.1009.0.tgz",
+            "integrity": "sha512-4+lBLB2sIdrnGruxqsfPM2AOSME3DVDRX7R5OXcgd2jfrUSyYdHJN1kT9hO/vwK4uajRZsQNP5hLJMttkjkoAQ==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "^3.973.20",
+                "@aws-sdk/credential-provider-node": "^3.972.21",
+                "@aws-sdk/middleware-host-header": "^3.972.8",
+                "@aws-sdk/middleware-logger": "^3.972.8",
+                "@aws-sdk/middleware-recursion-detection": "^3.972.8",
+                "@aws-sdk/middleware-user-agent": "^3.972.21",
+                "@aws-sdk/region-config-resolver": "^3.972.8",
+                "@aws-sdk/types": "^3.973.6",
+                "@aws-sdk/util-endpoints": "^3.996.5",
+                "@aws-sdk/util-user-agent-browser": "^3.972.8",
+                "@aws-sdk/util-user-agent-node": "^3.973.7",
+                "@smithy/config-resolver": "^4.4.11",
+                "@smithy/core": "^3.23.11",
+                "@smithy/fetch-http-handler": "^5.3.15",
+                "@smithy/hash-node": "^4.2.12",
+                "@smithy/invalid-dependency": "^4.2.12",
+                "@smithy/middleware-content-length": "^4.2.12",
+                "@smithy/middleware-endpoint": "^4.4.25",
+                "@smithy/middleware-retry": "^4.4.42",
+                "@smithy/middleware-serde": "^4.2.14",
+                "@smithy/middleware-stack": "^4.2.12",
+                "@smithy/node-config-provider": "^4.3.12",
+                "@smithy/node-http-handler": "^4.4.16",
+                "@smithy/protocol-http": "^5.3.12",
+                "@smithy/smithy-client": "^4.12.5",
+                "@smithy/types": "^4.13.1",
+                "@smithy/url-parser": "^4.2.12",
+                "@smithy/util-base64": "^4.3.2",
+                "@smithy/util-body-length-browser": "^4.2.2",
+                "@smithy/util-body-length-node": "^4.2.3",
+                "@smithy/util-defaults-mode-browser": "^4.3.41",
+                "@smithy/util-defaults-mode-node": "^4.2.44",
+                "@smithy/util-endpoints": "^3.3.3",
+                "@smithy/util-middleware": "^4.2.12",
+                "@smithy/util-retry": "^4.2.12",
+                "@smithy/util-utf8": "^4.2.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-secrets-manager": {
+            "version": "3.1009.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1009.0.tgz",
+            "integrity": "sha512-8CaFVjwOotZAsWKEXXPe23wwb1hqJWmy1os8WYCcN90h5VGdje47HeLgh66VDUJDTV2iWx1QeTBtwihioUB90w==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "^3.973.20",
+                "@aws-sdk/credential-provider-node": "^3.972.21",
+                "@aws-sdk/middleware-host-header": "^3.972.8",
+                "@aws-sdk/middleware-logger": "^3.972.8",
+                "@aws-sdk/middleware-recursion-detection": "^3.972.8",
+                "@aws-sdk/middleware-user-agent": "^3.972.21",
+                "@aws-sdk/region-config-resolver": "^3.972.8",
+                "@aws-sdk/types": "^3.973.6",
+                "@aws-sdk/util-endpoints": "^3.996.5",
+                "@aws-sdk/util-user-agent-browser": "^3.972.8",
+                "@aws-sdk/util-user-agent-node": "^3.973.7",
+                "@smithy/config-resolver": "^4.4.11",
+                "@smithy/core": "^3.23.11",
+                "@smithy/fetch-http-handler": "^5.3.15",
+                "@smithy/hash-node": "^4.2.12",
+                "@smithy/invalid-dependency": "^4.2.12",
+                "@smithy/middleware-content-length": "^4.2.12",
+                "@smithy/middleware-endpoint": "^4.4.25",
+                "@smithy/middleware-retry": "^4.4.42",
+                "@smithy/middleware-serde": "^4.2.14",
+                "@smithy/middleware-stack": "^4.2.12",
+                "@smithy/node-config-provider": "^4.3.12",
+                "@smithy/node-http-handler": "^4.4.16",
+                "@smithy/protocol-http": "^5.3.12",
+                "@smithy/smithy-client": "^4.12.5",
+                "@smithy/types": "^4.13.1",
+                "@smithy/url-parser": "^4.2.12",
+                "@smithy/util-base64": "^4.3.2",
+                "@smithy/util-body-length-browser": "^4.2.2",
+                "@smithy/util-body-length-node": "^4.2.3",
+                "@smithy/util-defaults-mode-browser": "^4.3.41",
+                "@smithy/util-defaults-mode-node": "^4.2.44",
+                "@smithy/util-endpoints": "^3.3.3",
+                "@smithy/util-middleware": "^4.2.12",
+                "@smithy/util-retry": "^4.2.12",
+                "@smithy/util-utf8": "^4.2.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/core": {
+            "version": "3.973.20",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.20.tgz",
+            "integrity": "sha512-i3GuX+lowD892F3IuJf8o6AbyDupMTdyTxQrCJGcn71ni5hTZ82L4nQhcdumxZ7XPJRJJVHS/CR3uYOIIs0PVA==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/types": "^3.973.6",
+                "@aws-sdk/xml-builder": "^3.972.11",
+                "@smithy/core": "^3.23.11",
+                "@smithy/node-config-provider": "^4.3.12",
+                "@smithy/property-provider": "^4.2.12",
+                "@smithy/protocol-http": "^5.3.12",
+                "@smithy/signature-v4": "^5.3.12",
+                "@smithy/smithy-client": "^4.12.5",
+                "@smithy/types": "^4.13.1",
+                "@smithy/util-base64": "^4.3.2",
+                "@smithy/util-middleware": "^4.2.12",
+                "@smithy/util-utf8": "^4.2.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity": {
+            "version": "3.972.13",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.972.13.tgz",
+            "integrity": "sha512-WZnIK8NPX+4OXkpVoNmUS+Ya1osqjszUsDqFEz97+a/LD5K012np9iR/eWEC43btx8zQjyRIK8kyiwbh8SiHzg==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/nested-clients": "^3.996.10",
+                "@aws-sdk/types": "^3.973.6",
+                "@smithy/property-provider": "^4.2.12",
+                "@smithy/types": "^4.13.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-env": {
+            "version": "3.972.18",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.18.tgz",
+            "integrity": "sha512-X0B8AlQY507i5DwjLByeU2Af4ARsl9Vr84koDcXCbAkplmU+1xBFWxEPrWRAoh56waBne/yJqEloSwvRf4x6XA==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/core": "^3.973.20",
+                "@aws-sdk/types": "^3.973.6",
+                "@smithy/property-provider": "^4.2.12",
+                "@smithy/types": "^4.13.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-http": {
+            "version": "3.972.20",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.20.tgz",
+            "integrity": "sha512-ey9Lelj001+oOfrbKmS6R2CJAiXX7QKY4Vj9VJv6L2eE6/VjD8DocHIoYqztTm70xDLR4E1jYPTKfIui+eRNDA==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/core": "^3.973.20",
+                "@aws-sdk/types": "^3.973.6",
+                "@smithy/fetch-http-handler": "^5.3.15",
+                "@smithy/node-http-handler": "^4.4.16",
+                "@smithy/property-provider": "^4.2.12",
+                "@smithy/protocol-http": "^5.3.12",
+                "@smithy/smithy-client": "^4.12.5",
+                "@smithy/types": "^4.13.1",
+                "@smithy/util-stream": "^4.5.19",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini": {
+            "version": "3.972.20",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.20.tgz",
+            "integrity": "sha512-5flXSnKHMloObNF+9N0cupKegnH1Z37cdVlpETVgx8/rAhCe+VNlkcZH3HDg2SDn9bI765S+rhNPXGDJJPfbtA==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/core": "^3.973.20",
+                "@aws-sdk/credential-provider-env": "^3.972.18",
+                "@aws-sdk/credential-provider-http": "^3.972.20",
+                "@aws-sdk/credential-provider-login": "^3.972.20",
+                "@aws-sdk/credential-provider-process": "^3.972.18",
+                "@aws-sdk/credential-provider-sso": "^3.972.20",
+                "@aws-sdk/credential-provider-web-identity": "^3.972.20",
+                "@aws-sdk/nested-clients": "^3.996.10",
+                "@aws-sdk/types": "^3.973.6",
+                "@smithy/credential-provider-imds": "^4.2.12",
+                "@smithy/property-provider": "^4.2.12",
+                "@smithy/shared-ini-file-loader": "^4.4.7",
+                "@smithy/types": "^4.13.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-login": {
+            "version": "3.972.20",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.20.tgz",
+            "integrity": "sha512-gEWo54nfqp2jABMu6HNsjVC4hDLpg9HC8IKSJnp0kqWtxIJYHTmiLSsIfI4ScQjxEwpB+jOOH8dOLax1+hy/Hw==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/core": "^3.973.20",
+                "@aws-sdk/nested-clients": "^3.996.10",
+                "@aws-sdk/types": "^3.973.6",
+                "@smithy/property-provider": "^4.2.12",
+                "@smithy/protocol-http": "^5.3.12",
+                "@smithy/shared-ini-file-loader": "^4.4.7",
+                "@smithy/types": "^4.13.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-node": {
+            "version": "3.972.21",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.21.tgz",
+            "integrity": "sha512-hah8if3/B/Q+LBYN5FukyQ1Mym6PLPDsBOBsIgNEYD6wLyZg0UmUF/OKIVC3nX9XH8TfTPuITK+7N/jenVACWA==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "^3.972.18",
+                "@aws-sdk/credential-provider-http": "^3.972.20",
+                "@aws-sdk/credential-provider-ini": "^3.972.20",
+                "@aws-sdk/credential-provider-process": "^3.972.18",
+                "@aws-sdk/credential-provider-sso": "^3.972.20",
+                "@aws-sdk/credential-provider-web-identity": "^3.972.20",
+                "@aws-sdk/types": "^3.973.6",
+                "@smithy/credential-provider-imds": "^4.2.12",
+                "@smithy/property-provider": "^4.2.12",
+                "@smithy/shared-ini-file-loader": "^4.4.7",
+                "@smithy/types": "^4.13.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-process": {
+            "version": "3.972.18",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.18.tgz",
+            "integrity": "sha512-Tpl7SRaPoOLT32jbTWchPsn52hYYgJ0kpiFgnwk8pxTANQdUymVSZkzFvv1+oOgZm1CrbQUP9MBeoMZ9IzLZjA==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/core": "^3.973.20",
+                "@aws-sdk/types": "^3.973.6",
+                "@smithy/property-provider": "^4.2.12",
+                "@smithy/shared-ini-file-loader": "^4.4.7",
+                "@smithy/types": "^4.13.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-sso": {
+            "version": "3.972.20",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.20.tgz",
+            "integrity": "sha512-p+R+PYR5Z7Gjqf/6pvbCnzEHcqPCpLzR7Yf127HjJ6EAb4hUcD+qsNRnuww1sB/RmSeCLxyay8FMyqREw4p1RA==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/core": "^3.973.20",
+                "@aws-sdk/nested-clients": "^3.996.10",
+                "@aws-sdk/token-providers": "3.1009.0",
+                "@aws-sdk/types": "^3.973.6",
+                "@smithy/property-provider": "^4.2.12",
+                "@smithy/shared-ini-file-loader": "^4.4.7",
+                "@smithy/types": "^4.13.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-web-identity": {
+            "version": "3.972.20",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.20.tgz",
+            "integrity": "sha512-rWCmh8o7QY4CsUj63qopzMzkDq/yPpkrpb+CnjBEFSOg/02T/we7sSTVg4QsDiVS9uwZ8VyONhq98qt+pIh3KA==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/core": "^3.973.20",
+                "@aws-sdk/nested-clients": "^3.996.10",
+                "@aws-sdk/types": "^3.973.6",
+                "@smithy/property-provider": "^4.2.12",
+                "@smithy/shared-ini-file-loader": "^4.4.7",
+                "@smithy/types": "^4.13.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers": {
+            "version": "3.1009.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.1009.0.tgz",
+            "integrity": "sha512-URs590x3cCOHvjgDz8J0iqxDQ87NjF550pnWmd1jQm+w5ZHTxuUEYjivBQQkAB603IlEdeadqO1+LSjtMznhwA==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/client-cognito-identity": "3.1009.0",
+                "@aws-sdk/core": "^3.973.20",
+                "@aws-sdk/credential-provider-cognito-identity": "^3.972.13",
+                "@aws-sdk/credential-provider-env": "^3.972.18",
+                "@aws-sdk/credential-provider-http": "^3.972.20",
+                "@aws-sdk/credential-provider-ini": "^3.972.20",
+                "@aws-sdk/credential-provider-login": "^3.972.20",
+                "@aws-sdk/credential-provider-node": "^3.972.21",
+                "@aws-sdk/credential-provider-process": "^3.972.18",
+                "@aws-sdk/credential-provider-sso": "^3.972.20",
+                "@aws-sdk/credential-provider-web-identity": "^3.972.20",
+                "@aws-sdk/nested-clients": "^3.996.10",
+                "@aws-sdk/types": "^3.973.6",
+                "@smithy/config-resolver": "^4.4.11",
+                "@smithy/core": "^3.23.11",
+                "@smithy/credential-provider-imds": "^4.2.12",
+                "@smithy/node-config-provider": "^4.3.12",
+                "@smithy/property-provider": "^4.2.12",
+                "@smithy/types": "^4.13.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-host-header": {
+            "version": "3.972.8",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.8.tgz",
+            "integrity": "sha512-wAr2REfKsqoKQ+OkNqvOShnBoh+nkPurDKW7uAeVSu6kUECnWlSJiPvnoqxGlfousEY/v9LfS9sNc46hjSYDIQ==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/types": "^3.973.6",
+                "@smithy/protocol-http": "^5.3.12",
+                "@smithy/types": "^4.13.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-logger": {
+            "version": "3.972.8",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.8.tgz",
+            "integrity": "sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/types": "^3.973.6",
+                "@smithy/types": "^4.13.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-recursion-detection": {
+            "version": "3.972.8",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.8.tgz",
+            "integrity": "sha512-BnnvYs2ZEpdlmZ2PNlV2ZyQ8j8AEkMTjN79y/YA475ER1ByFYrkVR85qmhni8oeTaJcDqbx364wDpitDAA/wCA==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/types": "^3.973.6",
+                "@aws/lambda-invoke-store": "^0.2.2",
+                "@smithy/protocol-http": "^5.3.12",
+                "@smithy/types": "^4.13.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-user-agent": {
+            "version": "3.972.21",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.21.tgz",
+            "integrity": "sha512-62XRl1GDYPpkt7cx1AX1SPy9wgNE9Iw/NPuurJu4lmhCWS7sGKO+kS53TQ8eRmIxy3skmvNInnk0ZbWrU5Dpyg==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/core": "^3.973.20",
+                "@aws-sdk/types": "^3.973.6",
+                "@aws-sdk/util-endpoints": "^3.996.5",
+                "@smithy/core": "^3.23.11",
+                "@smithy/protocol-http": "^5.3.12",
+                "@smithy/types": "^4.13.1",
+                "@smithy/util-retry": "^4.2.12",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients": {
+            "version": "3.996.10",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.10.tgz",
+            "integrity": "sha512-SlDol5Z+C7Ivnc2rKGqiqfSUmUZzY1qHfVs9myt/nxVwswgfpjdKahyTzLTx802Zfq0NFRs7AejwKzzzl5Co2w==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "^3.973.20",
+                "@aws-sdk/middleware-host-header": "^3.972.8",
+                "@aws-sdk/middleware-logger": "^3.972.8",
+                "@aws-sdk/middleware-recursion-detection": "^3.972.8",
+                "@aws-sdk/middleware-user-agent": "^3.972.21",
+                "@aws-sdk/region-config-resolver": "^3.972.8",
+                "@aws-sdk/types": "^3.973.6",
+                "@aws-sdk/util-endpoints": "^3.996.5",
+                "@aws-sdk/util-user-agent-browser": "^3.972.8",
+                "@aws-sdk/util-user-agent-node": "^3.973.7",
+                "@smithy/config-resolver": "^4.4.11",
+                "@smithy/core": "^3.23.11",
+                "@smithy/fetch-http-handler": "^5.3.15",
+                "@smithy/hash-node": "^4.2.12",
+                "@smithy/invalid-dependency": "^4.2.12",
+                "@smithy/middleware-content-length": "^4.2.12",
+                "@smithy/middleware-endpoint": "^4.4.25",
+                "@smithy/middleware-retry": "^4.4.42",
+                "@smithy/middleware-serde": "^4.2.14",
+                "@smithy/middleware-stack": "^4.2.12",
+                "@smithy/node-config-provider": "^4.3.12",
+                "@smithy/node-http-handler": "^4.4.16",
+                "@smithy/protocol-http": "^5.3.12",
+                "@smithy/smithy-client": "^4.12.5",
+                "@smithy/types": "^4.13.1",
+                "@smithy/url-parser": "^4.2.12",
+                "@smithy/util-base64": "^4.3.2",
+                "@smithy/util-body-length-browser": "^4.2.2",
+                "@smithy/util-body-length-node": "^4.2.3",
+                "@smithy/util-defaults-mode-browser": "^4.3.41",
+                "@smithy/util-defaults-mode-node": "^4.2.44",
+                "@smithy/util-endpoints": "^3.3.3",
+                "@smithy/util-middleware": "^4.2.12",
+                "@smithy/util-retry": "^4.2.12",
+                "@smithy/util-utf8": "^4.2.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/region-config-resolver": {
+            "version": "3.972.8",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.8.tgz",
+            "integrity": "sha512-1eD4uhTDeambO/PNIDVG19A6+v4NdD7xzwLHDutHsUqz0B+i661MwQB2eYO4/crcCvCiQG4SRm1k81k54FEIvw==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/types": "^3.973.6",
+                "@smithy/config-resolver": "^4.4.11",
+                "@smithy/node-config-provider": "^4.3.12",
+                "@smithy/types": "^4.13.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers": {
+            "version": "3.1009.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1009.0.tgz",
+            "integrity": "sha512-KCPLuTqN9u0Rr38Arln78fRG9KXpzsPWmof+PZzfAHMMQq2QED6YjQrkrfiH7PDefLWEposY1o4/eGwrmKA4JA==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/core": "^3.973.20",
+                "@aws-sdk/nested-clients": "^3.996.10",
+                "@aws-sdk/types": "^3.973.6",
+                "@smithy/property-provider": "^4.2.12",
+                "@smithy/shared-ini-file-loader": "^4.4.7",
+                "@smithy/types": "^4.13.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/types": {
+            "version": "3.973.6",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.6.tgz",
+            "integrity": "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.13.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-endpoints": {
+            "version": "3.996.5",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.5.tgz",
+            "integrity": "sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/types": "^3.973.6",
+                "@smithy/types": "^4.13.1",
+                "@smithy/url-parser": "^4.2.12",
+                "@smithy/util-endpoints": "^3.3.3",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-locate-window": {
+            "version": "3.965.5",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+            "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-user-agent-browser": {
+            "version": "3.972.8",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.8.tgz",
+            "integrity": "sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/types": "^3.973.6",
+                "@smithy/types": "^4.13.1",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/util-user-agent-node": {
+            "version": "3.973.7",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.7.tgz",
+            "integrity": "sha512-Hz6EZMUAEzqUd7e+vZ9LE7mn+5gMbxltXy18v+YSFY+9LBJz15wkNZvw5JqfX3z0FS9n3bgUtz3L5rAsfh4YlA==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@aws-sdk/middleware-user-agent": "^3.972.21",
+                "@aws-sdk/types": "^3.973.6",
+                "@smithy/node-config-provider": "^4.3.12",
+                "@smithy/types": "^4.13.1",
+                "@smithy/util-config-provider": "^4.2.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            },
+            "peerDependencies": {
+                "aws-crt": ">=1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "aws-crt": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@aws-sdk/xml-builder": {
+            "version": "3.972.11",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.11.tgz",
+            "integrity": "sha512-iitV/gZKQMvY9d7ovmyFnFuTHbBAtrmLnvaSb/3X8vOKyevwtpmEtyc8AdhVWZe0pI/1GsHxlEvQeOePFzy7KQ==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.13.1",
+                "fast-xml-parser": "5.4.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws/lambda-invoke-store": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+            "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "engines": {
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -2095,6 +2883,667 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/@smithy/abort-controller": {
+            "version": "4.2.12",
+            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.12.tgz",
+            "integrity": "sha512-xolrFw6b+2iYGl6EcOL7IJY71vvyZ0DJ3mcKtpykqPe2uscwtzDZJa1uVQXyP7w9Dd+kGwYnPbMsJrGISKiY/Q==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.13.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/config-resolver": {
+            "version": "4.4.11",
+            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.11.tgz",
+            "integrity": "sha512-YxFiiG4YDAtX7WMN7RuhHZLeTmRRAOyCbr+zB8e3AQzHPnUhS8zXjB1+cniPVQI3xbWsQPM0X2aaIkO/ME0ymw==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.3.12",
+                "@smithy/types": "^4.13.1",
+                "@smithy/util-config-provider": "^4.2.2",
+                "@smithy/util-endpoints": "^3.3.3",
+                "@smithy/util-middleware": "^4.2.12",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/core": {
+            "version": "3.23.11",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.11.tgz",
+            "integrity": "sha512-952rGf7hBRnhUIaeLp6q4MptKW8sPFe5VvkoZ5qIzFAtx6c/QZ/54FS3yootsyUSf9gJX/NBqEBNdNR7jMIlpQ==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@smithy/protocol-http": "^5.3.12",
+                "@smithy/types": "^4.13.1",
+                "@smithy/url-parser": "^4.2.12",
+                "@smithy/util-base64": "^4.3.2",
+                "@smithy/util-body-length-browser": "^4.2.2",
+                "@smithy/util-middleware": "^4.2.12",
+                "@smithy/util-stream": "^4.5.19",
+                "@smithy/util-utf8": "^4.2.2",
+                "@smithy/uuid": "^1.1.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/credential-provider-imds": {
+            "version": "4.2.12",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.12.tgz",
+            "integrity": "sha512-cr2lR792vNZcYMriSIj+Um3x9KWrjcu98kn234xA6reOAFMmbRpQMOv8KPgEmLLtx3eldU6c5wALKFqNOhugmg==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.3.12",
+                "@smithy/property-provider": "^4.2.12",
+                "@smithy/types": "^4.13.1",
+                "@smithy/url-parser": "^4.2.12",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/fetch-http-handler": {
+            "version": "5.3.15",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.15.tgz",
+            "integrity": "sha512-T4jFU5N/yiIfrtrsb9uOQn7RdELdM/7HbyLNr6uO/mpkj1ctiVs7CihVr51w4LyQlXWDpXFn4BElf1WmQvZu/A==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@smithy/protocol-http": "^5.3.12",
+                "@smithy/querystring-builder": "^4.2.12",
+                "@smithy/types": "^4.13.1",
+                "@smithy/util-base64": "^4.3.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/hash-node": {
+            "version": "4.2.12",
+            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.12.tgz",
+            "integrity": "sha512-QhBYbGrbxTkZ43QoTPrK72DoYviDeg6YKDrHTMJbbC+A0sml3kSjzFtXP7BtbyJnXojLfTQldGdUR0RGD8dA3w==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.13.1",
+                "@smithy/util-buffer-from": "^4.2.2",
+                "@smithy/util-utf8": "^4.2.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/invalid-dependency": {
+            "version": "4.2.12",
+            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.12.tgz",
+            "integrity": "sha512-/4F1zb7Z8LOu1PalTdESFHR0RbPwHd3FcaG1sI3UEIriQTWakysgJr65lc1jj6QY5ye7aFsisajotH6UhWfm/g==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.13.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/is-array-buffer": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+            "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-content-length": {
+            "version": "4.2.12",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.12.tgz",
+            "integrity": "sha512-YE58Yz+cvFInWI/wOTrB+DbvUVz/pLn5mC5MvOV4fdRUc6qGwygyngcucRQjAhiCEbmfLOXX0gntSIcgMvAjmA==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@smithy/protocol-http": "^5.3.12",
+                "@smithy/types": "^4.13.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-endpoint": {
+            "version": "4.4.25",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.25.tgz",
+            "integrity": "sha512-dqjLwZs2eBxIUG6Qtw8/YZ4DvzHGIf0DA18wrgtfP6a50UIO7e2nY0FPdcbv5tVJKqWCCU5BmGMOUwT7Puan+A==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@smithy/core": "^3.23.11",
+                "@smithy/middleware-serde": "^4.2.14",
+                "@smithy/node-config-provider": "^4.3.12",
+                "@smithy/shared-ini-file-loader": "^4.4.7",
+                "@smithy/types": "^4.13.1",
+                "@smithy/url-parser": "^4.2.12",
+                "@smithy/util-middleware": "^4.2.12",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-retry": {
+            "version": "4.4.42",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.42.tgz",
+            "integrity": "sha512-vbwyqHRIpIZutNXZpLAozakzamcINaRCpEy1MYmK6xBeW3xN+TyPRA123GjXnuxZIjc9848MRRCugVMTXxC4Eg==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.3.12",
+                "@smithy/protocol-http": "^5.3.12",
+                "@smithy/service-error-classification": "^4.2.12",
+                "@smithy/smithy-client": "^4.12.5",
+                "@smithy/types": "^4.13.1",
+                "@smithy/util-middleware": "^4.2.12",
+                "@smithy/util-retry": "^4.2.12",
+                "@smithy/uuid": "^1.1.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-serde": {
+            "version": "4.2.14",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.14.tgz",
+            "integrity": "sha512-+CcaLoLa5apzSRtloOyG7lQvkUw2ZDml3hRh4QiG9WyEPfW5Ke/3tPOPiPjUneuT59Tpn8+c3RVaUvvkkwqZwg==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@smithy/core": "^3.23.11",
+                "@smithy/protocol-http": "^5.3.12",
+                "@smithy/types": "^4.13.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-stack": {
+            "version": "4.2.12",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.12.tgz",
+            "integrity": "sha512-kruC5gRHwsCOuyCd4ouQxYjgRAym2uDlCvQ5acuMtRrcdfg7mFBg6blaxcJ09STpt3ziEkis6bhg1uwrWU7txw==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.13.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/node-config-provider": {
+            "version": "4.3.12",
+            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.12.tgz",
+            "integrity": "sha512-tr2oKX2xMcO+rBOjobSwVAkV05SIfUKz8iI53rzxEmgW3GOOPOv0UioSDk+J8OpRQnpnhsO3Af6IEBabQBVmiw==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@smithy/property-provider": "^4.2.12",
+                "@smithy/shared-ini-file-loader": "^4.4.7",
+                "@smithy/types": "^4.13.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/node-http-handler": {
+            "version": "4.4.16",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.16.tgz",
+            "integrity": "sha512-ULC8UCS/HivdCB3jhi+kLFYe4B5gxH2gi9vHBfEIiRrT2jfKiZNiETJSlzRtE6B26XbBHjPtc8iZKSNqMol9bw==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@smithy/abort-controller": "^4.2.12",
+                "@smithy/protocol-http": "^5.3.12",
+                "@smithy/querystring-builder": "^4.2.12",
+                "@smithy/types": "^4.13.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/property-provider": {
+            "version": "4.2.12",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.12.tgz",
+            "integrity": "sha512-jqve46eYU1v7pZ5BM+fmkbq3DerkSluPr5EhvOcHxygxzD05ByDRppRwRPPpFrsFo5yDtCYLKu+kreHKVrvc7A==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.13.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/protocol-http": {
+            "version": "5.3.12",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.12.tgz",
+            "integrity": "sha512-fit0GZK9I1xoRlR4jXmbLhoN0OdEpa96ul8M65XdmXnxXkuMxM0Y8HDT0Fh0Xb4I85MBvBClOzgSrV1X2s1Hxw==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.13.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/querystring-builder": {
+            "version": "4.2.12",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.12.tgz",
+            "integrity": "sha512-6wTZjGABQufekycfDGMEB84BgtdOE/rCVTov+EDXQ8NHKTUNIp/j27IliwP7tjIU9LR+sSzyGBOXjeEtVgzCHg==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.13.1",
+                "@smithy/util-uri-escape": "^4.2.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/querystring-parser": {
+            "version": "4.2.12",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.12.tgz",
+            "integrity": "sha512-P2OdvrgiAKpkPNKlKUtWbNZKB1XjPxM086NeVhK+W+wI46pIKdWBe5QyXvhUm3MEcyS/rkLvY8rZzyUdmyDZBw==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.13.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/service-error-classification": {
+            "version": "4.2.12",
+            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.12.tgz",
+            "integrity": "sha512-LlP29oSQN0Tw0b6D0Xo6BIikBswuIiGYbRACy5ujw/JgWSzTdYj46U83ssf6Ux0GyNJVivs2uReU8pt7Eu9okQ==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.13.1"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/shared-ini-file-loader": {
+            "version": "4.4.7",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.7.tgz",
+            "integrity": "sha512-HrOKWsUb+otTeo1HxVWeEb99t5ER1XrBi/xka2Wv6NVmTbuCUC1dvlrksdvxFtODLBjsC+PHK+fuy2x/7Ynyiw==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.13.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/signature-v4": {
+            "version": "5.3.12",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.12.tgz",
+            "integrity": "sha512-B/FBwO3MVOL00DaRSXfXfa/TRXRheagt/q5A2NM13u7q+sHS59EOVGQNfG7DkmVtdQm5m3vOosoKAXSqn/OEgw==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@smithy/is-array-buffer": "^4.2.2",
+                "@smithy/protocol-http": "^5.3.12",
+                "@smithy/types": "^4.13.1",
+                "@smithy/util-hex-encoding": "^4.2.2",
+                "@smithy/util-middleware": "^4.2.12",
+                "@smithy/util-uri-escape": "^4.2.2",
+                "@smithy/util-utf8": "^4.2.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/smithy-client": {
+            "version": "4.12.5",
+            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.5.tgz",
+            "integrity": "sha512-UqwYawyqSr/aog8mnLnfbPurS0gi4G7IYDcD28cUIBhsvWs1+rQcL2IwkUQ+QZ7dibaoRzhNF99fAQ9AUcO00w==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@smithy/core": "^3.23.11",
+                "@smithy/middleware-endpoint": "^4.4.25",
+                "@smithy/middleware-stack": "^4.2.12",
+                "@smithy/protocol-http": "^5.3.12",
+                "@smithy/types": "^4.13.1",
+                "@smithy/util-stream": "^4.5.19",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/types": {
+            "version": "4.13.1",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
+            "integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/url-parser": {
+            "version": "4.2.12",
+            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.12.tgz",
+            "integrity": "sha512-wOPKPEpso+doCZGIlr+e1lVI6+9VAKfL4kZWFgzVgGWY2hZxshNKod4l2LXS3PRC9otH/JRSjtEHqQ/7eLciRA==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@smithy/querystring-parser": "^4.2.12",
+                "@smithy/types": "^4.13.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-base64": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
+            "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@smithy/util-buffer-from": "^4.2.2",
+                "@smithy/util-utf8": "^4.2.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-body-length-browser": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
+            "integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-body-length-node": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
+            "integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-buffer-from": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+            "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@smithy/is-array-buffer": "^4.2.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-config-provider": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
+            "integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-defaults-mode-browser": {
+            "version": "4.3.41",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.41.tgz",
+            "integrity": "sha512-M1w1Ux0rSVvBOxIIiqbxvZvhnjQ+VUjJrugtORE90BbadSTH+jsQL279KRL3Hv0w69rE7EuYkV/4Lepz/NBW9g==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@smithy/property-provider": "^4.2.12",
+                "@smithy/smithy-client": "^4.12.5",
+                "@smithy/types": "^4.13.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-defaults-mode-node": {
+            "version": "4.2.44",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.44.tgz",
+            "integrity": "sha512-YPze3/lD1KmWuZsl9JlfhcgGLX7AXhSoaCDtiPntUjNW5/YY0lOHjkcgxyE9x/h5vvS1fzDifMGjzqnNlNiqOQ==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@smithy/config-resolver": "^4.4.11",
+                "@smithy/credential-provider-imds": "^4.2.12",
+                "@smithy/node-config-provider": "^4.3.12",
+                "@smithy/property-provider": "^4.2.12",
+                "@smithy/smithy-client": "^4.12.5",
+                "@smithy/types": "^4.13.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-endpoints": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.3.3.tgz",
+            "integrity": "sha512-VACQVe50j0HZPjpwWcjyT51KUQ4AnsvEaQ2lKHOSL4mNLD0G9BjEniQ+yCt1qqfKfiAHRAts26ud7hBjamrwig==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.3.12",
+                "@smithy/types": "^4.13.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-hex-encoding": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+            "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-middleware": {
+            "version": "4.2.12",
+            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.12.tgz",
+            "integrity": "sha512-Er805uFUOvgc0l8nv0e0su0VFISoxhJ/AwOn3gL2NWNY2LUEldP5WtVcRYSQBcjg0y9NfG8JYrCJaYDpupBHJQ==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@smithy/types": "^4.13.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-retry": {
+            "version": "4.2.12",
+            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.12.tgz",
+            "integrity": "sha512-1zopLDUEOwumjcHdJ1mwBHddubYF8GMQvstVCLC54Y46rqoHwlIU+8ZzUeaBcD+WCJHyDGSeZ2ml9YSe9aqcoQ==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@smithy/service-error-classification": "^4.2.12",
+                "@smithy/types": "^4.13.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-stream": {
+            "version": "4.5.19",
+            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.19.tgz",
+            "integrity": "sha512-v4sa+3xTweL1CLO2UP0p7tvIMH/Rq1X4KKOxd568mpe6LSLMQCnDHs4uv7m3ukpl3HvcN2JH6jiCS0SNRXKP/w==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@smithy/fetch-http-handler": "^5.3.15",
+                "@smithy/node-http-handler": "^4.4.16",
+                "@smithy/types": "^4.13.1",
+                "@smithy/util-base64": "^4.3.2",
+                "@smithy/util-buffer-from": "^4.2.2",
+                "@smithy/util-hex-encoding": "^4.2.2",
+                "@smithy/util-utf8": "^4.2.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-uri-escape": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+            "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-utf8": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+            "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@smithy/util-buffer-from": "^4.2.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/uuid": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
+            "integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
         "node_modules/@standard-schema/spec": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -2790,6 +4239,14 @@
             "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/bowser": {
+            "version": "2.14.1",
+            "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+            "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true
         },
         "node_modules/brace-expansion": {
             "version": "1.1.12",
@@ -3928,6 +5385,44 @@
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/fast-xml-builder": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.3.tgz",
+            "integrity": "sha512-1o60KoFw2+LWKQu3IdcfcFlGTW4dpqEWmjhYec6H82AYZU2TVBXep6tMl8Z1Y+wM+ZrzCwe3BZ9Vyd9N2rIvmg==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "path-expression-matcher": "^1.1.3"
+            }
+        },
+        "node_modules/fast-xml-parser": {
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.1.tgz",
+            "integrity": "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "fast-xml-builder": "^1.0.0",
+                "strnum": "^2.1.2"
+            },
+            "bin": {
+                "fxparser": "src/cli/cli.js"
+            }
         },
         "node_modules/fdir": {
             "version": "6.5.0",
@@ -8543,6 +10038,23 @@
                 "node": ">=8"
             }
         },
+        "node_modules/path-expression-matcher": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.1.3.tgz",
+            "integrity": "sha512-qdVgY8KXmVdJZRSS1JdEPOKPdTiEK/pi0RkcT2sw1RhXxohdujUlJFPuS1TSkevZ9vzd3ZlL7ULl1MHGTApKzQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
         "node_modules/path-key": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -9847,6 +11359,20 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/strnum": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.0.tgz",
+            "integrity": "sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "optional": true,
+            "peer": true
+        },
         "node_modules/stubs": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
@@ -10200,6 +11726,14 @@
             "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
             "dev": true,
             "license": "Apache-2.0"
+        },
+        "node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "license": "0BSD",
+            "optional": true,
+            "peer": true
         },
         "node_modules/tsup": {
             "version": "8.5.1",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,8 @@
         "vitest": "^4.0.18"
     },
     "dependencies": {
+        "@aws-sdk/client-secrets-manager": "^3.1009.0",
+        "@aws-sdk/credential-providers": "^3.1009.0",
         "@google-cloud/secret-manager": "^6.1.1",
         "@oclif/core": "^4.8.1",
         "js-yaml": "^4.1.1"

--- a/src/commands/env/create.ts
+++ b/src/commands/env/create.ts
@@ -26,10 +26,16 @@ export default class EnvCreate extends Command {
         }),
         adapter: Flags.string({
             description: 'Secret provider adapter for this environment',
-            options: ['local', 'gcp-sm']
+            options: ['local', 'gcp-sm', 'aws-sm']
         }),
         project: Flags.string({
             description: 'GCP project ID (required for gcp-sm adapter)'
+        }),
+        region: Flags.string({
+            description: 'AWS region (optional for aws-sm adapter)'
+        }),
+        profile: Flags.string({
+            description: 'AWS profile name (optional for aws-sm adapter)'
         })
     };
 
@@ -50,6 +56,13 @@ export default class EnvCreate extends Command {
                         this.error('--project is required when using the gcp-sm adapter');
                     }
                     provider = { adapter: 'gcp-sm', project: flags.project };
+                    break;
+                case 'aws-sm':
+                    provider = {
+                        adapter: 'aws-sm',
+                        ...(flags.region && { region: flags.region }),
+                        ...(flags.profile && { profile: flags.profile })
+                    };
                     break;
                 default:
                     provider = { adapter: 'local' };

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -12,11 +12,17 @@ export default class Init extends Command {
         force: Flags.boolean({ char: 'f', description: 'Overwrite existing keyshelf.yml' }),
         adapter: Flags.string({
             description: 'Secret provider adapter',
-            options: ['local', 'gcp-sm'],
+            options: ['local', 'gcp-sm', 'aws-sm'],
             default: 'local'
         }),
         project: Flags.string({
             description: 'GCP project ID (required for gcp-sm adapter)'
+        }),
+        region: Flags.string({
+            description: 'AWS region (optional for aws-sm adapter)'
+        }),
+        profile: Flags.string({
+            description: 'AWS profile name (optional for aws-sm adapter)'
         })
     };
 
@@ -36,6 +42,13 @@ export default class Init extends Command {
                     this.error('--project is required when using the gcp-sm adapter');
                 }
                 provider = { adapter: 'gcp-sm', project: flags.project };
+                break;
+            case 'aws-sm':
+                provider = {
+                    adapter: 'aws-sm',
+                    ...(flags.region && { region: flags.region }),
+                    ...(flags.profile && { profile: flags.profile })
+                };
                 break;
             default:
                 provider = { adapter: 'local' };

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import yaml from 'js-yaml';
 import { KeyshelfConfig, ProviderConfig } from './types.js';
 
-const KNOWN_ADAPTERS = ['local', 'gcp-sm'];
+const KNOWN_ADAPTERS = ['local', 'gcp-sm', 'aws-sm'];
 
 /** Parse and validate a raw provider object into a ProviderConfig. */
 export function parseProviderConfig(
@@ -30,6 +30,24 @@ export function parseProviderConfig(
                 );
             }
             return { adapter: 'gcp-sm', project: provider.project };
+        case 'aws-sm': {
+            if (provider.region !== undefined && typeof provider.region !== 'string') {
+                throw new Error(
+                    `Invalid ${context}: "aws-sm" field "provider.region" must be a string.`
+                );
+            }
+            if (provider.profile !== undefined && typeof provider.profile !== 'string') {
+                throw new Error(
+                    `Invalid ${context}: "aws-sm" field "provider.profile" must be a string.`
+                );
+            }
+            const awsConfig: { adapter: 'aws-sm'; region?: string; profile?: string } = {
+                adapter: 'aws-sm'
+            };
+            if (provider.region !== undefined) awsConfig.region = provider.region as string;
+            if (provider.profile !== undefined) awsConfig.profile = provider.profile as string;
+            return awsConfig;
+        }
         default:
             throw new Error('unreachable');
     }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -11,7 +11,10 @@ export interface EnvironmentDefinition {
 }
 
 /** Discriminated union for adapter-specific provider configuration. */
-export type ProviderConfig = { adapter: 'local' } | { adapter: 'gcp-sm'; project: string };
+export type ProviderConfig =
+    | { adapter: 'local' }
+    | { adapter: 'gcp-sm'; project: string }
+    | { adapter: 'aws-sm'; region?: string; profile?: string };
 
 /** Project-level configuration from keyshelf.yml. */
 export interface KeyshelfConfig {

--- a/src/providers/aws-sm.ts
+++ b/src/providers/aws-sm.ts
@@ -1,0 +1,132 @@
+import {
+    SecretsManagerClient,
+    SecretsManagerClientConfig,
+    GetSecretValueCommand,
+    PutSecretValueCommand,
+    CreateSecretCommand,
+    DeleteSecretCommand,
+    ListSecretsCommand
+} from '@aws-sdk/client-secrets-manager';
+import { fromIni } from '@aws-sdk/credential-providers';
+import { SecretProvider } from './provider.js';
+
+type AwsSmConfig = {
+    region?: string;
+    profile?: string;
+};
+
+/** Stores secrets in AWS Secrets Manager using configurable credentials. */
+export class AwsSmProvider implements SecretProvider {
+    private readonly client: SecretsManagerClient;
+
+    constructor(config: AwsSmConfig) {
+        const clientConfig: SecretsManagerClientConfig = {};
+        if (config.region) clientConfig.region = config.region;
+        if (config.profile) clientConfig.credentials = fromIni({ profile: config.profile });
+        this.client = new SecretsManagerClient(clientConfig);
+    }
+
+    ref(env: string, secretPath: string): string {
+        return buildSecretName(env, secretPath);
+    }
+
+    async get(env: string, secretPath: string): Promise<string> {
+        try {
+            const response = await this.client.send(
+                new GetSecretValueCommand({ SecretId: buildSecretName(env, secretPath) })
+            );
+            if (response.SecretString === undefined) {
+                throw new Error(
+                    `Secret "${secretPath}" in environment "${env}" is a binary secret, which is not supported.`
+                );
+            }
+            return response.SecretString;
+        } catch (err: unknown) {
+            if (isNotFoundError(err)) {
+                throw new Error(`Secret "${secretPath}" not found in environment "${env}"`);
+            }
+            throw err;
+        }
+    }
+
+    async set(env: string, secretPath: string, value: string): Promise<void> {
+        const secretId = buildSecretName(env, secretPath);
+
+        try {
+            await this.client.send(
+                new PutSecretValueCommand({ SecretId: secretId, SecretString: value })
+            );
+        } catch (err: unknown) {
+            if (!isNotFoundError(err)) throw err;
+            await this.client.send(
+                new CreateSecretCommand({ Name: secretId, SecretString: value })
+            );
+        }
+    }
+
+    async delete(env: string, secretPath: string): Promise<void> {
+        try {
+            await this.client.send(
+                new DeleteSecretCommand({
+                    SecretId: buildSecretName(env, secretPath),
+                    ForceDeleteWithoutRecovery: true
+                })
+            );
+        } catch (err: unknown) {
+            if (isNotFoundError(err)) {
+                throw new Error(`Secret "${secretPath}" not found in environment "${env}"`);
+            }
+            throw err;
+        }
+    }
+
+    async list(env: string, prefix?: string): Promise<string[]> {
+        const envPrefix = `keyshelf/${env}/`;
+        const paths: string[] = [];
+        let nextToken: string | undefined;
+
+        do {
+            const response = await this.client.send(
+                new ListSecretsCommand({
+                    Filters: [{ Key: 'name', Values: [envPrefix] }],
+                    NextToken: nextToken
+                })
+            );
+
+            for (const secret of response.SecretList ?? []) {
+                if (!secret.Name?.startsWith(envPrefix)) continue;
+                const secretPath = secret.Name.slice(envPrefix.length);
+                if (!secretPath) continue;
+                if (!prefix || secretPath === prefix || secretPath.startsWith(prefix + '/')) {
+                    paths.push(secretPath);
+                }
+            }
+
+            nextToken = response.NextToken;
+        } while (nextToken);
+
+        return paths;
+    }
+}
+
+/**
+ * Build the AWS Secrets Manager secret name for a given env and path.
+ * @param env - Environment name (must not contain `/`)
+ * @param secretPath - `/`-delimited path to the secret
+ * @returns The full secret name: `keyshelf/<env>/<secretPath>`
+ */
+export function buildSecretName(env: string, secretPath: string): string {
+    if (env.includes('/')) {
+        throw new Error(`env must not contain "/": got "${env}"`);
+    }
+    return `keyshelf/${env}/${secretPath}`;
+}
+
+function isNotFoundError(err: unknown): boolean {
+    return (
+        typeof err === 'object' &&
+        err !== null &&
+        'name' in err &&
+        (err as { name: string }).name === 'ResourceNotFoundException'
+    );
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -2,6 +2,7 @@ import { ProviderConfig, EnvironmentDefinition, KeyshelfConfig } from '../core/t
 import { SecretProvider } from './provider.js';
 import { LocalProvider } from './local.js';
 import { GcpSmProvider } from './gcp-sm.js';
+import { AwsSmProvider } from './aws-sm.js';
 
 /** Create a SecretProvider from adapter configuration. */
 export function createProvider(config: ProviderConfig, configDir: string): SecretProvider {
@@ -10,6 +11,8 @@ export function createProvider(config: ProviderConfig, configDir: string): Secre
             return new LocalProvider(configDir);
         case 'gcp-sm':
             return new GcpSmProvider(config.project);
+        case 'aws-sm':
+            return new AwsSmProvider({ region: config.region, profile: config.profile });
     }
 }
 

--- a/test/commands/env/create.test.ts
+++ b/test/commands/env/create.test.ts
@@ -70,6 +70,32 @@ describe('env:create command', () => {
         expect(def.provider).toBeUndefined();
     });
 
+    it('creates environment with --adapter aws-sm and optional flags', async () => {
+        await Create.run([
+            'prod',
+            '--adapter',
+            'aws-sm',
+            '--region',
+            'eu-west-1',
+            '--profile',
+            'production'
+        ]);
+
+        const def = await loadEnvironment(tmpDir, 'prod');
+        expect(def.provider).toEqual({
+            adapter: 'aws-sm',
+            region: 'eu-west-1',
+            profile: 'production'
+        });
+    });
+
+    it('creates environment with --adapter aws-sm without optional flags', async () => {
+        await Create.run(['prod', '--adapter', 'aws-sm']);
+
+        const def = await loadEnvironment(tmpDir, 'prod');
+        expect(def.provider).toEqual({ adapter: 'aws-sm' });
+    });
+
     it('errors if environment already exists', async () => {
         await Create.run(['dev']);
         await expect(Create.run(['dev'])).rejects.toThrow(/already exists/);

--- a/test/commands/init.test.ts
+++ b/test/commands/init.test.ts
@@ -66,4 +66,24 @@ describe('init command', () => {
     it('--adapter gcp-sm without --project errors', async () => {
         await expect(Init.run(['--adapter', 'gcp-sm'])).rejects.toThrow(/--project is required/);
     });
+
+    it('--adapter aws-sm creates aws-sm config', async () => {
+        await Init.run(['--adapter', 'aws-sm', '--region', 'us-east-1', '--profile', 'dev']);
+
+        const content = fs.readFileSync(path.join(tmpDir, 'keyshelf.yml'), 'utf-8');
+        const config = yaml.load(content) as Record<string, unknown>;
+        expect(config.provider).toEqual({
+            adapter: 'aws-sm',
+            region: 'us-east-1',
+            profile: 'dev'
+        });
+    });
+
+    it('--adapter aws-sm works without optional flags', async () => {
+        await Init.run(['--adapter', 'aws-sm']);
+
+        const content = fs.readFileSync(path.join(tmpDir, 'keyshelf.yml'), 'utf-8');
+        const config = yaml.load(content) as Record<string, unknown>;
+        expect(config.provider).toEqual({ adapter: 'aws-sm' });
+    });
 });

--- a/test/core/config.test.ts
+++ b/test/core/config.test.ts
@@ -91,6 +91,51 @@ describe('config validation', () => {
 
         expect(() => loadConfig(tmpDir)).toThrow(/gcp-sm.*requires field "provider\.project"/i);
     });
+
+    it('loads valid aws-sm config with region and profile', () => {
+        fs.writeFileSync(
+            path.join(tmpDir, 'keyshelf.yml'),
+            yaml.dump({
+                name: 'test',
+                provider: { adapter: 'aws-sm', region: 'us-east-1', profile: 'dev' }
+            })
+        );
+
+        const config = loadConfig(tmpDir);
+        expect(config.provider).toEqual({
+            adapter: 'aws-sm',
+            region: 'us-east-1',
+            profile: 'dev'
+        });
+    });
+
+    it('loads valid aws-sm config without optional fields', () => {
+        fs.writeFileSync(
+            path.join(tmpDir, 'keyshelf.yml'),
+            yaml.dump({ name: 'test', provider: { adapter: 'aws-sm' } })
+        );
+
+        const config = loadConfig(tmpDir);
+        expect(config.provider).toEqual({ adapter: 'aws-sm' });
+    });
+
+    it('aws-sm rejects non-string region', () => {
+        fs.writeFileSync(
+            path.join(tmpDir, 'keyshelf.yml'),
+            yaml.dump({ name: 'test', provider: { adapter: 'aws-sm', region: 123 } })
+        );
+
+        expect(() => loadConfig(tmpDir)).toThrow(/provider\.region.*must be a string/);
+    });
+
+    it('aws-sm rejects non-string profile', () => {
+        fs.writeFileSync(
+            path.join(tmpDir, 'keyshelf.yml'),
+            yaml.dump({ name: 'test', provider: { adapter: 'aws-sm', profile: true } })
+        );
+
+        expect(() => loadConfig(tmpDir)).toThrow(/provider\.profile.*must be a string/);
+    });
 });
 
 describe('parseProviderConfig', () => {

--- a/test/core/config.test.ts
+++ b/test/core/config.test.ts
@@ -65,10 +65,10 @@ describe('config validation', () => {
     it('unknown adapter name shows available adapters', () => {
         fs.writeFileSync(
             path.join(tmpDir, 'keyshelf.yml'),
-            yaml.dump({ name: 'test', provider: { adapter: 'aws-sm' } })
+            yaml.dump({ name: 'test', provider: { adapter: 'vault' } })
         );
 
-        expect(() => loadConfig(tmpDir)).toThrow(/unknown adapter "aws-sm"/i);
+        expect(() => loadConfig(tmpDir)).toThrow(/unknown adapter "vault"/i);
         expect(() => loadConfig(tmpDir)).toThrow(/local/);
         expect(() => loadConfig(tmpDir)).toThrow(/gcp-sm/);
     });
@@ -112,8 +112,8 @@ describe('parseProviderConfig', () => {
     });
 
     it('uses context in error messages for unknown adapter', () => {
-        expect(() => parseProviderConfig({ adapter: 'aws-sm' }, 'environment file')).toThrow(
-            /Invalid environment file.*unknown adapter "aws-sm"/
+        expect(() => parseProviderConfig({ adapter: 'vault' }, 'environment file')).toThrow(
+            /Invalid environment file.*unknown adapter "vault"/
         );
     });
 

--- a/test/providers/aws-sm.test.ts
+++ b/test/providers/aws-sm.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AwsSmProvider, buildSecretName } from '../../src/providers/aws-sm.js';
+
+const mockSend = vi.fn();
+
+vi.mock('@aws-sdk/client-secrets-manager', () => ({
+    SecretsManagerClient: class {
+        send = mockSend;
+    },
+    GetSecretValueCommand: class {
+        constructor(public input: unknown) {}
+    },
+    PutSecretValueCommand: class {
+        constructor(public input: unknown) {}
+    },
+    CreateSecretCommand: class {
+        constructor(public input: unknown) {}
+    },
+    DeleteSecretCommand: class {
+        constructor(public input: unknown) {}
+    },
+    ListSecretsCommand: class {
+        constructor(public input: unknown) {}
+    }
+}));
+
+vi.mock('@aws-sdk/credential-providers', () => ({
+    fromIni: vi.fn(() => 'mocked-credentials')
+}));
+
+describe('AwsSmProvider', () => {
+    let provider: AwsSmProvider;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        provider = new AwsSmProvider({});
+    });
+
+    describe('get', () => {
+        it('returns SecretString from AWS response', async () => {
+            mockSend.mockResolvedValue({ SecretString: 's3cret' });
+
+            const value = await provider.get('dev', 'db/password');
+
+            expect(mockSend).toHaveBeenCalledOnce();
+            const cmd = mockSend.mock.calls[0][0];
+            expect(cmd.input).toEqual({ SecretId: 'keyshelf/dev/db/password' });
+            expect(value).toBe('s3cret');
+        });
+
+        it('throws descriptive error on ResourceNotFoundException', async () => {
+            mockSend.mockRejectedValue({ name: 'ResourceNotFoundException' });
+
+            await expect(provider.get('dev', 'db/password')).rejects.toThrow(
+                /Secret "db\/password" not found in environment "dev"/
+            );
+        });
+
+        it('re-throws non-NOT_FOUND errors', async () => {
+            mockSend.mockRejectedValue(new Error('AccessDeniedException'));
+
+            await expect(provider.get('dev', 'db/password')).rejects.toThrow(
+                'AccessDeniedException'
+            );
+        });
+
+        it('throws when SecretString is undefined (binary secret)', async () => {
+            mockSend.mockResolvedValue({ SecretBinary: Buffer.from('data') });
+
+            await expect(provider.get('dev', 'db/password')).rejects.toThrow(/binary/);
+        });
+    });
+
+    describe('set', () => {
+        it('puts value to existing secret', async () => {
+            mockSend.mockResolvedValueOnce({});
+
+            await provider.set('dev', 'db/password', 'newvalue');
+
+            expect(mockSend).toHaveBeenCalledOnce();
+            const cmd = mockSend.mock.calls[0][0];
+            expect(cmd.input).toEqual({
+                SecretId: 'keyshelf/dev/db/password',
+                SecretString: 'newvalue'
+            });
+        });
+
+        it('creates secret when it does not exist', async () => {
+            mockSend.mockRejectedValueOnce({ name: 'ResourceNotFoundException' });
+            mockSend.mockResolvedValueOnce({});
+
+            await provider.set('dev', 'db/password', 'newvalue');
+
+            expect(mockSend).toHaveBeenCalledTimes(2);
+            const createCmd = mockSend.mock.calls[1][0];
+            expect(createCmd.input).toEqual({
+                Name: 'keyshelf/dev/db/password',
+                SecretString: 'newvalue'
+            });
+        });
+    });
+
+    describe('delete', () => {
+        it('deletes secret with ForceDeleteWithoutRecovery', async () => {
+            mockSend.mockResolvedValue({});
+
+            await provider.delete('dev', 'db/password');
+
+            expect(mockSend).toHaveBeenCalledOnce();
+            const cmd = mockSend.mock.calls[0][0];
+            expect(cmd.input).toEqual({
+                SecretId: 'keyshelf/dev/db/password',
+                ForceDeleteWithoutRecovery: true
+            });
+        });
+
+        it('throws descriptive error on ResourceNotFoundException', async () => {
+            mockSend.mockRejectedValue({ name: 'ResourceNotFoundException' });
+
+            await expect(provider.delete('dev', 'db/password')).rejects.toThrow(
+                /Secret "db\/password" not found in environment "dev"/
+            );
+        });
+    });
+
+    describe('list', () => {
+        it('returns paths filtered by env prefix', async () => {
+            mockSend.mockResolvedValue({
+                SecretList: [
+                    { Name: 'keyshelf/dev/db/password' },
+                    { Name: 'keyshelf/dev/db/host' },
+                    { Name: 'keyshelf/staging/db/password' }
+                ],
+                NextToken: undefined
+            });
+
+            const paths = await provider.list('dev');
+
+            expect(paths).toEqual(['db/password', 'db/host']);
+        });
+
+        it('filters by path prefix', async () => {
+            mockSend.mockResolvedValue({
+                SecretList: [
+                    { Name: 'keyshelf/dev/db/password' },
+                    { Name: 'keyshelf/dev/db/host' },
+                    { Name: 'keyshelf/dev/cache/url' }
+                ],
+                NextToken: undefined
+            });
+
+            const paths = await provider.list('dev', 'db');
+
+            expect(paths).toEqual(['db/password', 'db/host']);
+        });
+
+        it('paginates through multiple pages', async () => {
+            mockSend
+                .mockResolvedValueOnce({
+                    SecretList: [{ Name: 'keyshelf/dev/db/password' }],
+                    NextToken: 'page2token'
+                })
+                .mockResolvedValueOnce({
+                    SecretList: [{ Name: 'keyshelf/dev/db/host' }],
+                    NextToken: undefined
+                });
+
+            const paths = await provider.list('dev');
+
+            expect(mockSend).toHaveBeenCalledTimes(2);
+            expect(paths).toEqual(['db/password', 'db/host']);
+        });
+
+        it('returns empty array when no secrets match', async () => {
+            mockSend.mockResolvedValue({ SecretList: [], NextToken: undefined });
+
+            const paths = await provider.list('dev');
+
+            expect(paths).toEqual([]);
+        });
+    });
+
+    describe('ref', () => {
+        it('returns keyshelf/<env>/<path>', () => {
+            expect(provider.ref('prod', 'database/password')).toBe(
+                'keyshelf/prod/database/password'
+            );
+        });
+
+        it('handles deeply nested paths', () => {
+            expect(provider.ref('dev', 'a/b/c/d')).toBe('keyshelf/dev/a/b/c/d');
+        });
+    });
+});
+
+describe('buildSecretName', () => {
+    it('returns keyshelf/<env>/<path>', () => {
+        expect(buildSecretName('dev', 'db/password')).toBe('keyshelf/dev/db/password');
+    });
+
+    it('handles deeply nested paths', () => {
+        expect(buildSecretName('prod', 'a/b/c/d')).toBe('keyshelf/prod/a/b/c/d');
+    });
+
+    it('throws when env contains a slash', () => {
+        expect(() => buildSecretName('dev/bad', 'db/password')).toThrow(/env/);
+    });
+});

--- a/test/providers/aws-sm.test.ts
+++ b/test/providers/aws-sm.test.ts
@@ -121,6 +121,14 @@ describe('AwsSmProvider', () => {
                 /Secret "db\/password" not found in environment "dev"/
             );
         });
+
+        it('re-throws non-NOT_FOUND errors', async () => {
+            mockSend.mockRejectedValue(new Error('AccessDeniedException'));
+
+            await expect(provider.delete('dev', 'db/password')).rejects.toThrow(
+                'AccessDeniedException'
+            );
+        });
     });
 
     describe('list', () => {

--- a/test/providers/index.test.ts
+++ b/test/providers/index.test.ts
@@ -5,6 +5,7 @@ import os from 'node:os';
 import { createProvider, resolveProvider } from '../../src/providers/index.js';
 import { LocalProvider } from '../../src/providers/local.js';
 import { GcpSmProvider } from '../../src/providers/gcp-sm.js';
+import { AwsSmProvider } from '../../src/providers/aws-sm.js';
 
 describe('createProvider', () => {
     let tmpDir: string;
@@ -28,6 +29,14 @@ describe('createProvider', () => {
     it('creates a gcp-sm provider', () => {
         const provider = createProvider({ adapter: 'gcp-sm', project: 'my-project' }, tmpDir);
         expect(provider).toBeDefined();
+    });
+
+    it('creates an aws-sm provider', () => {
+        const provider = createProvider(
+            { adapter: 'aws-sm', region: 'us-east-1', profile: 'dev' },
+            tmpDir
+        );
+        expect(provider).toBeInstanceOf(AwsSmProvider);
     });
 });
 


### PR DESCRIPTION
## Summary

- Add `aws-sm` secret provider backed by AWS Secrets Manager, with optional `--region` and `--profile` configuration
- Secrets use natural `/`-delimited naming: `keyshelf/<env>/<path>`
- Uses try-put-catch-create pattern for idempotent writes, `ForceDeleteWithoutRecovery` for clean deletes, and paginated listing
- Extends `ProviderConfig` union, config parsing, provider factory, and both `init`/`env:create` commands

## Test plan

- [x] 17 new tests covering get/set/delete/list/ref/buildSecretName (including pagination, binary secret rejection, error handling)
- [x] Updated existing config tests that used `aws-sm` as an unknown adapter example
- [x] All 196 tests pass, build succeeds, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)