### PR TITLE
fix: scope provider keys by project name

### DIFF
--- a/src/providers/aws-sm.ts
+++ b/src/providers/aws-sm.ts
@@ -11,6 +11,7 @@ import { fromIni } from '@aws-sdk/credential-providers';
 import { SecretProvider } from './provider.js';
 
 type AwsSmConfig = {
+    name: string;
     region?: string;
     profile?: string;
 };
@@ -18,8 +19,13 @@ type AwsSmConfig = {
 /** Stores secrets in AWS Secrets Manager using configurable credentials. */
 export class AwsSmProvider implements SecretProvider {
     private readonly client: SecretsManagerClient;
+    private readonly name: string;
 
     constructor(config: AwsSmConfig) {
+        if (config.name.includes('/')) {
+            throw new Error(`project name must not contain "/": got "${config.name}"`);
+        }
+        this.name = config.name;
         const clientConfig: SecretsManagerClientConfig = {};
         if (config.region) clientConfig.region = config.region;
         if (config.profile) clientConfig.credentials = fromIni({ profile: config.profile });
@@ -27,13 +33,13 @@ export class AwsSmProvider implements SecretProvider {
     }
 
     ref(env: string, secretPath: string): string {
-        return buildSecretName(env, secretPath);
+        return buildSecretName(this.name, env, secretPath);
     }
 
     async get(env: string, secretPath: string): Promise<string> {
         try {
             const response = await this.client.send(
-                new GetSecretValueCommand({ SecretId: buildSecretName(env, secretPath) })
+                new GetSecretValueCommand({ SecretId: buildSecretName(this.name, env, secretPath) })
             );
             if (response.SecretString === undefined) {
                 throw new Error(
@@ -50,7 +56,7 @@ export class AwsSmProvider implements SecretProvider {
     }
 
     async set(env: string, secretPath: string, value: string): Promise<void> {
-        const secretId = buildSecretName(env, secretPath);
+        const secretId = buildSecretName(this.name, env, secretPath);
 
         try {
             await this.client.send(
@@ -68,7 +74,7 @@ export class AwsSmProvider implements SecretProvider {
         try {
             await this.client.send(
                 new DeleteSecretCommand({
-                    SecretId: buildSecretName(env, secretPath),
+                    SecretId: buildSecretName(this.name, env, secretPath),
                     ForceDeleteWithoutRecovery: true
                 })
             );
@@ -81,7 +87,7 @@ export class AwsSmProvider implements SecretProvider {
     }
 
     async list(env: string, prefix?: string): Promise<string[]> {
-        const envPrefix = `keyshelf/${env}/`;
+        const envPrefix = `keyshelf/${this.name}/${env}/`;
         const paths: string[] = [];
         let nextToken: string | undefined;
 
@@ -111,15 +117,19 @@ export class AwsSmProvider implements SecretProvider {
 
 /**
  * Build the AWS Secrets Manager secret name for a given env and path.
+ * @param name - Project name (must not contain `/`)
  * @param env - Environment name (must not contain `/`)
  * @param secretPath - `/`-delimited path to the secret
- * @returns The full secret name: `keyshelf/<env>/<secretPath>`
+ * @returns The full secret name: `keyshelf/<name>/<env>/<secretPath>`
  */
-export function buildSecretName(env: string, secretPath: string): string {
+export function buildSecretName(name: string, env: string, secretPath: string): string {
+    if (name.includes('/')) {
+        throw new Error(`name must not contain "/": got "${name}"`);
+    }
     if (env.includes('/')) {
         throw new Error(`env must not contain "/": got "${env}"`);
     }
-    return `keyshelf/${env}/${secretPath}`;
+    return `keyshelf/${name}/${env}/${secretPath}`;
 }
 
 function isNotFoundError(err: unknown): boolean {

--- a/src/providers/gcp-sm.ts
+++ b/src/providers/gcp-sm.ts
@@ -7,18 +7,20 @@ const MAX_SECRET_ID_LENGTH = 255;
 export class GcpSmProvider implements SecretProvider {
     private readonly client: SecretManagerServiceClient;
     private readonly project: string;
+    private readonly name: string;
 
-    constructor(project: string) {
+    constructor(name: string, project: string) {
+        this.name = name;
         this.project = project;
         this.client = new SecretManagerServiceClient();
     }
 
     ref(env: string, secretPath: string): string {
-        return buildSecretId(env, secretPath);
+        return buildSecretId(this.name, env, secretPath);
     }
 
     async get(env: string, secretPath: string): Promise<string> {
-        const secretId = buildSecretId(env, secretPath);
+        const secretId = buildSecretId(this.name, env, secretPath);
         const name = `projects/${this.project}/secrets/${secretId}/versions/latest`;
 
         try {
@@ -33,7 +35,7 @@ export class GcpSmProvider implements SecretProvider {
     }
 
     async set(env: string, secretPath: string, value: string): Promise<void> {
-        const secretId = buildSecretId(env, secretPath);
+        const secretId = buildSecretId(this.name, env, secretPath);
         const parent = `projects/${this.project}`;
         const secretName = `${parent}/secrets/${secretId}`;
 
@@ -58,7 +60,7 @@ export class GcpSmProvider implements SecretProvider {
     }
 
     async delete(env: string, secretPath: string): Promise<void> {
-        const secretId = buildSecretId(env, secretPath);
+        const secretId = buildSecretId(this.name, env, secretPath);
         const name = `projects/${this.project}/secrets/${secretId}`;
 
         try {
@@ -73,7 +75,7 @@ export class GcpSmProvider implements SecretProvider {
 
     async list(env: string, prefix?: string): Promise<string[]> {
         const parent = `projects/${this.project}`;
-        const envPrefix = `${env}__`;
+        const envPrefix = `${this.name}__${env}__`;
         const paths: string[] = [];
 
         const [secrets] = await this.client.listSecrets({ parent });
@@ -91,9 +93,9 @@ export class GcpSmProvider implements SecretProvider {
     }
 }
 
-/** Encode env + path into a GCP-safe secret ID. */
-export function buildSecretId(env: string, secretPath: string): string {
-    const id = `${env}__${secretPath.replaceAll('/', '__')}`;
+/** Encode project name, env and path into a GCP-safe secret ID. */
+export function buildSecretId(name: string, env: string, secretPath: string): string {
+    const id = `${name}__${env}__${secretPath.replaceAll('/', '__')}`;
     if (id.length > MAX_SECRET_ID_LENGTH) {
         throw new Error(
             `Secret ID exceeds GCP's ${MAX_SECRET_ID_LENGTH}-character limit: "${id}" (${id.length} chars).`

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -5,14 +5,22 @@ import { GcpSmProvider } from './gcp-sm.js';
 import { AwsSmProvider } from './aws-sm.js';
 
 /** Create a SecretProvider from adapter configuration. */
-export function createProvider(config: ProviderConfig, configDir: string): SecretProvider {
+export function createProvider(
+    config: ProviderConfig,
+    configDir: string,
+    projectName: string
+): SecretProvider {
     switch (config.adapter) {
         case 'local':
             return new LocalProvider(configDir);
         case 'gcp-sm':
-            return new GcpSmProvider(config.project);
+            return new GcpSmProvider(projectName, config.project);
         case 'aws-sm':
-            return new AwsSmProvider({ region: config.region, profile: config.profile });
+            return new AwsSmProvider({
+                name: projectName,
+                region: config.region,
+                profile: config.profile
+            });
     }
 }
 
@@ -23,5 +31,5 @@ export function resolveProvider(
     configDir: string
 ): SecretProvider {
     const providerConfig = envDef.provider ?? globalConfig.provider;
-    return createProvider(providerConfig, configDir);
+    return createProvider(providerConfig, configDir, globalConfig.name);
 }

--- a/test/providers/aws-sm.test.ts
+++ b/test/providers/aws-sm.test.ts
@@ -33,7 +33,7 @@ describe('AwsSmProvider', () => {
 
     beforeEach(() => {
         vi.clearAllMocks();
-        provider = new AwsSmProvider({});
+        provider = new AwsSmProvider({ name: 'myapp' });
     });
 
     describe('get', () => {
@@ -44,7 +44,7 @@ describe('AwsSmProvider', () => {
 
             expect(mockSend).toHaveBeenCalledOnce();
             const cmd = mockSend.mock.calls[0][0];
-            expect(cmd.input).toEqual({ SecretId: 'keyshelf/dev/db/password' });
+            expect(cmd.input).toEqual({ SecretId: 'keyshelf/myapp/dev/db/password' });
             expect(value).toBe('s3cret');
         });
 
@@ -80,7 +80,7 @@ describe('AwsSmProvider', () => {
             expect(mockSend).toHaveBeenCalledOnce();
             const cmd = mockSend.mock.calls[0][0];
             expect(cmd.input).toEqual({
-                SecretId: 'keyshelf/dev/db/password',
+                SecretId: 'keyshelf/myapp/dev/db/password',
                 SecretString: 'newvalue'
             });
         });
@@ -94,7 +94,7 @@ describe('AwsSmProvider', () => {
             expect(mockSend).toHaveBeenCalledTimes(2);
             const createCmd = mockSend.mock.calls[1][0];
             expect(createCmd.input).toEqual({
-                Name: 'keyshelf/dev/db/password',
+                Name: 'keyshelf/myapp/dev/db/password',
                 SecretString: 'newvalue'
             });
         });
@@ -109,7 +109,7 @@ describe('AwsSmProvider', () => {
             expect(mockSend).toHaveBeenCalledOnce();
             const cmd = mockSend.mock.calls[0][0];
             expect(cmd.input).toEqual({
-                SecretId: 'keyshelf/dev/db/password',
+                SecretId: 'keyshelf/myapp/dev/db/password',
                 ForceDeleteWithoutRecovery: true
             });
         });
@@ -135,9 +135,9 @@ describe('AwsSmProvider', () => {
         it('returns paths filtered by env prefix', async () => {
             mockSend.mockResolvedValue({
                 SecretList: [
-                    { Name: 'keyshelf/dev/db/password' },
-                    { Name: 'keyshelf/dev/db/host' },
-                    { Name: 'keyshelf/staging/db/password' }
+                    { Name: 'keyshelf/myapp/dev/db/password' },
+                    { Name: 'keyshelf/myapp/dev/db/host' },
+                    { Name: 'keyshelf/myapp/staging/db/password' }
                 ],
                 NextToken: undefined
             });
@@ -150,9 +150,9 @@ describe('AwsSmProvider', () => {
         it('filters by path prefix', async () => {
             mockSend.mockResolvedValue({
                 SecretList: [
-                    { Name: 'keyshelf/dev/db/password' },
-                    { Name: 'keyshelf/dev/db/host' },
-                    { Name: 'keyshelf/dev/cache/url' }
+                    { Name: 'keyshelf/myapp/dev/db/password' },
+                    { Name: 'keyshelf/myapp/dev/db/host' },
+                    { Name: 'keyshelf/myapp/dev/cache/url' }
                 ],
                 NextToken: undefined
             });
@@ -165,11 +165,11 @@ describe('AwsSmProvider', () => {
         it('paginates through multiple pages', async () => {
             mockSend
                 .mockResolvedValueOnce({
-                    SecretList: [{ Name: 'keyshelf/dev/db/password' }],
+                    SecretList: [{ Name: 'keyshelf/myapp/dev/db/password' }],
                     NextToken: 'page2token'
                 })
                 .mockResolvedValueOnce({
-                    SecretList: [{ Name: 'keyshelf/dev/db/host' }],
+                    SecretList: [{ Name: 'keyshelf/myapp/dev/db/host' }],
                     NextToken: undefined
                 });
 
@@ -189,28 +189,104 @@ describe('AwsSmProvider', () => {
     });
 
     describe('ref', () => {
-        it('returns keyshelf/<env>/<path>', () => {
+        it('returns keyshelf/<name>/<env>/<path>', () => {
             expect(provider.ref('prod', 'database/password')).toBe(
-                'keyshelf/prod/database/password'
+                'keyshelf/myapp/prod/database/password'
             );
         });
 
         it('handles deeply nested paths', () => {
-            expect(provider.ref('dev', 'a/b/c/d')).toBe('keyshelf/dev/a/b/c/d');
+            expect(provider.ref('dev', 'a/b/c/d')).toBe('keyshelf/myapp/dev/a/b/c/d');
+        });
+    });
+
+    describe('project isolation', () => {
+        let providerA: AwsSmProvider;
+        let providerB: AwsSmProvider;
+
+        beforeEach(() => {
+            providerA = new AwsSmProvider({ name: 'project-a' });
+            providerB = new AwsSmProvider({ name: 'project-b' });
+        });
+
+        it('produces different keys for different project names', () => {
+            expect(providerA.ref('dev', 'db/password')).toBe('keyshelf/project-a/dev/db/password');
+            expect(providerB.ref('dev', 'db/password')).toBe('keyshelf/project-b/dev/db/password');
+        });
+
+        it('sends project-scoped key on get', async () => {
+            mockSend.mockResolvedValue({ SecretString: 'val' });
+
+            await providerA.get('dev', 'db/password');
+
+            const cmd = mockSend.mock.calls[0][0];
+            expect(cmd.input).toEqual({ SecretId: 'keyshelf/project-a/dev/db/password' });
+        });
+
+        it('sends project-scoped key on set', async () => {
+            mockSend.mockResolvedValue({});
+
+            await providerB.set('dev', 'db/password', 'val');
+
+            const cmd = mockSend.mock.calls[0][0];
+            expect(cmd.input).toEqual({
+                SecretId: 'keyshelf/project-b/dev/db/password',
+                SecretString: 'val'
+            });
+        });
+
+        it('sends project-scoped key on delete', async () => {
+            mockSend.mockResolvedValue({});
+
+            await providerA.delete('dev', 'db/password');
+
+            const cmd = mockSend.mock.calls[0][0];
+            expect(cmd.input).toEqual({
+                SecretId: 'keyshelf/project-a/dev/db/password',
+                ForceDeleteWithoutRecovery: true
+            });
+        });
+
+        it('scopes list filter by project name', async () => {
+            mockSend.mockResolvedValue({
+                SecretList: [
+                    { Name: 'keyshelf/project-a/dev/db/password' },
+                    { Name: 'keyshelf/project-b/dev/db/password' }
+                ],
+                NextToken: undefined
+            });
+
+            const paths = await providerA.list('dev');
+
+            expect(paths).toEqual(['db/password']);
+        });
+    });
+
+    describe('constructor validation', () => {
+        it('throws when project name contains a slash', () => {
+            expect(() => new AwsSmProvider({ name: 'bad/name' })).toThrow(
+                /project name must not contain "\/"/
+            );
         });
     });
 });
 
 describe('buildSecretName', () => {
-    it('returns keyshelf/<env>/<path>', () => {
-        expect(buildSecretName('dev', 'db/password')).toBe('keyshelf/dev/db/password');
+    it('returns keyshelf/<name>/<env>/<path>', () => {
+        expect(buildSecretName('myapp', 'dev', 'db/password')).toBe(
+            'keyshelf/myapp/dev/db/password'
+        );
     });
 
     it('handles deeply nested paths', () => {
-        expect(buildSecretName('prod', 'a/b/c/d')).toBe('keyshelf/prod/a/b/c/d');
+        expect(buildSecretName('myapp', 'prod', 'a/b/c/d')).toBe('keyshelf/myapp/prod/a/b/c/d');
+    });
+
+    it('throws when name contains a slash', () => {
+        expect(() => buildSecretName('bad/name', 'dev', 'db/password')).toThrow(/name/);
     });
 
     it('throws when env contains a slash', () => {
-        expect(() => buildSecretName('dev/bad', 'db/password')).toThrow(/env/);
+        expect(() => buildSecretName('myapp', 'dev/bad', 'db/password')).toThrow(/env/);
     });
 });

--- a/test/providers/gcp-sm.test.ts
+++ b/test/providers/gcp-sm.test.ts
@@ -28,7 +28,7 @@ describe('GcpSmProvider', () => {
 
     beforeEach(() => {
         vi.clearAllMocks();
-        provider = new GcpSmProvider('my-project');
+        provider = new GcpSmProvider('myapp', 'my-project');
     });
 
     describe('get', () => {
@@ -40,7 +40,7 @@ describe('GcpSmProvider', () => {
             const value = await provider.get('dev', 'db/password');
 
             expect(mockClient.accessSecretVersion).toHaveBeenCalledWith({
-                name: 'projects/my-project/secrets/dev__db__password/versions/latest'
+                name: 'projects/my-project/secrets/myapp__dev__db__password/versions/latest'
             });
             expect(value).toBe('s3cret');
         });
@@ -68,11 +68,11 @@ describe('GcpSmProvider', () => {
             await provider.set('dev', 'db/password', 'newvalue');
 
             expect(mockClient.getSecret).toHaveBeenCalledWith({
-                name: 'projects/my-project/secrets/dev__db__password'
+                name: 'projects/my-project/secrets/myapp__dev__db__password'
             });
             expect(mockClient.createSecret).not.toHaveBeenCalled();
             expect(mockClient.addSecretVersion).toHaveBeenCalledWith({
-                parent: 'projects/my-project/secrets/dev__db__password',
+                parent: 'projects/my-project/secrets/myapp__dev__db__password',
                 payload: { data: Buffer.from('newvalue', 'utf-8') }
             });
         });
@@ -86,7 +86,7 @@ describe('GcpSmProvider', () => {
 
             expect(mockClient.createSecret).toHaveBeenCalledWith({
                 parent: 'projects/my-project',
-                secretId: 'dev__db__password',
+                secretId: 'myapp__dev__db__password',
                 secret: { replication: { automatic: {} } }
             });
             expect(mockClient.addSecretVersion).toHaveBeenCalled();
@@ -100,7 +100,7 @@ describe('GcpSmProvider', () => {
             await provider.delete('dev', 'db/password');
 
             expect(mockClient.deleteSecret).toHaveBeenCalledWith({
-                name: 'projects/my-project/secrets/dev__db__password'
+                name: 'projects/my-project/secrets/myapp__dev__db__password'
             });
         });
 
@@ -117,9 +117,9 @@ describe('GcpSmProvider', () => {
         it('returns paths for matching environment', async () => {
             mockClient.listSecrets.mockResolvedValue([
                 [
-                    { name: 'projects/my-project/secrets/dev__db__password' },
-                    { name: 'projects/my-project/secrets/dev__db__host' },
-                    { name: 'projects/my-project/secrets/staging__db__password' }
+                    { name: 'projects/my-project/secrets/myapp__dev__db__password' },
+                    { name: 'projects/my-project/secrets/myapp__dev__db__host' },
+                    { name: 'projects/my-project/secrets/myapp__staging__db__password' }
                 ]
             ]);
 
@@ -131,9 +131,9 @@ describe('GcpSmProvider', () => {
         it('filters by prefix', async () => {
             mockClient.listSecrets.mockResolvedValue([
                 [
-                    { name: 'projects/my-project/secrets/dev__db__password' },
-                    { name: 'projects/my-project/secrets/dev__db__host' },
-                    { name: 'projects/my-project/secrets/dev__cache__url' }
+                    { name: 'projects/my-project/secrets/myapp__dev__db__password' },
+                    { name: 'projects/my-project/secrets/myapp__dev__db__host' },
+                    { name: 'projects/my-project/secrets/myapp__dev__cache__url' }
                 ]
             ]);
 
@@ -152,27 +152,92 @@ describe('GcpSmProvider', () => {
     });
 
     describe('ref', () => {
-        it('returns the GCP secret ID', () => {
-            expect(provider.ref('prod', 'database/password')).toBe('prod__database__password');
+        it('returns the GCP secret ID with project name', () => {
+            expect(provider.ref('prod', 'database/password')).toBe(
+                'myapp__prod__database__password'
+            );
         });
 
         it('handles deeply nested paths', () => {
-            expect(provider.ref('dev', 'a/b/c/d')).toBe('dev__a__b__c__d');
+            expect(provider.ref('dev', 'a/b/c/d')).toBe('myapp__dev__a__b__c__d');
+        });
+    });
+
+    describe('project isolation', () => {
+        let providerA: GcpSmProvider;
+        let providerB: GcpSmProvider;
+
+        beforeEach(() => {
+            providerA = new GcpSmProvider('project-a', 'my-project');
+            providerB = new GcpSmProvider('project-b', 'my-project');
+        });
+
+        it('produces different keys for different project names', () => {
+            expect(providerA.ref('dev', 'db/password')).toBe('project-a__dev__db__password');
+            expect(providerB.ref('dev', 'db/password')).toBe('project-b__dev__db__password');
+        });
+
+        it('sends project-scoped key on get', async () => {
+            mockClient.accessSecretVersion.mockResolvedValue([
+                { payload: { data: Buffer.from('val') } }
+            ]);
+
+            await providerA.get('dev', 'db/password');
+
+            expect(mockClient.accessSecretVersion).toHaveBeenCalledWith({
+                name: 'projects/my-project/secrets/project-a__dev__db__password/versions/latest'
+            });
+        });
+
+        it('sends project-scoped key on set', async () => {
+            mockClient.getSecret.mockResolvedValue([{}]);
+            mockClient.addSecretVersion.mockResolvedValue([{}]);
+
+            await providerB.set('dev', 'db/password', 'val');
+
+            expect(mockClient.getSecret).toHaveBeenCalledWith({
+                name: 'projects/my-project/secrets/project-b__dev__db__password'
+            });
+        });
+
+        it('sends project-scoped key on delete', async () => {
+            mockClient.deleteSecret.mockResolvedValue([{}]);
+
+            await providerA.delete('dev', 'db/password');
+
+            expect(mockClient.deleteSecret).toHaveBeenCalledWith({
+                name: 'projects/my-project/secrets/project-a__dev__db__password'
+            });
+        });
+
+        it('scopes list filter by project name', async () => {
+            mockClient.listSecrets.mockResolvedValue([
+                [
+                    { name: 'projects/my-project/secrets/project-a__dev__db__password' },
+                    { name: 'projects/my-project/secrets/project-b__dev__db__password' }
+                ]
+            ]);
+
+            const paths = await providerA.list('dev');
+
+            expect(paths).toEqual(['db/password']);
         });
     });
 });
 
 describe('buildSecretId', () => {
-    it('encodes env and path with double underscores', () => {
-        expect(buildSecretId('dev', 'db/password')).toBe('dev__db__password');
+    it('encodes name, env and path with double underscores', () => {
+        expect(buildSecretId('myapp', 'dev', 'db/password')).toBe('myapp__dev__db__password');
     });
 
     it('handles deeply nested paths', () => {
-        expect(buildSecretId('prod', 'a/b/c/d')).toBe('prod__a__b__c__d');
+        expect(buildSecretId('myapp', 'prod', 'a/b/c/d')).toBe('myapp__prod__a__b__c__d');
     });
 
     it('throws when secret ID exceeds 255 characters', () => {
         const longPath = 'a'.repeat(300);
-        expect(() => buildSecretId('dev', longPath)).toThrow(/exceeds GCP's 255-character limit/);
+        expect(() => buildSecretId('myapp', 'dev', longPath)).toThrow(
+            /exceeds GCP's 255-character limit/
+        );
     });
 });

--- a/test/providers/index.test.ts
+++ b/test/providers/index.test.ts
@@ -19,7 +19,7 @@ describe('createProvider', () => {
     });
 
     it('creates a working local provider', async () => {
-        const provider = createProvider({ adapter: 'local' }, tmpDir);
+        const provider = createProvider({ adapter: 'local' }, tmpDir, 'myapp');
 
         await provider.set('dev', 'db/pass', 'secret123');
         const value = await provider.get('dev', 'db/pass');
@@ -27,14 +27,19 @@ describe('createProvider', () => {
     });
 
     it('creates a gcp-sm provider', () => {
-        const provider = createProvider({ adapter: 'gcp-sm', project: 'my-project' }, tmpDir);
-        expect(provider).toBeDefined();
+        const provider = createProvider(
+            { adapter: 'gcp-sm', project: 'my-project' },
+            tmpDir,
+            'myapp'
+        );
+        expect(provider).toBeInstanceOf(GcpSmProvider);
     });
 
     it('creates an aws-sm provider', () => {
         const provider = createProvider(
             { adapter: 'aws-sm', region: 'us-east-1', profile: 'dev' },
-            tmpDir
+            tmpDir,
+            'myapp'
         );
         expect(provider).toBeInstanceOf(AwsSmProvider);
     });


### PR DESCRIPTION
## Summary
- Cloud providers (AWS SM, GCP SM) now include the project name in storage keys to prevent collisions between projects sharing the same cloud account
- AWS key format: `keyshelf/<name>/<env>/<path>` (was `keyshelf/<env>/<path>`)
- GCP key format: `<name>__<env>__<path>` (was `<env>__<path>`)
- Project name is threaded from `globalConfig.name` through the provider factory

## Test plan
- [x] All existing provider tests updated for new key format
- [x] Cross-project isolation tests added for both AWS and GCP providers
- [x] Constructor validation test for name containing `/`
- [x] Factory tests pass project name through
- [x] `npm run build` compiles cleanly
- [x] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)