### PR TITLE
feat: add keyshelf/preload ESM module for Lambda env injection

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,16 @@
     "type": "module",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
+    "exports": {
+        ".": {
+            "import": "./dist/index.js",
+            "types": "./dist/index.d.ts"
+        },
+        "./preload": {
+            "import": "./dist/preload.js",
+            "types": "./dist/preload.d.ts"
+        }
+    },
     "bin": {
         "keyshelf": "./bin/run.js"
     },

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,12 +1,6 @@
 import { Command, Flags } from '@oclif/core';
-import path from 'node:path';
-import os from 'node:os';
 import { spawnSync } from 'node:child_process';
-import { loadEnvironment } from '../core/environment.js';
-import { loadConfig } from '../core/config.js';
-import { resolve } from '../core/resolver.js';
-import { replaceSecrets, flattenToEnvRecord } from '../core/env-vars.js';
-import { resolveProvider } from '../providers/index.js';
+import { resolveEnv } from '../core/resolve-env.js';
 
 export default class Run extends Command {
     static override description =
@@ -32,16 +26,12 @@ export default class Run extends Command {
             this.error('No command specified. Provide a command after "--".');
         }
 
-        const cwd = process.cwd();
-        const envDef = await loadEnvironment(cwd, flags.env);
-        const resolved = await resolve(flags.env, (name) => loadEnvironment(cwd, name));
-        const config = loadConfig(cwd);
-        const configDirPath =
-            flags['config-dir'] ?? path.join(os.homedir(), '.config', 'keyshelf', config.name);
-        const provider = resolveProvider(envDef, config, configDirPath);
-
-        const replaced = await replaceSecrets(resolved.values, flags.env, provider, 'reveal');
-        const envRecord = flattenToEnvRecord(replaced);
+        const projectDir = process.cwd();
+        const envRecord = await resolveEnv({
+            env: flags.env,
+            projectDir,
+            configDir: flags['config-dir']
+        });
 
         const [cmd, ...args] = command;
         const result = spawnSync(cmd, args, {

--- a/src/core/resolve-env.ts
+++ b/src/core/resolve-env.ts
@@ -1,0 +1,33 @@
+import path from 'node:path';
+import os from 'node:os';
+import { loadEnvironment } from './environment.js';
+import { loadConfig } from './config.js';
+import { resolve } from './resolver.js';
+import { replaceSecrets, flattenToEnvRecord } from './env-vars.js';
+import { resolveProvider } from '../providers/index.js';
+
+interface ResolveEnvOptions {
+    env: string;
+    projectDir: string;
+    configDir?: string;
+}
+
+/**
+ * Resolve an environment to a flat env var record, with secrets replaced.
+ *
+ * @param options.env - Environment name to resolve
+ * @param options.projectDir - Path to project root containing keyshelf.yml
+ * @param options.configDir - Override for the provider config directory
+ * @returns Flat record of uppercased env var names to string values
+ */
+export async function resolveEnv(options: ResolveEnvOptions): Promise<Record<string, string>> {
+    const { env, projectDir } = options;
+    const envDef = await loadEnvironment(projectDir, env);
+    const resolved = await resolve(env, (name) => loadEnvironment(projectDir, name));
+    const config = loadConfig(projectDir);
+    const configDir =
+        options.configDir ?? path.join(os.homedir(), '.config', 'keyshelf', config.name);
+    const provider = resolveProvider(envDef, config, configDir);
+    const replaced = await replaceSecrets(resolved.values, env, provider, 'reveal');
+    return flattenToEnvRecord(replaced);
+}

--- a/src/core/resolve-env.ts
+++ b/src/core/resolve-env.ts
@@ -5,6 +5,7 @@ import { loadConfig } from './config.js';
 import { resolve } from './resolver.js';
 import { replaceSecrets, flattenToEnvRecord } from './env-vars.js';
 import { resolveProvider } from '../providers/index.js';
+import { EnvironmentDefinition } from './types.js';
 
 interface ResolveEnvOptions {
     env: string;
@@ -22,8 +23,17 @@ interface ResolveEnvOptions {
  */
 export async function resolveEnv(options: ResolveEnvOptions): Promise<Record<string, string>> {
     const { env, projectDir } = options;
-    const envDef = await loadEnvironment(projectDir, env);
-    const resolved = await resolve(env, (name) => loadEnvironment(projectDir, name));
+    const cache = new Map<string, EnvironmentDefinition>();
+    const loadFn = async (name: string) => {
+        const cached = cache.get(name);
+        if (cached) return cached;
+        const def = await loadEnvironment(projectDir, name);
+        cache.set(name, def);
+        return def;
+    };
+
+    const envDef = await loadFn(env);
+    const resolved = await resolve(env, loadFn);
     const config = loadConfig(projectDir);
     const configDir =
         options.configDir ?? path.join(os.homedir(), '.config', 'keyshelf', config.name);

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -1,0 +1,14 @@
+import { resolveEnv } from './core/resolve-env.js';
+
+const env = process.env.KEYSHELF_ENV;
+if (!env) {
+    throw new Error('KEYSHELF_ENV is required when using keyshelf/preload');
+}
+
+const projectDir = process.env.KEYSHELF_PROJECT_DIR ?? process.cwd();
+const configDir = process.env.KEYSHELF_CONFIG_DIR;
+const envRecord = await resolveEnv({ env, projectDir, configDir });
+
+for (const [key, value] of Object.entries(envRecord)) {
+    process.env[key] = value;
+}

--- a/test/core/resolve-env.test.ts
+++ b/test/core/resolve-env.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import yaml from 'js-yaml';
+import { saveEnvironment } from '../../src/core/environment.js';
+import { LocalProvider } from '../../src/providers/local.js';
+import { SecretRef } from '../../src/core/types.js';
+import { resolveEnv } from '../../src/core/resolve-env.js';
+
+describe('resolveEnv', () => {
+    let tmpDir: string;
+    let configDir: string;
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'keyshelf-resolve-env-'));
+        configDir = path.join(tmpDir, '.config');
+        fs.mkdirSync(path.join(tmpDir, '.keyshelf', 'environments'), { recursive: true });
+        fs.writeFileSync(
+            path.join(tmpDir, 'keyshelf.yml'),
+            yaml.dump({ name: 'test-project', provider: { adapter: 'local' } })
+        );
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('resolves plain config values to a flat env record', async () => {
+        await saveEnvironment(tmpDir, 'dev', {
+            imports: [],
+            values: { database: { host: 'localhost', port: 5432 } }
+        });
+
+        const result = await resolveEnv({ env: 'dev', projectDir: tmpDir, configDir });
+
+        expect(result).toEqual({
+            DATABASE_HOST: 'localhost',
+            DATABASE_PORT: '5432'
+        });
+    });
+
+    it('resolves secret refs to actual values', async () => {
+        const provider = new LocalProvider(configDir);
+        await provider.set('prod', 'api/key', 'super-secret-key');
+
+        await saveEnvironment(tmpDir, 'prod', {
+            imports: [],
+            values: {
+                api: { key: new SecretRef('api/key'), url: 'https://api.example.com' }
+            }
+        });
+
+        const result = await resolveEnv({ env: 'prod', projectDir: tmpDir, configDir });
+
+        expect(result).toEqual({
+            API_KEY: 'super-secret-key',
+            API_URL: 'https://api.example.com'
+        });
+    });
+
+    it('merges inherited values from imports', async () => {
+        await saveEnvironment(tmpDir, 'base', {
+            imports: [],
+            values: { shared: 'from-base' }
+        });
+        await saveEnvironment(tmpDir, 'dev', {
+            imports: ['base'],
+            values: { local: 'from-dev' }
+        });
+
+        const result = await resolveEnv({ env: 'dev', projectDir: tmpDir, configDir });
+
+        expect(result).toEqual({
+            SHARED: 'from-base',
+            LOCAL: 'from-dev'
+        });
+    });
+
+    it('child env values override parent values', async () => {
+        await saveEnvironment(tmpDir, 'base', {
+            imports: [],
+            values: { setting: 'base-value' }
+        });
+        await saveEnvironment(tmpDir, 'dev', {
+            imports: ['base'],
+            values: { setting: 'dev-value' }
+        });
+
+        const result = await resolveEnv({ env: 'dev', projectDir: tmpDir, configDir });
+
+        expect(result).toEqual({ SETTING: 'dev-value' });
+    });
+
+    it('throws when environment does not exist', async () => {
+        await expect(
+            resolveEnv({ env: 'nonexistent', projectDir: tmpDir, configDir })
+        ).rejects.toThrow(/Environment "nonexistent" not found/);
+    });
+
+    it('throws when keyshelf.yml is missing', async () => {
+        const noConfigDir = fs.mkdtempSync(path.join(os.tmpdir(), 'keyshelf-noconfig-'));
+        try {
+            fs.mkdirSync(path.join(noConfigDir, '.keyshelf', 'environments'), { recursive: true });
+            await saveEnvironment(noConfigDir, 'dev', { imports: [], values: { key: 'val' } });
+            await expect(
+                resolveEnv({ env: 'dev', projectDir: noConfigDir, configDir })
+            ).rejects.toThrow(/keyshelf.yml not found/);
+        } finally {
+            fs.rmSync(noConfigDir, { recursive: true, force: true });
+        }
+    });
+});

--- a/test/preload.test.ts
+++ b/test/preload.test.ts
@@ -33,6 +33,20 @@ describe('keyshelf/preload', () => {
         fs.rmSync(tmpDir, { recursive: true, force: true });
     });
 
+    function runPreload(script: string, env: Record<string, string | undefined>) {
+        const result = spawnSync(
+            'node',
+            ['--import', `file://${PRELOAD_PATH}`, '--input-type=module'],
+            { input: script, env: { ...process.env, ...env } }
+        );
+        if (result.error) throw result.error;
+        return {
+            status: result.status,
+            stderr: result.stderr?.toString() ?? '',
+            output: fs.existsSync(outFile) ? fs.readFileSync(outFile, 'utf-8') : ''
+        };
+    }
+
     it('injects resolved config values into process.env', async () => {
         await saveEnvironment(tmpDir, 'dev', {
             imports: [],
@@ -40,23 +54,13 @@ describe('keyshelf/preload', () => {
         });
 
         const script = `import fs from "node:fs"; fs.writeFileSync(${JSON.stringify(outFile)}, process.env.DATABASE_HOST + ":" + process.env.DATABASE_PORT)`;
-        const result = spawnSync(
-            'node',
-            ['--import', `file://${PRELOAD_PATH}`, '--input-type=module'],
-            {
-                input: script,
-                env: {
-                    ...process.env,
-                    KEYSHELF_ENV: 'dev',
-                    KEYSHELF_PROJECT_DIR: tmpDir
-                }
-            }
-        );
+        const result = runPreload(script, {
+            KEYSHELF_ENV: 'dev',
+            KEYSHELF_PROJECT_DIR: tmpDir
+        });
 
-        if (result.error) throw result.error;
-        expect(result.status, result.stderr?.toString()).toBe(0);
-        const output = fs.readFileSync(outFile, 'utf-8');
-        expect(output).toBe('localhost:5432');
+        expect(result.status, result.stderr).toBe(0);
+        expect(result.output).toBe('localhost:5432');
     });
 
     it('injects resolved secret values into process.env', async () => {
@@ -71,44 +75,24 @@ describe('keyshelf/preload', () => {
         });
 
         const script = `import fs from "node:fs"; fs.writeFileSync(${JSON.stringify(outFile)}, process.env.API_KEY + "|" + process.env.API_URL)`;
-        const result = spawnSync(
-            'node',
-            ['--import', `file://${PRELOAD_PATH}`, '--input-type=module'],
-            {
-                input: script,
-                env: {
-                    ...process.env,
-                    KEYSHELF_ENV: 'prod',
-                    KEYSHELF_PROJECT_DIR: tmpDir,
-                    KEYSHELF_CONFIG_DIR: configDir
-                }
-            }
-        );
+        const result = runPreload(script, {
+            KEYSHELF_ENV: 'prod',
+            KEYSHELF_PROJECT_DIR: tmpDir,
+            KEYSHELF_CONFIG_DIR: configDir
+        });
 
-        if (result.error) throw result.error;
-        expect(result.status, result.stderr?.toString()).toBe(0);
-        const output = fs.readFileSync(outFile, 'utf-8');
-        expect(output).toBe('super-secret-key|https://api.example.com');
+        expect(result.status, result.stderr).toBe(0);
+        expect(result.output).toBe('super-secret-key|https://api.example.com');
     });
 
     it('throws a clear error when KEYSHELF_ENV is not set', async () => {
-        const result = spawnSync(
-            'node',
-            ['--import', `file://${PRELOAD_PATH}`, '--input-type=module'],
-            {
-                input: 'console.log("should not reach")',
-                env: {
-                    ...process.env,
-                    KEYSHELF_ENV: undefined,
-                    KEYSHELF_PROJECT_DIR: tmpDir
-                }
-            }
-        );
+        const result = runPreload('console.log("should not reach")', {
+            KEYSHELF_ENV: undefined,
+            KEYSHELF_PROJECT_DIR: tmpDir
+        });
 
         expect(result.status).not.toBe(0);
-        expect(result.stderr?.toString()).toMatch(
-            /KEYSHELF_ENV is required when using keyshelf\/preload/
-        );
+        expect(result.stderr).toMatch(/KEYSHELF_ENV is required when using keyshelf\/preload/);
     });
 
     it('merges inherited values from imported environments', async () => {
@@ -122,22 +106,12 @@ describe('keyshelf/preload', () => {
         });
 
         const script = `import fs from "node:fs"; fs.writeFileSync(${JSON.stringify(outFile)}, process.env.SHARED + "|" + process.env.LOCAL)`;
-        const result = spawnSync(
-            'node',
-            ['--import', `file://${PRELOAD_PATH}`, '--input-type=module'],
-            {
-                input: script,
-                env: {
-                    ...process.env,
-                    KEYSHELF_ENV: 'dev',
-                    KEYSHELF_PROJECT_DIR: tmpDir
-                }
-            }
-        );
+        const result = runPreload(script, {
+            KEYSHELF_ENV: 'dev',
+            KEYSHELF_PROJECT_DIR: tmpDir
+        });
 
-        if (result.error) throw result.error;
-        expect(result.status, result.stderr?.toString()).toBe(0);
-        const output = fs.readFileSync(outFile, 'utf-8');
-        expect(output).toBe('from-base|from-dev');
+        expect(result.status, result.stderr).toBe(0);
+        expect(result.output).toBe('from-base|from-dev');
     });
 });

--- a/test/preload.test.ts
+++ b/test/preload.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import yaml from 'js-yaml';
+import { spawnSync } from 'node:child_process';
+import { saveEnvironment } from '../src/core/environment.js';
+import { LocalProvider } from '../src/providers/local.js';
+import { SecretRef } from '../src/core/types.js';
+
+const PRELOAD_PATH = path.resolve(
+    path.dirname(new URL(import.meta.url).pathname),
+    '../dist/preload.js'
+);
+
+describe('keyshelf/preload', () => {
+    let tmpDir: string;
+    let configDir: string;
+    let outFile: string;
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'keyshelf-preload-'));
+        configDir = path.join(tmpDir, '.config');
+        outFile = path.join(tmpDir, 'output.txt');
+        fs.mkdirSync(path.join(tmpDir, '.keyshelf', 'environments'), { recursive: true });
+        fs.writeFileSync(
+            path.join(tmpDir, 'keyshelf.yml'),
+            yaml.dump({ name: 'test-project', provider: { adapter: 'local' } })
+        );
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('injects resolved config values into process.env', async () => {
+        await saveEnvironment(tmpDir, 'dev', {
+            imports: [],
+            values: { database: { host: 'localhost', port: 5432 } }
+        });
+
+        const script = `import fs from "node:fs"; fs.writeFileSync(${JSON.stringify(outFile)}, process.env.DATABASE_HOST + ":" + process.env.DATABASE_PORT)`;
+        const result = spawnSync(
+            'node',
+            ['--import', `file://${PRELOAD_PATH}`, '--input-type=module'],
+            {
+                input: script,
+                env: {
+                    ...process.env,
+                    KEYSHELF_ENV: 'dev',
+                    KEYSHELF_PROJECT_DIR: tmpDir
+                }
+            }
+        );
+
+        if (result.error) throw result.error;
+        expect(result.status, result.stderr?.toString()).toBe(0);
+        const output = fs.readFileSync(outFile, 'utf-8');
+        expect(output).toBe('localhost:5432');
+    });
+
+    it('injects resolved secret values into process.env', async () => {
+        const provider = new LocalProvider(configDir);
+        await provider.set('prod', 'api/key', 'super-secret-key');
+
+        await saveEnvironment(tmpDir, 'prod', {
+            imports: [],
+            values: {
+                api: { key: new SecretRef('api/key'), url: 'https://api.example.com' }
+            }
+        });
+
+        const script = `import fs from "node:fs"; fs.writeFileSync(${JSON.stringify(outFile)}, process.env.API_KEY + "|" + process.env.API_URL)`;
+        const result = spawnSync(
+            'node',
+            ['--import', `file://${PRELOAD_PATH}`, '--input-type=module'],
+            {
+                input: script,
+                env: {
+                    ...process.env,
+                    KEYSHELF_ENV: 'prod',
+                    KEYSHELF_PROJECT_DIR: tmpDir,
+                    KEYSHELF_CONFIG_DIR: configDir
+                }
+            }
+        );
+
+        if (result.error) throw result.error;
+        expect(result.status, result.stderr?.toString()).toBe(0);
+        const output = fs.readFileSync(outFile, 'utf-8');
+        expect(output).toBe('super-secret-key|https://api.example.com');
+    });
+
+    it('throws a clear error when KEYSHELF_ENV is not set', async () => {
+        const result = spawnSync(
+            'node',
+            ['--import', `file://${PRELOAD_PATH}`, '--input-type=module'],
+            {
+                input: 'console.log("should not reach")',
+                env: {
+                    ...process.env,
+                    KEYSHELF_ENV: undefined,
+                    KEYSHELF_PROJECT_DIR: tmpDir
+                }
+            }
+        );
+
+        expect(result.status).not.toBe(0);
+        expect(result.stderr?.toString()).toMatch(
+            /KEYSHELF_ENV is required when using keyshelf\/preload/
+        );
+    });
+
+    it('merges inherited values from imported environments', async () => {
+        await saveEnvironment(tmpDir, 'base', {
+            imports: [],
+            values: { shared: 'from-base' }
+        });
+        await saveEnvironment(tmpDir, 'dev', {
+            imports: ['base'],
+            values: { local: 'from-dev' }
+        });
+
+        const script = `import fs from "node:fs"; fs.writeFileSync(${JSON.stringify(outFile)}, process.env.SHARED + "|" + process.env.LOCAL)`;
+        const result = spawnSync(
+            'node',
+            ['--import', `file://${PRELOAD_PATH}`, '--input-type=module'],
+            {
+                input: script,
+                env: {
+                    ...process.env,
+                    KEYSHELF_ENV: 'dev',
+                    KEYSHELF_PROJECT_DIR: tmpDir
+                }
+            }
+        );
+
+        if (result.error) throw result.error;
+        expect(result.status, result.stderr?.toString()).toBe(0);
+        const output = fs.readFileSync(outFile, 'utf-8');
+        expect(output).toBe('from-base|from-dev');
+    });
+});


### PR DESCRIPTION
## Summary

- Adds a `keyshelf/preload` ESM module that resolves secrets and injects them into `process.env` at import time
- Consumers use `NODE_OPTIONS="--import keyshelf/preload"` in Lambda (or similar) — no code changes to handlers needed
- Extracts shared resolution logic into `resolveEnv()` function, refactors `run` command to use it

## Usage

```hcl
# Terraform / Pulumi
environment {
  variables = {
    NODE_OPTIONS           = "--import keyshelf/preload"
    KEYSHELF_ENV           = "production"
    KEYSHELF_PROJECT_DIR   = "/var/task"      # optional, defaults to cwd
    KEYSHELF_CONFIG_DIR    = "/opt/config"     # optional
  }
}
```

## Changes

- **`src/core/resolve-env.ts`** — new `resolveEnv()` function encapsulating the full pipeline (load env → resolve imports → load config → create provider → replace secrets → flatten)
- **`src/preload.ts`** — thin ESM preload module using top-level `await`
- **`src/commands/run.ts`** — refactored to delegate to `resolveEnv()`
- **`package.json`** — added `exports` map for `keyshelf/preload`
- **`test/core/resolve-env.test.ts`** — 6 unit tests
- **`test/preload.test.ts`** — 4 integration tests (spawns child processes with `--import`)

## Test plan

- [x] All existing tests pass (407 tests)
- [x] Unit tests verify `resolveEnv` with plain values, secrets, imports, overrides, and error cases
- [x] Integration tests spawn real Node processes with `--import file://dist/preload.js` and verify `process.env` injection

🤖 Generated with [Claude Code](https://claude.com/claude-code)