### PR TITLE
refactor: remove profile option from aws-sm provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "0.0.0-development",
             "license": "ISC",
             "dependencies": {
+                "@aws-sdk/client-secrets-manager": "^3.1009.0",
                 "@google-cloud/secret-manager": "^6.1.1",
                 "@oclif/core": "^4.8.1",
                 "js-yaml": "^4.1.1"
@@ -36,18 +37,6 @@
             },
             "engines": {
                 "node": ">=20"
-            },
-            "peerDependencies": {
-                "@aws-sdk/client-secrets-manager": "^3.1009.0",
-                "@aws-sdk/credential-providers": "^3.1009.0"
-            },
-            "peerDependenciesMeta": {
-                "@aws-sdk/client-secrets-manager": {
-                    "optional": true
-                },
-                "@aws-sdk/credential-providers": {
-                    "optional": true
-                }
             }
         },
         "node_modules/@aws-crypto/sha256-browser": {
@@ -55,8 +44,6 @@
             "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
             "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-js": "^5.2.0",
                 "@aws-crypto/supports-web-crypto": "^5.2.0",
@@ -72,8 +59,6 @@
             "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
             "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -86,8 +71,6 @@
             "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
             "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@smithy/is-array-buffer": "^2.2.0",
                 "tslib": "^2.6.2"
@@ -101,8 +84,6 @@
             "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
             "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@smithy/util-buffer-from": "^2.2.0",
                 "tslib": "^2.6.2"
@@ -116,8 +97,6 @@
             "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
             "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@aws-crypto/util": "^5.2.0",
                 "@aws-sdk/types": "^3.222.0",
@@ -132,8 +111,6 @@
             "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
             "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             }
@@ -143,8 +120,6 @@
             "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
             "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "^3.222.0",
                 "@smithy/util-utf8": "^2.0.0",
@@ -156,8 +131,6 @@
             "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
             "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -170,8 +143,6 @@
             "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
             "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@smithy/is-array-buffer": "^2.2.0",
                 "tslib": "^2.6.2"
@@ -185,8 +156,6 @@
             "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
             "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@smithy/util-buffer-from": "^2.2.0",
                 "tslib": "^2.6.2"
@@ -195,65 +164,11 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-cognito-identity": {
-            "version": "3.1009.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.1009.0.tgz",
-            "integrity": "sha512-4+lBLB2sIdrnGruxqsfPM2AOSME3DVDRX7R5OXcgd2jfrUSyYdHJN1kT9hO/vwK4uajRZsQNP5hLJMttkjkoAQ==",
-            "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@aws-crypto/sha256-browser": "5.2.0",
-                "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "^3.973.20",
-                "@aws-sdk/credential-provider-node": "^3.972.21",
-                "@aws-sdk/middleware-host-header": "^3.972.8",
-                "@aws-sdk/middleware-logger": "^3.972.8",
-                "@aws-sdk/middleware-recursion-detection": "^3.972.8",
-                "@aws-sdk/middleware-user-agent": "^3.972.21",
-                "@aws-sdk/region-config-resolver": "^3.972.8",
-                "@aws-sdk/types": "^3.973.6",
-                "@aws-sdk/util-endpoints": "^3.996.5",
-                "@aws-sdk/util-user-agent-browser": "^3.972.8",
-                "@aws-sdk/util-user-agent-node": "^3.973.7",
-                "@smithy/config-resolver": "^4.4.11",
-                "@smithy/core": "^3.23.11",
-                "@smithy/fetch-http-handler": "^5.3.15",
-                "@smithy/hash-node": "^4.2.12",
-                "@smithy/invalid-dependency": "^4.2.12",
-                "@smithy/middleware-content-length": "^4.2.12",
-                "@smithy/middleware-endpoint": "^4.4.25",
-                "@smithy/middleware-retry": "^4.4.42",
-                "@smithy/middleware-serde": "^4.2.14",
-                "@smithy/middleware-stack": "^4.2.12",
-                "@smithy/node-config-provider": "^4.3.12",
-                "@smithy/node-http-handler": "^4.4.16",
-                "@smithy/protocol-http": "^5.3.12",
-                "@smithy/smithy-client": "^4.12.5",
-                "@smithy/types": "^4.13.1",
-                "@smithy/url-parser": "^4.2.12",
-                "@smithy/util-base64": "^4.3.2",
-                "@smithy/util-body-length-browser": "^4.2.2",
-                "@smithy/util-body-length-node": "^4.2.3",
-                "@smithy/util-defaults-mode-browser": "^4.3.41",
-                "@smithy/util-defaults-mode-node": "^4.2.44",
-                "@smithy/util-endpoints": "^3.3.3",
-                "@smithy/util-middleware": "^4.2.12",
-                "@smithy/util-retry": "^4.2.12",
-                "@smithy/util-utf8": "^4.2.2",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
         "node_modules/@aws-sdk/client-secrets-manager": {
             "version": "3.1009.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1009.0.tgz",
             "integrity": "sha512-8CaFVjwOotZAsWKEXXPe23wwb1hqJWmy1os8WYCcN90h5VGdje47HeLgh66VDUJDTV2iWx1QeTBtwihioUB90w==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -304,8 +219,6 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.20.tgz",
             "integrity": "sha512-i3GuX+lowD892F3IuJf8o6AbyDupMTdyTxQrCJGcn71ni5hTZ82L4nQhcdumxZ7XPJRJJVHS/CR3uYOIIs0PVA==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "^3.973.6",
                 "@aws-sdk/xml-builder": "^3.972.11",
@@ -325,31 +238,11 @@
                 "node": ">=20.0.0"
             }
         },
-        "node_modules/@aws-sdk/credential-provider-cognito-identity": {
-            "version": "3.972.13",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.972.13.tgz",
-            "integrity": "sha512-WZnIK8NPX+4OXkpVoNmUS+Ya1osqjszUsDqFEz97+a/LD5K012np9iR/eWEC43btx8zQjyRIK8kyiwbh8SiHzg==",
-            "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@aws-sdk/nested-clients": "^3.996.10",
-                "@aws-sdk/types": "^3.973.6",
-                "@smithy/property-provider": "^4.2.12",
-                "@smithy/types": "^4.13.1",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
         "node_modules/@aws-sdk/credential-provider-env": {
             "version": "3.972.18",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.18.tgz",
             "integrity": "sha512-X0B8AlQY507i5DwjLByeU2Af4ARsl9Vr84koDcXCbAkplmU+1xBFWxEPrWRAoh56waBne/yJqEloSwvRf4x6XA==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/core": "^3.973.20",
                 "@aws-sdk/types": "^3.973.6",
@@ -366,8 +259,6 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.20.tgz",
             "integrity": "sha512-ey9Lelj001+oOfrbKmS6R2CJAiXX7QKY4Vj9VJv6L2eE6/VjD8DocHIoYqztTm70xDLR4E1jYPTKfIui+eRNDA==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/core": "^3.973.20",
                 "@aws-sdk/types": "^3.973.6",
@@ -389,8 +280,6 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.20.tgz",
             "integrity": "sha512-5flXSnKHMloObNF+9N0cupKegnH1Z37cdVlpETVgx8/rAhCe+VNlkcZH3HDg2SDn9bI765S+rhNPXGDJJPfbtA==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/core": "^3.973.20",
                 "@aws-sdk/credential-provider-env": "^3.972.18",
@@ -416,8 +305,6 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.20.tgz",
             "integrity": "sha512-gEWo54nfqp2jABMu6HNsjVC4hDLpg9HC8IKSJnp0kqWtxIJYHTmiLSsIfI4ScQjxEwpB+jOOH8dOLax1+hy/Hw==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/core": "^3.973.20",
                 "@aws-sdk/nested-clients": "^3.996.10",
@@ -437,8 +324,6 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.21.tgz",
             "integrity": "sha512-hah8if3/B/Q+LBYN5FukyQ1Mym6PLPDsBOBsIgNEYD6wLyZg0UmUF/OKIVC3nX9XH8TfTPuITK+7N/jenVACWA==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/credential-provider-env": "^3.972.18",
                 "@aws-sdk/credential-provider-http": "^3.972.20",
@@ -462,8 +347,6 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.18.tgz",
             "integrity": "sha512-Tpl7SRaPoOLT32jbTWchPsn52hYYgJ0kpiFgnwk8pxTANQdUymVSZkzFvv1+oOgZm1CrbQUP9MBeoMZ9IzLZjA==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/core": "^3.973.20",
                 "@aws-sdk/types": "^3.973.6",
@@ -481,8 +364,6 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.20.tgz",
             "integrity": "sha512-p+R+PYR5Z7Gjqf/6pvbCnzEHcqPCpLzR7Yf127HjJ6EAb4hUcD+qsNRnuww1sB/RmSeCLxyay8FMyqREw4p1RA==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/core": "^3.973.20",
                 "@aws-sdk/nested-clients": "^3.996.10",
@@ -502,8 +383,6 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.20.tgz",
             "integrity": "sha512-rWCmh8o7QY4CsUj63qopzMzkDq/yPpkrpb+CnjBEFSOg/02T/we7sSTVg4QsDiVS9uwZ8VyONhq98qt+pIh3KA==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/core": "^3.973.20",
                 "@aws-sdk/nested-clients": "^3.996.10",
@@ -517,46 +396,11 @@
                 "node": ">=20.0.0"
             }
         },
-        "node_modules/@aws-sdk/credential-providers": {
-            "version": "3.1009.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.1009.0.tgz",
-            "integrity": "sha512-URs590x3cCOHvjgDz8J0iqxDQ87NjF550pnWmd1jQm+w5ZHTxuUEYjivBQQkAB603IlEdeadqO1+LSjtMznhwA==",
-            "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@aws-sdk/client-cognito-identity": "3.1009.0",
-                "@aws-sdk/core": "^3.973.20",
-                "@aws-sdk/credential-provider-cognito-identity": "^3.972.13",
-                "@aws-sdk/credential-provider-env": "^3.972.18",
-                "@aws-sdk/credential-provider-http": "^3.972.20",
-                "@aws-sdk/credential-provider-ini": "^3.972.20",
-                "@aws-sdk/credential-provider-login": "^3.972.20",
-                "@aws-sdk/credential-provider-node": "^3.972.21",
-                "@aws-sdk/credential-provider-process": "^3.972.18",
-                "@aws-sdk/credential-provider-sso": "^3.972.20",
-                "@aws-sdk/credential-provider-web-identity": "^3.972.20",
-                "@aws-sdk/nested-clients": "^3.996.10",
-                "@aws-sdk/types": "^3.973.6",
-                "@smithy/config-resolver": "^4.4.11",
-                "@smithy/core": "^3.23.11",
-                "@smithy/credential-provider-imds": "^4.2.12",
-                "@smithy/node-config-provider": "^4.3.12",
-                "@smithy/property-provider": "^4.2.12",
-                "@smithy/types": "^4.13.1",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
         "node_modules/@aws-sdk/middleware-host-header": {
             "version": "3.972.8",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.8.tgz",
             "integrity": "sha512-wAr2REfKsqoKQ+OkNqvOShnBoh+nkPurDKW7uAeVSu6kUECnWlSJiPvnoqxGlfousEY/v9LfS9sNc46hjSYDIQ==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "^3.973.6",
                 "@smithy/protocol-http": "^5.3.12",
@@ -572,8 +416,6 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.8.tgz",
             "integrity": "sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "^3.973.6",
                 "@smithy/types": "^4.13.1",
@@ -588,8 +430,6 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.8.tgz",
             "integrity": "sha512-BnnvYs2ZEpdlmZ2PNlV2ZyQ8j8AEkMTjN79y/YA475ER1ByFYrkVR85qmhni8oeTaJcDqbx364wDpitDAA/wCA==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "^3.973.6",
                 "@aws/lambda-invoke-store": "^0.2.2",
@@ -606,8 +446,6 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.21.tgz",
             "integrity": "sha512-62XRl1GDYPpkt7cx1AX1SPy9wgNE9Iw/NPuurJu4lmhCWS7sGKO+kS53TQ8eRmIxy3skmvNInnk0ZbWrU5Dpyg==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/core": "^3.973.20",
                 "@aws-sdk/types": "^3.973.6",
@@ -627,8 +465,6 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.10.tgz",
             "integrity": "sha512-SlDol5Z+C7Ivnc2rKGqiqfSUmUZzY1qHfVs9myt/nxVwswgfpjdKahyTzLTx802Zfq0NFRs7AejwKzzzl5Co2w==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
@@ -678,8 +514,6 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.8.tgz",
             "integrity": "sha512-1eD4uhTDeambO/PNIDVG19A6+v4NdD7xzwLHDutHsUqz0B+i661MwQB2eYO4/crcCvCiQG4SRm1k81k54FEIvw==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "^3.973.6",
                 "@smithy/config-resolver": "^4.4.11",
@@ -696,8 +530,6 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1009.0.tgz",
             "integrity": "sha512-KCPLuTqN9u0Rr38Arln78fRG9KXpzsPWmof+PZzfAHMMQq2QED6YjQrkrfiH7PDefLWEposY1o4/eGwrmKA4JA==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/core": "^3.973.20",
                 "@aws-sdk/nested-clients": "^3.996.10",
@@ -716,8 +548,6 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.6.tgz",
             "integrity": "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.13.1",
                 "tslib": "^2.6.2"
@@ -731,8 +561,6 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.5.tgz",
             "integrity": "sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "^3.973.6",
                 "@smithy/types": "^4.13.1",
@@ -749,8 +577,6 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
             "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -763,8 +589,6 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.8.tgz",
             "integrity": "sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/types": "^3.973.6",
                 "@smithy/types": "^4.13.1",
@@ -777,8 +601,6 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.7.tgz",
             "integrity": "sha512-Hz6EZMUAEzqUd7e+vZ9LE7mn+5gMbxltXy18v+YSFY+9LBJz15wkNZvw5JqfX3z0FS9n3bgUtz3L5rAsfh4YlA==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@aws-sdk/middleware-user-agent": "^3.972.21",
                 "@aws-sdk/types": "^3.973.6",
@@ -804,8 +626,6 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.11.tgz",
             "integrity": "sha512-iitV/gZKQMvY9d7ovmyFnFuTHbBAtrmLnvaSb/3X8vOKyevwtpmEtyc8AdhVWZe0pI/1GsHxlEvQeOePFzy7KQ==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.13.1",
                 "fast-xml-parser": "5.4.1",
@@ -820,8 +640,6 @@
             "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
             "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "engines": {
                 "node": ">=18.0.0"
             }
@@ -2888,8 +2706,6 @@
             "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.12.tgz",
             "integrity": "sha512-xolrFw6b+2iYGl6EcOL7IJY71vvyZ0DJ3mcKtpykqPe2uscwtzDZJa1uVQXyP7w9Dd+kGwYnPbMsJrGISKiY/Q==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.13.1",
                 "tslib": "^2.6.2"
@@ -2903,8 +2719,6 @@
             "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.11.tgz",
             "integrity": "sha512-YxFiiG4YDAtX7WMN7RuhHZLeTmRRAOyCbr+zB8e3AQzHPnUhS8zXjB1+cniPVQI3xbWsQPM0X2aaIkO/ME0ymw==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@smithy/node-config-provider": "^4.3.12",
                 "@smithy/types": "^4.13.1",
@@ -2922,8 +2736,6 @@
             "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.11.tgz",
             "integrity": "sha512-952rGf7hBRnhUIaeLp6q4MptKW8sPFe5VvkoZ5qIzFAtx6c/QZ/54FS3yootsyUSf9gJX/NBqEBNdNR7jMIlpQ==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@smithy/protocol-http": "^5.3.12",
                 "@smithy/types": "^4.13.1",
@@ -2945,8 +2757,6 @@
             "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.12.tgz",
             "integrity": "sha512-cr2lR792vNZcYMriSIj+Um3x9KWrjcu98kn234xA6reOAFMmbRpQMOv8KPgEmLLtx3eldU6c5wALKFqNOhugmg==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@smithy/node-config-provider": "^4.3.12",
                 "@smithy/property-provider": "^4.2.12",
@@ -2963,8 +2773,6 @@
             "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.15.tgz",
             "integrity": "sha512-T4jFU5N/yiIfrtrsb9uOQn7RdELdM/7HbyLNr6uO/mpkj1ctiVs7CihVr51w4LyQlXWDpXFn4BElf1WmQvZu/A==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@smithy/protocol-http": "^5.3.12",
                 "@smithy/querystring-builder": "^4.2.12",
@@ -2981,8 +2789,6 @@
             "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.12.tgz",
             "integrity": "sha512-QhBYbGrbxTkZ43QoTPrK72DoYviDeg6YKDrHTMJbbC+A0sml3kSjzFtXP7BtbyJnXojLfTQldGdUR0RGD8dA3w==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.13.1",
                 "@smithy/util-buffer-from": "^4.2.2",
@@ -2998,8 +2804,6 @@
             "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.12.tgz",
             "integrity": "sha512-/4F1zb7Z8LOu1PalTdESFHR0RbPwHd3FcaG1sI3UEIriQTWakysgJr65lc1jj6QY5ye7aFsisajotH6UhWfm/g==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.13.1",
                 "tslib": "^2.6.2"
@@ -3013,8 +2817,6 @@
             "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
             "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -3027,8 +2829,6 @@
             "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.12.tgz",
             "integrity": "sha512-YE58Yz+cvFInWI/wOTrB+DbvUVz/pLn5mC5MvOV4fdRUc6qGwygyngcucRQjAhiCEbmfLOXX0gntSIcgMvAjmA==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@smithy/protocol-http": "^5.3.12",
                 "@smithy/types": "^4.13.1",
@@ -3043,8 +2843,6 @@
             "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.25.tgz",
             "integrity": "sha512-dqjLwZs2eBxIUG6Qtw8/YZ4DvzHGIf0DA18wrgtfP6a50UIO7e2nY0FPdcbv5tVJKqWCCU5BmGMOUwT7Puan+A==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@smithy/core": "^3.23.11",
                 "@smithy/middleware-serde": "^4.2.14",
@@ -3064,8 +2862,6 @@
             "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.42.tgz",
             "integrity": "sha512-vbwyqHRIpIZutNXZpLAozakzamcINaRCpEy1MYmK6xBeW3xN+TyPRA123GjXnuxZIjc9848MRRCugVMTXxC4Eg==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@smithy/node-config-provider": "^4.3.12",
                 "@smithy/protocol-http": "^5.3.12",
@@ -3086,8 +2882,6 @@
             "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.14.tgz",
             "integrity": "sha512-+CcaLoLa5apzSRtloOyG7lQvkUw2ZDml3hRh4QiG9WyEPfW5Ke/3tPOPiPjUneuT59Tpn8+c3RVaUvvkkwqZwg==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@smithy/core": "^3.23.11",
                 "@smithy/protocol-http": "^5.3.12",
@@ -3103,8 +2897,6 @@
             "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.12.tgz",
             "integrity": "sha512-kruC5gRHwsCOuyCd4ouQxYjgRAym2uDlCvQ5acuMtRrcdfg7mFBg6blaxcJ09STpt3ziEkis6bhg1uwrWU7txw==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.13.1",
                 "tslib": "^2.6.2"
@@ -3118,8 +2910,6 @@
             "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.12.tgz",
             "integrity": "sha512-tr2oKX2xMcO+rBOjobSwVAkV05SIfUKz8iI53rzxEmgW3GOOPOv0UioSDk+J8OpRQnpnhsO3Af6IEBabQBVmiw==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@smithy/property-provider": "^4.2.12",
                 "@smithy/shared-ini-file-loader": "^4.4.7",
@@ -3135,8 +2925,6 @@
             "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.16.tgz",
             "integrity": "sha512-ULC8UCS/HivdCB3jhi+kLFYe4B5gxH2gi9vHBfEIiRrT2jfKiZNiETJSlzRtE6B26XbBHjPtc8iZKSNqMol9bw==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@smithy/abort-controller": "^4.2.12",
                 "@smithy/protocol-http": "^5.3.12",
@@ -3153,8 +2941,6 @@
             "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.12.tgz",
             "integrity": "sha512-jqve46eYU1v7pZ5BM+fmkbq3DerkSluPr5EhvOcHxygxzD05ByDRppRwRPPpFrsFo5yDtCYLKu+kreHKVrvc7A==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.13.1",
                 "tslib": "^2.6.2"
@@ -3168,8 +2954,6 @@
             "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.12.tgz",
             "integrity": "sha512-fit0GZK9I1xoRlR4jXmbLhoN0OdEpa96ul8M65XdmXnxXkuMxM0Y8HDT0Fh0Xb4I85MBvBClOzgSrV1X2s1Hxw==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.13.1",
                 "tslib": "^2.6.2"
@@ -3183,8 +2967,6 @@
             "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.12.tgz",
             "integrity": "sha512-6wTZjGABQufekycfDGMEB84BgtdOE/rCVTov+EDXQ8NHKTUNIp/j27IliwP7tjIU9LR+sSzyGBOXjeEtVgzCHg==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.13.1",
                 "@smithy/util-uri-escape": "^4.2.2",
@@ -3199,8 +2981,6 @@
             "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.12.tgz",
             "integrity": "sha512-P2OdvrgiAKpkPNKlKUtWbNZKB1XjPxM086NeVhK+W+wI46pIKdWBe5QyXvhUm3MEcyS/rkLvY8rZzyUdmyDZBw==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.13.1",
                 "tslib": "^2.6.2"
@@ -3214,8 +2994,6 @@
             "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.12.tgz",
             "integrity": "sha512-LlP29oSQN0Tw0b6D0Xo6BIikBswuIiGYbRACy5ujw/JgWSzTdYj46U83ssf6Ux0GyNJVivs2uReU8pt7Eu9okQ==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.13.1"
             },
@@ -3228,8 +3006,6 @@
             "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.7.tgz",
             "integrity": "sha512-HrOKWsUb+otTeo1HxVWeEb99t5ER1XrBi/xka2Wv6NVmTbuCUC1dvlrksdvxFtODLBjsC+PHK+fuy2x/7Ynyiw==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.13.1",
                 "tslib": "^2.6.2"
@@ -3243,8 +3019,6 @@
             "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.12.tgz",
             "integrity": "sha512-B/FBwO3MVOL00DaRSXfXfa/TRXRheagt/q5A2NM13u7q+sHS59EOVGQNfG7DkmVtdQm5m3vOosoKAXSqn/OEgw==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@smithy/is-array-buffer": "^4.2.2",
                 "@smithy/protocol-http": "^5.3.12",
@@ -3264,8 +3038,6 @@
             "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.5.tgz",
             "integrity": "sha512-UqwYawyqSr/aog8mnLnfbPurS0gi4G7IYDcD28cUIBhsvWs1+rQcL2IwkUQ+QZ7dibaoRzhNF99fAQ9AUcO00w==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@smithy/core": "^3.23.11",
                 "@smithy/middleware-endpoint": "^4.4.25",
@@ -3284,8 +3056,6 @@
             "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
             "integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -3298,8 +3068,6 @@
             "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.12.tgz",
             "integrity": "sha512-wOPKPEpso+doCZGIlr+e1lVI6+9VAKfL4kZWFgzVgGWY2hZxshNKod4l2LXS3PRC9otH/JRSjtEHqQ/7eLciRA==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@smithy/querystring-parser": "^4.2.12",
                 "@smithy/types": "^4.13.1",
@@ -3314,8 +3082,6 @@
             "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
             "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@smithy/util-buffer-from": "^4.2.2",
                 "@smithy/util-utf8": "^4.2.2",
@@ -3330,8 +3096,6 @@
             "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
             "integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -3344,8 +3108,6 @@
             "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
             "integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -3358,8 +3120,6 @@
             "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
             "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@smithy/is-array-buffer": "^4.2.2",
                 "tslib": "^2.6.2"
@@ -3373,8 +3133,6 @@
             "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
             "integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -3387,8 +3145,6 @@
             "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.41.tgz",
             "integrity": "sha512-M1w1Ux0rSVvBOxIIiqbxvZvhnjQ+VUjJrugtORE90BbadSTH+jsQL279KRL3Hv0w69rE7EuYkV/4Lepz/NBW9g==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@smithy/property-provider": "^4.2.12",
                 "@smithy/smithy-client": "^4.12.5",
@@ -3404,8 +3160,6 @@
             "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.44.tgz",
             "integrity": "sha512-YPze3/lD1KmWuZsl9JlfhcgGLX7AXhSoaCDtiPntUjNW5/YY0lOHjkcgxyE9x/h5vvS1fzDifMGjzqnNlNiqOQ==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@smithy/config-resolver": "^4.4.11",
                 "@smithy/credential-provider-imds": "^4.2.12",
@@ -3424,8 +3178,6 @@
             "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.3.3.tgz",
             "integrity": "sha512-VACQVe50j0HZPjpwWcjyT51KUQ4AnsvEaQ2lKHOSL4mNLD0G9BjEniQ+yCt1qqfKfiAHRAts26ud7hBjamrwig==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@smithy/node-config-provider": "^4.3.12",
                 "@smithy/types": "^4.13.1",
@@ -3440,8 +3192,6 @@
             "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
             "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -3454,8 +3204,6 @@
             "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.12.tgz",
             "integrity": "sha512-Er805uFUOvgc0l8nv0e0su0VFISoxhJ/AwOn3gL2NWNY2LUEldP5WtVcRYSQBcjg0y9NfG8JYrCJaYDpupBHJQ==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@smithy/types": "^4.13.1",
                 "tslib": "^2.6.2"
@@ -3469,8 +3217,6 @@
             "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.12.tgz",
             "integrity": "sha512-1zopLDUEOwumjcHdJ1mwBHddubYF8GMQvstVCLC54Y46rqoHwlIU+8ZzUeaBcD+WCJHyDGSeZ2ml9YSe9aqcoQ==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@smithy/service-error-classification": "^4.2.12",
                 "@smithy/types": "^4.13.1",
@@ -3485,8 +3231,6 @@
             "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.19.tgz",
             "integrity": "sha512-v4sa+3xTweL1CLO2UP0p7tvIMH/Rq1X4KKOxd568mpe6LSLMQCnDHs4uv7m3ukpl3HvcN2JH6jiCS0SNRXKP/w==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@smithy/fetch-http-handler": "^5.3.15",
                 "@smithy/node-http-handler": "^4.4.16",
@@ -3506,8 +3250,6 @@
             "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
             "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -3520,8 +3262,6 @@
             "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
             "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "@smithy/util-buffer-from": "^4.2.2",
                 "tslib": "^2.6.2"
@@ -3535,8 +3275,6 @@
             "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
             "integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
             "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -4244,9 +3982,7 @@
             "version": "2.14.1",
             "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
             "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
-            "license": "MIT",
-            "optional": true,
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/brace-expansion": {
             "version": "1.1.12",
@@ -5397,8 +5133,6 @@
                 }
             ],
             "license": "MIT",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "path-expression-matcher": "^1.1.3"
             }
@@ -5414,8 +5148,6 @@
                 }
             ],
             "license": "MIT",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "fast-xml-builder": "^1.0.0",
                 "strnum": "^2.1.2"
@@ -10049,8 +9781,6 @@
                 }
             ],
             "license": "MIT",
-            "optional": true,
-            "peer": true,
             "engines": {
                 "node": ">=14.0.0"
             }
@@ -11369,9 +11099,7 @@
                     "url": "https://github.com/sponsors/NaturalIntelligence"
                 }
             ],
-            "license": "MIT",
-            "optional": true,
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/stubs": {
             "version": "3.0.0",
@@ -11731,9 +11459,7 @@
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD",
-            "optional": true,
-            "peer": true
+            "license": "0BSD"
         },
         "node_modules/tsup": {
             "version": "8.5.1",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     },
     "dependencies": {
         "@aws-sdk/client-secrets-manager": "^3.1009.0",
-        "@aws-sdk/credential-providers": "^3.1009.0",
         "@google-cloud/secret-manager": "^6.1.1",
         "@oclif/core": "^4.8.1",
         "js-yaml": "^4.1.1"

--- a/src/commands/env/create.ts
+++ b/src/commands/env/create.ts
@@ -33,9 +33,6 @@ export default class EnvCreate extends Command {
         }),
         region: Flags.string({
             description: 'AWS region (optional for aws-sm adapter)'
-        }),
-        profile: Flags.string({
-            description: 'AWS profile name (optional for aws-sm adapter)'
         })
     };
 
@@ -60,8 +57,7 @@ export default class EnvCreate extends Command {
                 case 'aws-sm':
                     provider = {
                         adapter: 'aws-sm',
-                        ...(flags.region && { region: flags.region }),
-                        ...(flags.profile && { profile: flags.profile })
+                        ...(flags.region && { region: flags.region })
                     };
                     break;
                 default:

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -20,9 +20,6 @@ export default class Init extends Command {
         }),
         region: Flags.string({
             description: 'AWS region (optional for aws-sm adapter)'
-        }),
-        profile: Flags.string({
-            description: 'AWS profile name (optional for aws-sm adapter)'
         })
     };
 
@@ -46,8 +43,7 @@ export default class Init extends Command {
             case 'aws-sm':
                 provider = {
                     adapter: 'aws-sm',
-                    ...(flags.region && { region: flags.region }),
-                    ...(flags.profile && { profile: flags.profile })
+                    ...(flags.region && { region: flags.region })
                 };
                 break;
             default:

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -36,16 +36,10 @@ export function parseProviderConfig(
                     `Invalid ${context}: "aws-sm" field "provider.region" must be a string.`
                 );
             }
-            if (provider.profile !== undefined && typeof provider.profile !== 'string') {
-                throw new Error(
-                    `Invalid ${context}: "aws-sm" field "provider.profile" must be a string.`
-                );
-            }
-            const awsConfig: { adapter: 'aws-sm'; region?: string; profile?: string } = {
+            const awsConfig: { adapter: 'aws-sm'; region?: string } = {
                 adapter: 'aws-sm'
             };
             if (provider.region !== undefined) awsConfig.region = provider.region as string;
-            if (provider.profile !== undefined) awsConfig.profile = provider.profile as string;
             return awsConfig;
         }
         default:

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -14,7 +14,7 @@ export interface EnvironmentDefinition {
 export type ProviderConfig =
     | { adapter: 'local' }
     | { adapter: 'gcp-sm'; project: string }
-    | { adapter: 'aws-sm'; region?: string; profile?: string };
+    | { adapter: 'aws-sm'; region?: string };
 
 /** Project-level configuration from keyshelf.yml. */
 export interface KeyshelfConfig {

--- a/src/providers/aws-sm.ts
+++ b/src/providers/aws-sm.ts
@@ -7,13 +7,11 @@ import {
     DeleteSecretCommand,
     ListSecretsCommand
 } from '@aws-sdk/client-secrets-manager';
-import { fromIni } from '@aws-sdk/credential-providers';
 import { SecretProvider } from './provider.js';
 
 type AwsSmConfig = {
     name: string;
     region?: string;
-    profile?: string;
 };
 
 /** Stores secrets in AWS Secrets Manager using configurable credentials. */
@@ -28,7 +26,6 @@ export class AwsSmProvider implements SecretProvider {
         this.name = config.name;
         const clientConfig: SecretsManagerClientConfig = {};
         if (config.region) clientConfig.region = config.region;
-        if (config.profile) clientConfig.credentials = fromIni({ profile: config.profile });
         this.client = new SecretsManagerClient(clientConfig);
     }
 

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -18,8 +18,7 @@ export function createProvider(
         case 'aws-sm':
             return new AwsSmProvider({
                 name: projectName,
-                region: config.region,
-                profile: config.profile
+                region: config.region
             });
     }
 }

--- a/test/commands/env/create.test.ts
+++ b/test/commands/env/create.test.ts
@@ -71,22 +71,10 @@ describe('env:create command', () => {
     });
 
     it('creates environment with --adapter aws-sm and optional flags', async () => {
-        await Create.run([
-            'prod',
-            '--adapter',
-            'aws-sm',
-            '--region',
-            'eu-west-1',
-            '--profile',
-            'production'
-        ]);
+        await Create.run(['prod', '--adapter', 'aws-sm', '--region', 'eu-west-1']);
 
         const def = await loadEnvironment(tmpDir, 'prod');
-        expect(def.provider).toEqual({
-            adapter: 'aws-sm',
-            region: 'eu-west-1',
-            profile: 'production'
-        });
+        expect(def.provider).toEqual({ adapter: 'aws-sm', region: 'eu-west-1' });
     });
 
     it('creates environment with --adapter aws-sm without optional flags', async () => {

--- a/test/commands/init.test.ts
+++ b/test/commands/init.test.ts
@@ -68,15 +68,11 @@ describe('init command', () => {
     });
 
     it('--adapter aws-sm creates aws-sm config', async () => {
-        await Init.run(['--adapter', 'aws-sm', '--region', 'us-east-1', '--profile', 'dev']);
+        await Init.run(['--adapter', 'aws-sm', '--region', 'us-east-1']);
 
         const content = fs.readFileSync(path.join(tmpDir, 'keyshelf.yml'), 'utf-8');
         const config = yaml.load(content) as Record<string, unknown>;
-        expect(config.provider).toEqual({
-            adapter: 'aws-sm',
-            region: 'us-east-1',
-            profile: 'dev'
-        });
+        expect(config.provider).toEqual({ adapter: 'aws-sm', region: 'us-east-1' });
     });
 
     it('--adapter aws-sm works without optional flags', async () => {

--- a/test/core/config.test.ts
+++ b/test/core/config.test.ts
@@ -92,21 +92,17 @@ describe('config validation', () => {
         expect(() => loadConfig(tmpDir)).toThrow(/gcp-sm.*requires field "provider\.project"/i);
     });
 
-    it('loads valid aws-sm config with region and profile', () => {
+    it('loads valid aws-sm config with region', () => {
         fs.writeFileSync(
             path.join(tmpDir, 'keyshelf.yml'),
             yaml.dump({
                 name: 'test',
-                provider: { adapter: 'aws-sm', region: 'us-east-1', profile: 'dev' }
+                provider: { adapter: 'aws-sm', region: 'us-east-1' }
             })
         );
 
         const config = loadConfig(tmpDir);
-        expect(config.provider).toEqual({
-            adapter: 'aws-sm',
-            region: 'us-east-1',
-            profile: 'dev'
-        });
+        expect(config.provider).toEqual({ adapter: 'aws-sm', region: 'us-east-1' });
     });
 
     it('loads valid aws-sm config without optional fields', () => {
@@ -126,15 +122,6 @@ describe('config validation', () => {
         );
 
         expect(() => loadConfig(tmpDir)).toThrow(/provider\.region.*must be a string/);
-    });
-
-    it('aws-sm rejects non-string profile', () => {
-        fs.writeFileSync(
-            path.join(tmpDir, 'keyshelf.yml'),
-            yaml.dump({ name: 'test', provider: { adapter: 'aws-sm', profile: true } })
-        );
-
-        expect(() => loadConfig(tmpDir)).toThrow(/provider\.profile.*must be a string/);
     });
 });
 

--- a/test/providers/aws-sm.test.ts
+++ b/test/providers/aws-sm.test.ts
@@ -24,10 +24,6 @@ vi.mock('@aws-sdk/client-secrets-manager', () => ({
     }
 }));
 
-vi.mock('@aws-sdk/credential-providers', () => ({
-    fromIni: vi.fn(() => 'mocked-credentials')
-}));
-
 describe('AwsSmProvider', () => {
     let provider: AwsSmProvider;
 

--- a/test/providers/index.test.ts
+++ b/test/providers/index.test.ts
@@ -37,7 +37,7 @@ describe('createProvider', () => {
 
     it('creates an aws-sm provider', () => {
         const provider = createProvider(
-            { adapter: 'aws-sm', region: 'us-east-1', profile: 'dev' },
+            { adapter: 'aws-sm', region: 'us-east-1' },
             tmpDir,
             'myapp'
         );


### PR DESCRIPTION
## Summary

- Removes the `profile` config option from `AwsSmConfig` and all surfaces that exposed it (`ProviderConfig` type, `parseProviderConfig`, `init` command, `env:create` command)
- Removes the `fromIni` import and the `@aws-sdk/credential-providers` dependency entirely
- The AWS SDK's default credential chain already respects `AWS_PROFILE` natively, so explicit profile support was redundant and added an unnecessary dependency

## Test plan

- [ ] `npm run build` passes with no TypeScript errors
- [ ] `npm run test` — all 227 tests pass across 26 test files
- [ ] `AWS_PROFILE=myprofile keyshelf ...` continues to work via the SDK default credential chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)