### PR TITLE
feat: remove region config from aws-sm provider

### DIFF
--- a/src/commands/env/create.ts
+++ b/src/commands/env/create.ts
@@ -31,9 +31,6 @@ export default class EnvCreate extends Command {
         project: Flags.string({
             description: 'GCP project ID (required for gcp-sm adapter)'
         }),
-        region: Flags.string({
-            description: 'AWS region (optional for aws-sm adapter)'
-        }),
         profile: Flags.string({
             description: 'AWS profile name (optional for aws-sm adapter)'
         })
@@ -60,7 +57,6 @@ export default class EnvCreate extends Command {
                 case 'aws-sm':
                     provider = {
                         adapter: 'aws-sm',
-                        ...(flags.region && { region: flags.region }),
                         ...(flags.profile && { profile: flags.profile })
                     };
                     break;

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -18,9 +18,6 @@ export default class Init extends Command {
         project: Flags.string({
             description: 'GCP project ID (required for gcp-sm adapter)'
         }),
-        region: Flags.string({
-            description: 'AWS region (optional for aws-sm adapter)'
-        }),
         profile: Flags.string({
             description: 'AWS profile name (optional for aws-sm adapter)'
         })
@@ -46,7 +43,6 @@ export default class Init extends Command {
             case 'aws-sm':
                 provider = {
                     adapter: 'aws-sm',
-                    ...(flags.region && { region: flags.region }),
                     ...(flags.profile && { profile: flags.profile })
                 };
                 break;

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -31,20 +31,12 @@ export function parseProviderConfig(
             }
             return { adapter: 'gcp-sm', project: provider.project };
         case 'aws-sm': {
-            if (provider.region !== undefined && typeof provider.region !== 'string') {
-                throw new Error(
-                    `Invalid ${context}: "aws-sm" field "provider.region" must be a string.`
-                );
-            }
             if (provider.profile !== undefined && typeof provider.profile !== 'string') {
                 throw new Error(
                     `Invalid ${context}: "aws-sm" field "provider.profile" must be a string.`
                 );
             }
-            const awsConfig: { adapter: 'aws-sm'; region?: string; profile?: string } = {
-                adapter: 'aws-sm'
-            };
-            if (provider.region !== undefined) awsConfig.region = provider.region as string;
+            const awsConfig: { adapter: 'aws-sm'; profile?: string } = { adapter: 'aws-sm' };
             if (provider.profile !== undefined) awsConfig.profile = provider.profile as string;
             return awsConfig;
         }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -14,7 +14,7 @@ export interface EnvironmentDefinition {
 export type ProviderConfig =
     | { adapter: 'local' }
     | { adapter: 'gcp-sm'; project: string }
-    | { adapter: 'aws-sm'; region?: string; profile?: string };
+    | { adapter: 'aws-sm'; profile?: string };
 
 /** Project-level configuration from keyshelf.yml. */
 export interface KeyshelfConfig {

--- a/src/providers/aws-sm.ts
+++ b/src/providers/aws-sm.ts
@@ -1,6 +1,5 @@
 import {
     SecretsManagerClient,
-    SecretsManagerClientConfig,
     GetSecretValueCommand,
     PutSecretValueCommand,
     CreateSecretCommand,
@@ -12,7 +11,6 @@ import { SecretProvider } from './provider.js';
 
 type AwsSmConfig = {
     name: string;
-    region?: string;
     profile?: string;
 };
 
@@ -26,10 +24,8 @@ export class AwsSmProvider implements SecretProvider {
             throw new Error(`project name must not contain "/": got "${config.name}"`);
         }
         this.name = config.name;
-        const clientConfig: SecretsManagerClientConfig = {};
-        if (config.region) clientConfig.region = config.region;
-        if (config.profile) clientConfig.credentials = fromIni({ profile: config.profile });
-        this.client = new SecretsManagerClient(clientConfig);
+        const credentials = config.profile ? fromIni({ profile: config.profile }) : undefined;
+        this.client = new SecretsManagerClient(credentials ? { credentials } : {});
     }
 
     ref(env: string, secretPath: string): string {

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -16,11 +16,7 @@ export function createProvider(
         case 'gcp-sm':
             return new GcpSmProvider(projectName, config.project);
         case 'aws-sm':
-            return new AwsSmProvider({
-                name: projectName,
-                region: config.region,
-                profile: config.profile
-            });
+            return new AwsSmProvider({ name: projectName, profile: config.profile });
     }
 }
 

--- a/test/commands/env/create.test.ts
+++ b/test/commands/env/create.test.ts
@@ -71,22 +71,10 @@ describe('env:create command', () => {
     });
 
     it('creates environment with --adapter aws-sm and optional flags', async () => {
-        await Create.run([
-            'prod',
-            '--adapter',
-            'aws-sm',
-            '--region',
-            'eu-west-1',
-            '--profile',
-            'production'
-        ]);
+        await Create.run(['prod', '--adapter', 'aws-sm', '--profile', 'production']);
 
         const def = await loadEnvironment(tmpDir, 'prod');
-        expect(def.provider).toEqual({
-            adapter: 'aws-sm',
-            region: 'eu-west-1',
-            profile: 'production'
-        });
+        expect(def.provider).toEqual({ adapter: 'aws-sm', profile: 'production' });
     });
 
     it('creates environment with --adapter aws-sm without optional flags', async () => {

--- a/test/commands/init.test.ts
+++ b/test/commands/init.test.ts
@@ -68,15 +68,11 @@ describe('init command', () => {
     });
 
     it('--adapter aws-sm creates aws-sm config', async () => {
-        await Init.run(['--adapter', 'aws-sm', '--region', 'us-east-1', '--profile', 'dev']);
+        await Init.run(['--adapter', 'aws-sm', '--profile', 'dev']);
 
         const content = fs.readFileSync(path.join(tmpDir, 'keyshelf.yml'), 'utf-8');
         const config = yaml.load(content) as Record<string, unknown>;
-        expect(config.provider).toEqual({
-            adapter: 'aws-sm',
-            region: 'us-east-1',
-            profile: 'dev'
-        });
+        expect(config.provider).toEqual({ adapter: 'aws-sm', profile: 'dev' });
     });
 
     it('--adapter aws-sm works without optional flags', async () => {

--- a/test/core/config.test.ts
+++ b/test/core/config.test.ts
@@ -92,21 +92,14 @@ describe('config validation', () => {
         expect(() => loadConfig(tmpDir)).toThrow(/gcp-sm.*requires field "provider\.project"/i);
     });
 
-    it('loads valid aws-sm config with region and profile', () => {
+    it('loads valid aws-sm config with profile', () => {
         fs.writeFileSync(
             path.join(tmpDir, 'keyshelf.yml'),
-            yaml.dump({
-                name: 'test',
-                provider: { adapter: 'aws-sm', region: 'us-east-1', profile: 'dev' }
-            })
+            yaml.dump({ name: 'test', provider: { adapter: 'aws-sm', profile: 'dev' } })
         );
 
         const config = loadConfig(tmpDir);
-        expect(config.provider).toEqual({
-            adapter: 'aws-sm',
-            region: 'us-east-1',
-            profile: 'dev'
-        });
+        expect(config.provider).toEqual({ adapter: 'aws-sm', profile: 'dev' });
     });
 
     it('loads valid aws-sm config without optional fields', () => {
@@ -117,15 +110,6 @@ describe('config validation', () => {
 
         const config = loadConfig(tmpDir);
         expect(config.provider).toEqual({ adapter: 'aws-sm' });
-    });
-
-    it('aws-sm rejects non-string region', () => {
-        fs.writeFileSync(
-            path.join(tmpDir, 'keyshelf.yml'),
-            yaml.dump({ name: 'test', provider: { adapter: 'aws-sm', region: 123 } })
-        );
-
-        expect(() => loadConfig(tmpDir)).toThrow(/provider\.region.*must be a string/);
     });
 
     it('aws-sm rejects non-string profile', () => {

--- a/test/providers/index.test.ts
+++ b/test/providers/index.test.ts
@@ -36,11 +36,7 @@ describe('createProvider', () => {
     });
 
     it('creates an aws-sm provider', () => {
-        const provider = createProvider(
-            { adapter: 'aws-sm', region: 'us-east-1', profile: 'dev' },
-            tmpDir,
-            'myapp'
-        );
+        const provider = createProvider({ adapter: 'aws-sm', profile: 'dev' }, tmpDir, 'myapp');
         expect(provider).toBeInstanceOf(AwsSmProvider);
     });
 });


### PR DESCRIPTION
## Summary

- Removes `region` from `AwsSmConfig`, `ProviderConfig`, and config parsing — the AWS SDK already reads `AWS_REGION` / `AWS_DEFAULT_REGION` from the environment natively
- Removes `--region` flag from `init` and `env:create` commands
- Simplifies the `SecretsManagerClient` constructor call in `AwsSmProvider`
- Updates all affected tests

## Test plan

- [x] `npm run build` passes with no TypeScript errors
- [x] `npm run test` — all 227 tests across 26 files pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)