### PR TITLE
refactor: remove profile option from aws-sm provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
             "license": "ISC",
             "dependencies": {
                 "@aws-sdk/client-secrets-manager": "^3.1009.0",
-                "@aws-sdk/credential-providers": "^3.1009.0",
                 "@google-cloud/secret-manager": "^6.1.1",
                 "@oclif/core": "^4.8.1",
                 "js-yaml": "^4.1.1"
@@ -165,56 +164,6 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-cognito-identity": {
-            "version": "3.1009.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.1009.0.tgz",
-            "integrity": "sha512-4+lBLB2sIdrnGruxqsfPM2AOSME3DVDRX7R5OXcgd2jfrUSyYdHJN1kT9hO/vwK4uajRZsQNP5hLJMttkjkoAQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-crypto/sha256-browser": "5.2.0",
-                "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "^3.973.20",
-                "@aws-sdk/credential-provider-node": "^3.972.21",
-                "@aws-sdk/middleware-host-header": "^3.972.8",
-                "@aws-sdk/middleware-logger": "^3.972.8",
-                "@aws-sdk/middleware-recursion-detection": "^3.972.8",
-                "@aws-sdk/middleware-user-agent": "^3.972.21",
-                "@aws-sdk/region-config-resolver": "^3.972.8",
-                "@aws-sdk/types": "^3.973.6",
-                "@aws-sdk/util-endpoints": "^3.996.5",
-                "@aws-sdk/util-user-agent-browser": "^3.972.8",
-                "@aws-sdk/util-user-agent-node": "^3.973.7",
-                "@smithy/config-resolver": "^4.4.11",
-                "@smithy/core": "^3.23.11",
-                "@smithy/fetch-http-handler": "^5.3.15",
-                "@smithy/hash-node": "^4.2.12",
-                "@smithy/invalid-dependency": "^4.2.12",
-                "@smithy/middleware-content-length": "^4.2.12",
-                "@smithy/middleware-endpoint": "^4.4.25",
-                "@smithy/middleware-retry": "^4.4.42",
-                "@smithy/middleware-serde": "^4.2.14",
-                "@smithy/middleware-stack": "^4.2.12",
-                "@smithy/node-config-provider": "^4.3.12",
-                "@smithy/node-http-handler": "^4.4.16",
-                "@smithy/protocol-http": "^5.3.12",
-                "@smithy/smithy-client": "^4.12.5",
-                "@smithy/types": "^4.13.1",
-                "@smithy/url-parser": "^4.2.12",
-                "@smithy/util-base64": "^4.3.2",
-                "@smithy/util-body-length-browser": "^4.2.2",
-                "@smithy/util-body-length-node": "^4.2.3",
-                "@smithy/util-defaults-mode-browser": "^4.3.41",
-                "@smithy/util-defaults-mode-node": "^4.2.44",
-                "@smithy/util-endpoints": "^3.3.3",
-                "@smithy/util-middleware": "^4.2.12",
-                "@smithy/util-retry": "^4.2.12",
-                "@smithy/util-utf8": "^4.2.2",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
         "node_modules/@aws-sdk/client-secrets-manager": {
             "version": "3.1009.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1009.0.tgz",
@@ -283,22 +232,6 @@
                 "@smithy/util-base64": "^4.3.2",
                 "@smithy/util-middleware": "^4.2.12",
                 "@smithy/util-utf8": "^4.2.2",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-cognito-identity": {
-            "version": "3.972.13",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.972.13.tgz",
-            "integrity": "sha512-WZnIK8NPX+4OXkpVoNmUS+Ya1osqjszUsDqFEz97+a/LD5K012np9iR/eWEC43btx8zQjyRIK8kyiwbh8SiHzg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/nested-clients": "^3.996.10",
-                "@aws-sdk/types": "^3.973.6",
-                "@smithy/property-provider": "^4.2.12",
-                "@smithy/types": "^4.13.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -456,37 +389,6 @@
                 "@aws-sdk/types": "^3.973.6",
                 "@smithy/property-provider": "^4.2.12",
                 "@smithy/shared-ini-file-loader": "^4.4.7",
-                "@smithy/types": "^4.13.1",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-providers": {
-            "version": "3.1009.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.1009.0.tgz",
-            "integrity": "sha512-URs590x3cCOHvjgDz8J0iqxDQ87NjF550pnWmd1jQm+w5ZHTxuUEYjivBQQkAB603IlEdeadqO1+LSjtMznhwA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/client-cognito-identity": "3.1009.0",
-                "@aws-sdk/core": "^3.973.20",
-                "@aws-sdk/credential-provider-cognito-identity": "^3.972.13",
-                "@aws-sdk/credential-provider-env": "^3.972.18",
-                "@aws-sdk/credential-provider-http": "^3.972.20",
-                "@aws-sdk/credential-provider-ini": "^3.972.20",
-                "@aws-sdk/credential-provider-login": "^3.972.20",
-                "@aws-sdk/credential-provider-node": "^3.972.21",
-                "@aws-sdk/credential-provider-process": "^3.972.18",
-                "@aws-sdk/credential-provider-sso": "^3.972.20",
-                "@aws-sdk/credential-provider-web-identity": "^3.972.20",
-                "@aws-sdk/nested-clients": "^3.996.10",
-                "@aws-sdk/types": "^3.973.6",
-                "@smithy/config-resolver": "^4.4.11",
-                "@smithy/core": "^3.23.11",
-                "@smithy/credential-provider-imds": "^4.2.12",
-                "@smithy/node-config-provider": "^4.3.12",
-                "@smithy/property-provider": "^4.2.12",
                 "@smithy/types": "^4.13.1",
                 "tslib": "^2.6.2"
             },

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     },
     "dependencies": {
         "@aws-sdk/client-secrets-manager": "^3.1009.0",
-        "@aws-sdk/credential-providers": "^3.1009.0",
         "@google-cloud/secret-manager": "^6.1.1",
         "@oclif/core": "^4.8.1",
         "js-yaml": "^4.1.1"

--- a/src/commands/env/create.ts
+++ b/src/commands/env/create.ts
@@ -30,9 +30,6 @@ export default class EnvCreate extends Command {
         }),
         project: Flags.string({
             description: 'GCP project ID (required for gcp-sm adapter)'
-        }),
-        profile: Flags.string({
-            description: 'AWS profile name (optional for aws-sm adapter)'
         })
     };
 
@@ -55,10 +52,7 @@ export default class EnvCreate extends Command {
                     provider = { adapter: 'gcp-sm', project: flags.project };
                     break;
                 case 'aws-sm':
-                    provider = {
-                        adapter: 'aws-sm',
-                        ...(flags.profile && { profile: flags.profile })
-                    };
+                    provider = { adapter: 'aws-sm' };
                     break;
                 default:
                     provider = { adapter: 'local' };

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -17,9 +17,6 @@ export default class Init extends Command {
         }),
         project: Flags.string({
             description: 'GCP project ID (required for gcp-sm adapter)'
-        }),
-        profile: Flags.string({
-            description: 'AWS profile name (optional for aws-sm adapter)'
         })
     };
 
@@ -41,10 +38,7 @@ export default class Init extends Command {
                 provider = { adapter: 'gcp-sm', project: flags.project };
                 break;
             case 'aws-sm':
-                provider = {
-                    adapter: 'aws-sm',
-                    ...(flags.profile && { profile: flags.profile })
-                };
+                provider = { adapter: 'aws-sm' };
                 break;
             default:
                 provider = { adapter: 'local' };

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -31,16 +31,8 @@ export function parseProviderConfig(
                 );
             }
             return { adapter: 'gcp-sm', project: provider.project };
-        case 'aws-sm': {
-            if (provider.profile !== undefined && typeof provider.profile !== 'string') {
-                throw new Error(
-                    `Invalid ${context}: "aws-sm" field "provider.profile" must be a string.`
-                );
-            }
-            const awsConfig: { adapter: 'aws-sm'; profile?: string } = { adapter: 'aws-sm' };
-            if (provider.profile !== undefined) awsConfig.profile = provider.profile as string;
-            return awsConfig;
-        }
+        case 'aws-sm':
+            return { adapter: 'aws-sm' };
         default:
             throw new Error('unreachable');
     }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -15,7 +15,7 @@ export interface EnvironmentDefinition {
 export type ProviderConfig =
     | { adapter: 'local' }
     | { adapter: 'gcp-sm'; project: string }
-    | { adapter: 'aws-sm'; profile?: string };
+    | { adapter: 'aws-sm' };
 
 /** Project-level configuration from keyshelf.yml. */
 export interface KeyshelfConfig {

--- a/src/providers/aws-sm.ts
+++ b/src/providers/aws-sm.ts
@@ -6,12 +6,10 @@ import {
     DeleteSecretCommand,
     ListSecretsCommand
 } from '@aws-sdk/client-secrets-manager';
-import { fromIni } from '@aws-sdk/credential-providers';
 import { SecretProvider } from './provider.js';
 
 type AwsSmConfig = {
     name: string;
-    profile?: string;
 };
 
 /** Stores secrets in AWS Secrets Manager using configurable credentials. */
@@ -24,8 +22,7 @@ export class AwsSmProvider implements SecretProvider {
             throw new Error(`project name must not contain "/": got "${config.name}"`);
         }
         this.name = config.name;
-        const credentials = config.profile ? fromIni({ profile: config.profile }) : undefined;
-        this.client = new SecretsManagerClient(credentials ? { credentials } : {});
+        this.client = new SecretsManagerClient({});
     }
 
     ref(env: string, secretPath: string): string {

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -16,7 +16,7 @@ export function createProvider(
         case 'gcp-sm':
             return new GcpSmProvider(projectName, config.project);
         case 'aws-sm':
-            return new AwsSmProvider({ name: projectName, profile: config.profile });
+            return new AwsSmProvider({ name: projectName });
     }
 }
 

--- a/test/commands/env/create.test.ts
+++ b/test/commands/env/create.test.ts
@@ -70,11 +70,11 @@ describe('env:create command', () => {
         expect(def.provider).toBeUndefined();
     });
 
-    it('creates environment with --adapter aws-sm and optional flags', async () => {
-        await Create.run(['prod', '--adapter', 'aws-sm', '--profile', 'production']);
+    it('creates environment with --adapter aws-sm', async () => {
+        await Create.run(['prod', '--adapter', 'aws-sm']);
 
         const def = await loadEnvironment(tmpDir, 'prod');
-        expect(def.provider).toEqual({ adapter: 'aws-sm', profile: 'production' });
+        expect(def.provider).toEqual({ adapter: 'aws-sm' });
     });
 
     it('creates environment with --adapter aws-sm without optional flags', async () => {

--- a/test/commands/init.test.ts
+++ b/test/commands/init.test.ts
@@ -68,11 +68,11 @@ describe('init command', () => {
     });
 
     it('--adapter aws-sm creates aws-sm config', async () => {
-        await Init.run(['--adapter', 'aws-sm', '--profile', 'dev']);
+        await Init.run(['--adapter', 'aws-sm']);
 
         const content = fs.readFileSync(path.join(tmpDir, 'keyshelf.yml'), 'utf-8');
         const config = yaml.load(content) as Record<string, unknown>;
-        expect(config.provider).toEqual({ adapter: 'aws-sm', profile: 'dev' });
+        expect(config.provider).toEqual({ adapter: 'aws-sm' });
     });
 
     it('--adapter aws-sm works without optional flags', async () => {

--- a/test/core/config.test.ts
+++ b/test/core/config.test.ts
@@ -92,14 +92,14 @@ describe('config validation', () => {
         expect(() => loadConfig(tmpDir)).toThrow(/gcp-sm.*requires field "provider\.project"/i);
     });
 
-    it('loads valid aws-sm config with profile', () => {
+    it('loads valid aws-sm config', () => {
         fs.writeFileSync(
             path.join(tmpDir, 'keyshelf.yml'),
-            yaml.dump({ name: 'test', provider: { adapter: 'aws-sm', profile: 'dev' } })
+            yaml.dump({ name: 'test', provider: { adapter: 'aws-sm' } })
         );
 
         const config = loadConfig(tmpDir);
-        expect(config.provider).toEqual({ adapter: 'aws-sm', profile: 'dev' });
+        expect(config.provider).toEqual({ adapter: 'aws-sm' });
     });
 
     it('loads valid aws-sm config without optional fields', () => {
@@ -110,15 +110,6 @@ describe('config validation', () => {
 
         const config = loadConfig(tmpDir);
         expect(config.provider).toEqual({ adapter: 'aws-sm' });
-    });
-
-    it('aws-sm rejects non-string profile', () => {
-        fs.writeFileSync(
-            path.join(tmpDir, 'keyshelf.yml'),
-            yaml.dump({ name: 'test', provider: { adapter: 'aws-sm', profile: true } })
-        );
-
-        expect(() => loadConfig(tmpDir)).toThrow(/provider\.profile.*must be a string/);
     });
 });
 

--- a/test/providers/aws-sm.test.ts
+++ b/test/providers/aws-sm.test.ts
@@ -24,10 +24,6 @@ vi.mock('@aws-sdk/client-secrets-manager', () => ({
     }
 }));
 
-vi.mock('@aws-sdk/credential-providers', () => ({
-    fromIni: vi.fn(() => 'mocked-credentials')
-}));
-
 describe('AwsSmProvider', () => {
     let provider: AwsSmProvider;
 

--- a/test/providers/index.test.ts
+++ b/test/providers/index.test.ts
@@ -36,7 +36,7 @@ describe('createProvider', () => {
     });
 
     it('creates an aws-sm provider', () => {
-        const provider = createProvider({ adapter: 'aws-sm', profile: 'dev' }, tmpDir, 'myapp');
+        const provider = createProvider({ adapter: 'aws-sm' }, tmpDir, 'myapp');
         expect(provider).toBeInstanceOf(AwsSmProvider);
     });
 });


### PR DESCRIPTION
## Summary

- Removes `profile` from `AwsSmConfig`, `ProviderConfig`, and config parsing — the AWS SDK's default credential chain already respects `AWS_PROFILE` natively
- Removes `--profile` flag from `init` and `env:create` commands
- Removes the `@aws-sdk/credential-providers` dependency entirely

Replaces #6 which was closed due to merge conflicts.

## Test plan

- [x] `npm run build` — no TypeScript errors
- [x] `npm run test` — 226 tests pass across 26 test files
- [ ] `AWS_PROFILE=myprofile keyshelf ...` continues to work via the SDK default credential chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)