### PR TITLE
fix: resume stdin after readline closes it

### DIFF
--- a/src/core/reconciler/input.ts
+++ b/src/core/reconciler/input.ts
@@ -39,6 +39,7 @@ export function readMaskedLine(prompt: string): Promise<string> {
     return new Promise((resolve, reject) => {
         process.stdout.write(prompt);
         process.stdin.setRawMode?.(true);
+        process.stdin.resume();
 
         let value = '';
 
@@ -47,6 +48,7 @@ export function readMaskedLine(prompt: string): Promise<string> {
                 if (char === '\r' || char === '\n') {
                     process.stdin.setRawMode?.(false);
                     process.stdin.removeListener('data', onData);
+                    process.stdin.pause();
                     process.stdout.write('\n');
                     resolve(value);
                     return;
@@ -54,6 +56,7 @@ export function readMaskedLine(prompt: string): Promise<string> {
                 if (char === '\u0003') {
                     process.stdin.setRawMode?.(false);
                     process.stdin.removeListener('data', onData);
+                    process.stdin.pause();
                     reject(new Error('Aborted by user'));
                     return;
                 }
@@ -62,7 +65,7 @@ export function readMaskedLine(prompt: string): Promise<string> {
             }
         }
 
-        process.stdin.once('data', onData);
+        process.stdin.on('data', onData);
     });
 }
 

--- a/test/core/reconciler/input.test.ts
+++ b/test/core/reconciler/input.test.ts
@@ -5,8 +5,10 @@ describe('readMaskedLine', () => {
     it('resolves correctly when a multi-character chunk with newline is delivered at once', async () => {
         const mockStdin = {
             setRawMode: vi.fn(),
-            once: vi.fn(),
-            removeListener: vi.fn()
+            on: vi.fn(),
+            removeListener: vi.fn(),
+            resume: vi.fn(),
+            pause: vi.fn()
         };
         const mockStdout = { write: vi.fn() };
 
@@ -16,7 +18,7 @@ describe('readMaskedLine', () => {
         Object.defineProperty(process, 'stdout', { value: mockStdout, configurable: true });
 
         let capturedHandler: ((chunk: Buffer) => void) | undefined;
-        mockStdin.once.mockImplementation((_event: string, handler: (chunk: Buffer) => void) => {
+        mockStdin.on.mockImplementation((_event: string, handler: (chunk: Buffer) => void) => {
             capturedHandler = handler;
         });
 


### PR DESCRIPTION
## Summary
- `readline.createInterface` pauses stdin on `rl.close()`, causing `readMaskedLine` to hang when prompting for secret values after the "Apply changes?" confirmation
- Resume stdin before listening for data and pause it when done to avoid keeping the event loop alive
- Changed `once` to `on` to handle multi-chunk input correctly

## Test plan
- [x] Existing tests updated and passing
- [ ] Run `npx keyshelf up` in a project with new secrets and verify interactive input works after the confirmation prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)