### PR TITLE
feat: batch secret value collection before writes

### DIFF
--- a/src/core/reconciler/apply.ts
+++ b/src/core/reconciler/apply.ts
@@ -19,11 +19,18 @@ interface ApplyOptions {
 export async function applyEnvironmentPlan(options: ApplyOptions): Promise<void> {
     const { plan, provider, collectValue, getSourceProvider } = options;
 
+    const collected = new Map<string, string>();
+
+    for (const change of plan.secretChanges) {
+        if (change.kind === 'add') {
+            collected.set(change.path, await collectValue(change.path));
+        }
+    }
+
     for (const change of plan.secretChanges) {
         switch (change.kind) {
             case 'add': {
-                const value = await collectValue(change.path);
-                await provider.set(plan.envName, change.path, value);
+                await provider.set(plan.envName, change.path, collected.get(change.path)!);
                 break;
             }
             case 'copy': {

--- a/test/core/reconciler/apply.test.ts
+++ b/test/core/reconciler/apply.test.ts
@@ -92,6 +92,42 @@ describe('applyEnvironmentPlan', () => {
         expect(provider.delete).toHaveBeenCalledWith('dev', 'old/key');
     });
 
+    it('collects all values before writing any secrets', async () => {
+        const provider = makeMockProvider();
+        const plan: EnvironmentPlan = {
+            envName: 'dev',
+            secretChanges: [
+                { kind: 'add', path: 'first/secret' },
+                { kind: 'add', path: 'second/secret' }
+            ]
+        };
+
+        const events: string[] = [];
+        const collectValue = vi.fn(async (path: string) => {
+            events.push(`collect:${path}`);
+            return `value-for-${path}`;
+        });
+        (provider.set as ReturnType<typeof vi.fn>).mockImplementation(
+            async (_env: string, path: string) => {
+                events.push(`set:${path}`);
+            }
+        );
+
+        await applyEnvironmentPlan({
+            plan,
+            provider,
+            collectValue,
+            getSourceProvider: vi.fn()
+        });
+
+        expect(events).toEqual([
+            'collect:first/secret',
+            'collect:second/secret',
+            'set:first/secret',
+            'set:second/secret'
+        ]);
+    });
+
     it('processes all changes in a mixed plan', async () => {
         const targetProvider = makeMockProvider({ 'old/key': 'value' });
         const sourceProvider = makeMockProvider({ 'shared/token': 'token-value' });


### PR DESCRIPTION
## Summary
- Splits `applyEnvironmentPlan` into two passes: first collects all `add` secret values, then writes all changes
- In interactive mode (`keyshelf up`), all prompts now appear upfront before any provider writes, so users can abort cleanly without partial state
- Adds a test verifying collection ordering (all collects before any sets)

## Test plan
- [x] Existing `apply.test.ts` tests pass unchanged
- [x] New ordering test verifies collect-then-write sequencing
- [x] Full test suite passes (1445 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)