### PR TITLE
chore: add e2e tests for keyshelf up against real AWS SM

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "format": "prettier --write .",
         "format:check": "prettier --check .",
         "test": "vitest run",
+        "test:e2e": "vitest run --config vitest.e2e.config.ts",
         "test:watch": "vitest",
         "prepublishOnly": "npm run build"
     },

--- a/test/e2e/up.e2e.test.ts
+++ b/test/e2e/up.e2e.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import yaml from 'js-yaml';
+import Up from '../../src/commands/up.js';
+import { saveEnvironment } from '../../src/core/environment.js';
+import { AwsSmProvider } from '../../src/providers/aws-sm.js';
+import { SecretRef } from '../../src/core/types.js';
+
+describe('up command (e2e against real AWS SM)', () => {
+    let tmpDir: string;
+    let origCwd: string;
+    let provider: AwsSmProvider;
+    /** Tracks every {env, path} pair that might exist in AWS SM, for deterministic cleanup. */
+    let secretsToCleanup: Array<{ env: string; path: string }>;
+
+    beforeEach(() => {
+        const projectName = `e2e-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'keyshelf-e2e-up-'));
+        origCwd = process.cwd();
+        process.chdir(tmpDir);
+        fs.mkdirSync(path.join(tmpDir, '.keyshelf', 'environments'), { recursive: true });
+        fs.writeFileSync(
+            path.join(tmpDir, 'keyshelf.yml'),
+            yaml.dump({ name: projectName, provider: { adapter: 'aws-sm' } })
+        );
+        provider = new AwsSmProvider({ name: projectName });
+        secretsToCleanup = [];
+    });
+
+    afterEach(async () => {
+        process.chdir(origCwd);
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+
+        for (const { env, path: secretPath } of secretsToCleanup) {
+            try {
+                await provider.delete(env, secretPath);
+            } catch {
+                // Ignore — secret may already be deleted by the test or not yet created
+            }
+        }
+    });
+
+    it('creates new secrets in AWS SM', async () => {
+        secretsToCleanup.push({ env: 'dev', path: 'db/password' });
+        await saveEnvironment(tmpDir, 'dev', {
+            imports: [],
+            values: { db: { password: new SecretRef('db/password') } }
+        });
+
+        const secretsFile = path.join(tmpDir, 'secrets.env');
+        fs.writeFileSync(secretsFile, 'db/password=e2e-secret-value\n');
+
+        await Up.run(['--apply', '--from-file', secretsFile]);
+
+        const value = await provider.get('dev', 'db/password');
+        expect(value).toBe('e2e-secret-value');
+    });
+
+    it('deletes stale secrets from AWS SM', async () => {
+        secretsToCleanup.push({ env: 'dev', path: 'old/stale-key' });
+        await provider.set('dev', 'old/stale-key', 'stale-value');
+        await waitForSecretInList(provider, 'dev', 'old/stale-key');
+
+        await saveEnvironment(tmpDir, 'dev', {
+            imports: [],
+            values: { db: { host: 'localhost' } }
+        });
+
+        const secretsFile = path.join(tmpDir, 'secrets.env');
+        fs.writeFileSync(secretsFile, '');
+
+        await Up.run(['--apply', '--from-file', secretsFile]);
+
+        await expect(provider.get('dev', 'old/stale-key')).rejects.toThrow(
+            /not found|marked for deletion/
+        );
+    });
+
+    it('copies secrets from parent to child environment', async () => {
+        secretsToCleanup.push(
+            { env: 'base', path: 'shared/token' },
+            { env: 'dev', path: 'shared/token' }
+        );
+        await provider.set('base', 'shared/token', 'base-token-value');
+        await waitForSecretInList(provider, 'base', 'shared/token');
+
+        await saveEnvironment(tmpDir, 'base', {
+            imports: [],
+            values: { shared: { token: new SecretRef('shared/token') } }
+        });
+        await saveEnvironment(tmpDir, 'dev', {
+            imports: ['base'],
+            values: { shared: { token: new SecretRef('shared/token') } }
+        });
+
+        await Up.run(['--apply']);
+
+        const value = await provider.get('dev', 'shared/token');
+        expect(value).toBe('base-token-value');
+    });
+
+    it('does nothing when provider already has all secrets', async () => {
+        secretsToCleanup.push({ env: 'dev', path: 'db/password' });
+        await provider.set('dev', 'db/password', 'already-set');
+        await waitForSecretInList(provider, 'dev', 'db/password');
+
+        await saveEnvironment(tmpDir, 'dev', {
+            imports: [],
+            values: { db: { password: new SecretRef('db/password') } }
+        });
+
+        await Up.run(['--apply']);
+
+        const value = await provider.get('dev', 'db/password');
+        expect(value).toBe('already-set');
+    });
+});
+
+async function waitForSecretInList(
+    provider: AwsSmProvider,
+    env: string,
+    secretPath: string,
+    timeoutMs = 30_000
+): Promise<void> {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+        const paths = await provider.list(env);
+        if (paths.includes(secretPath)) return;
+        await new Promise((r) => setTimeout(r, 1000));
+    }
+    throw new Error(
+        `Secret "${secretPath}" did not appear in list for env "${env}" within ${timeoutMs}ms`
+    );
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
     test: {
         globals: true,
         root: '.',
+        exclude: ['test/e2e/**', 'node_modules/**'],
         coverage: {
             provider: 'v8',
             reporter: ['text', 'lcov', 'clover', 'json'],

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        globals: true,
+        root: '.',
+        include: ['test/e2e/**/*.e2e.test.ts'],
+        testTimeout: 60_000,
+        hookTimeout: 60_000
+    }
+});


### PR DESCRIPTION
## Summary
- Adds e2e tests that run `keyshelf up` against real AWS Secrets Manager
- Separate vitest config (`vitest.e2e.config.ts`) with 60s timeouts; `npm test` excludes e2e via `exclude: ['test/e2e/**']`
- New `npm run test:e2e` script (local-only, requires AWS credentials via standard chain)

## Tests
4 tests covering the core `keyshelf up` reconciliation flows:
- **Create**: adds new secrets to AWS SM
- **Delete**: removes stale secrets from AWS SM
- **Copy**: inherits secrets from parent to child environment
- **Idempotent**: no-op when provider already has all secrets

Each test uses a unique `e2e-<timestamp>-<random>` project name to avoid collisions. Cleanup deletes secrets by explicit path (not `list()`) to avoid AWS SM eventual consistency issues.

## Test plan
- [x] `npm test` — 270 unit tests pass, e2e excluded
- [x] `AWS_PROFILE=self npm run test:e2e` — 4/4 pass
- [x] Verified zero leftover secrets in AWS SM after test run

🤖 Generated with [Claude Code](https://claude.com/claude-code)