### PR TITLE
feat: add secret:set command

### DIFF
--- a/src/commands/secret/set.ts
+++ b/src/commands/secret/set.ts
@@ -1,0 +1,134 @@
+import { Args, Command, Flags } from '@oclif/core';
+import { loadEnvironment, saveEnvironment, listEnvironments } from '../../core/environment.js';
+import { loadConfig, defaultConfigDir } from '../../core/config.js';
+import { resolve } from '../../core/resolver.js';
+import { PathTree } from '../../core/path-tree.js';
+import { SecretRef, EnvironmentDefinition } from '../../core/types.js';
+import { resolveProvider } from '../../providers/index.js';
+import { readMaskedLine } from '../../core/input.js';
+import { topoSort } from '../../core/reconciler/topo-sort.js';
+
+export default class SecretSet extends Command {
+    static override description = 'Set a secret value in an environment';
+
+    static override examples = [
+        '<%= config.bin %> secret:set --env dev database/password',
+        '<%= config.bin %> secret:set --env dev database/password mysecret'
+    ];
+
+    static override args = {
+        path: Args.string({ description: 'Secret path (slash-delimited)', required: true }),
+        value: Args.string({ description: 'Secret value (prompted if omitted)', required: false })
+    };
+
+    static override flags = {
+        env: Flags.string({ description: 'Environment name', required: true }),
+        'config-dir': Flags.string({ description: 'Override config directory', hidden: true })
+    };
+
+    async run(): Promise<void> {
+        const { args, flags } = await this.parse(SecretSet);
+        const cwd = process.cwd();
+        const envName = flags.env;
+
+        const resolved = await resolve(envName, (name) => loadEnvironment(cwd, name));
+        const resolvedTree = PathTree.fromJSON(resolved.values);
+        const existing = resolvedTree.get(args.path);
+
+        await this.ensureSecretRef(cwd, envName, args.path, existing);
+
+        const value = args.value ?? (await readMaskedLine(`Enter value for "${args.path}": `));
+
+        const config = loadConfig(cwd);
+        const configDir = flags['config-dir'] ?? defaultConfigDir(config);
+        const envDef = await loadEnvironment(cwd, envName);
+        const provider = resolveProvider(envDef, config, configDir);
+        await provider.set(envName, args.path, value);
+
+        await this.propagateToImporters(cwd, envName, args.path, value, config, configDir);
+    }
+
+    private async ensureSecretRef(
+        cwd: string,
+        envName: string,
+        secretPath: string,
+        existing: unknown
+    ): Promise<void> {
+        if (existing instanceof SecretRef) return;
+
+        if (existing !== undefined) {
+            process.stderr.write(
+                `Warning: Overwriting plain value at ${secretPath} with a secret reference\n`
+            );
+        }
+
+        await this.addSecretRefToEnv(cwd, envName, secretPath);
+    }
+
+    private async addSecretRefToEnv(
+        cwd: string,
+        envName: string,
+        secretPath: string
+    ): Promise<void> {
+        const envDef = await loadEnvironment(cwd, envName);
+        const tree = PathTree.fromJSON(envDef.values);
+        tree.set(secretPath, new SecretRef(secretPath));
+        const updated: EnvironmentDefinition = { ...envDef, values: tree.toJSON() };
+        await saveEnvironment(cwd, envName, updated);
+    }
+
+    private async propagateToImporters(
+        cwd: string,
+        envName: string,
+        secretPath: string,
+        value: string,
+        config: ReturnType<typeof loadConfig>,
+        configDir: string
+    ): Promise<void> {
+        const allEnvNames = await listEnvironments(cwd);
+        const envDefs = await this.loadAllEnvDefs(cwd, allEnvNames);
+        const sorted = topoSort(envDefs);
+        const importers = this.findTransitiveImporters(envDefs, envName, sorted);
+
+        for (const importerName of importers) {
+            const resolved = await resolve(importerName, (name) => loadEnvironment(cwd, name));
+            const tree = PathTree.fromJSON(resolved.values);
+            const ref = tree.get(secretPath);
+            if (!(ref instanceof SecretRef)) continue;
+
+            this.log(`↻ ${importerName} ${secretPath} (from ${envName})`);
+            const importerDef = await loadEnvironment(cwd, importerName);
+            const importerProvider = resolveProvider(importerDef, config, configDir);
+            await importerProvider.set(importerName, secretPath, value);
+        }
+    }
+
+    private async loadAllEnvDefs(
+        cwd: string,
+        envNames: string[]
+    ): Promise<Record<string, { imports: string[] }>> {
+        const entries = await Promise.all(
+            envNames.map(async (name) => {
+                const def = await loadEnvironment(cwd, name);
+                return [name, { imports: def.imports }] as const;
+            })
+        );
+        return Object.fromEntries(entries);
+    }
+
+    private findTransitiveImporters(
+        envDefs: Record<string, { imports: string[] }>,
+        targetEnv: string,
+        sorted: string[]
+    ): string[] {
+        const importers = new Set<string>();
+        for (const name of sorted) {
+            if (name === targetEnv) continue;
+            const { imports } = envDefs[name];
+            const importsTarget =
+                imports.includes(targetEnv) || imports.some((imp) => importers.has(imp));
+            if (importsTarget) importers.add(name);
+        }
+        return sorted.filter((name) => importers.has(name));
+    }
+}

--- a/src/core/input.ts
+++ b/src/core/input.ts
@@ -1,0 +1,40 @@
+/**
+ * Read a line from stdin with masked output (each character shown as '*').
+ * Handles multi-character chunks by processing characters one-by-one.
+ *
+ * @param prompt - Text to display before the input
+ * @returns The entered string (without the trailing newline)
+ */
+export function readMaskedLine(prompt: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+        process.stdout.write(prompt);
+        process.stdin.setRawMode?.(true);
+        process.stdin.resume();
+
+        let value = '';
+
+        function onData(chunk: Buffer): void {
+            for (const char of chunk.toString()) {
+                if (char === '\r' || char === '\n') {
+                    process.stdin.setRawMode?.(false);
+                    process.stdin.removeListener('data', onData);
+                    process.stdin.pause();
+                    process.stdout.write('\n');
+                    resolve(value);
+                    return;
+                }
+                if (char === '\u0003') {
+                    process.stdin.setRawMode?.(false);
+                    process.stdin.removeListener('data', onData);
+                    process.stdin.pause();
+                    reject(new Error('Aborted by user'));
+                    return;
+                }
+                value += char;
+                process.stdout.write('*');
+            }
+        }
+
+        process.stdin.on('data', onData);
+    });
+}

--- a/src/core/reconciler/input.ts
+++ b/src/core/reconciler/input.ts
@@ -1,3 +1,7 @@
+import { readMaskedLine } from '../input.js';
+
+export { readMaskedLine };
+
 type ValueSource =
     | { kind: 'prompt' }
     | { kind: 'env'; mapping: Record<string, string> }
@@ -26,47 +30,6 @@ export function makeCollector(source: ValueSource): (path: string) => Promise<st
 
 async function promptCollector(path: string): Promise<string> {
     return readMaskedLine(`Enter value for "${path}": `);
-}
-
-/**
- * Read a line from stdin with masked output (each character shown as '*').
- * Handles multi-character chunks by processing characters one-by-one.
- *
- * @param prompt - Text to display before the input
- * @returns The entered string (without the trailing newline)
- */
-export function readMaskedLine(prompt: string): Promise<string> {
-    return new Promise((resolve, reject) => {
-        process.stdout.write(prompt);
-        process.stdin.setRawMode?.(true);
-        process.stdin.resume();
-
-        let value = '';
-
-        function onData(chunk: Buffer): void {
-            for (const char of chunk.toString()) {
-                if (char === '\r' || char === '\n') {
-                    process.stdin.setRawMode?.(false);
-                    process.stdin.removeListener('data', onData);
-                    process.stdin.pause();
-                    process.stdout.write('\n');
-                    resolve(value);
-                    return;
-                }
-                if (char === '\u0003') {
-                    process.stdin.setRawMode?.(false);
-                    process.stdin.removeListener('data', onData);
-                    process.stdin.pause();
-                    reject(new Error('Aborted by user'));
-                    return;
-                }
-                value += char;
-                process.stdout.write('*');
-            }
-        }
-
-        process.stdin.on('data', onData);
-    });
 }
 
 function makeEnvCollector(mapping: Record<string, string>): (path: string) => Promise<string> {

--- a/test/commands/secret/set.test.ts
+++ b/test/commands/secret/set.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import yaml from 'js-yaml';
+import SecretSet from '../../../src/commands/secret/set.js';
+import { saveEnvironment, loadEnvironment } from '../../../src/core/environment.js';
+import { LocalProvider } from '../../../src/providers/local.js';
+import { SecretRef } from '../../../src/core/types.js';
+import * as inputModule from '../../../src/core/input.js';
+
+describe('secret:set command', () => {
+    let tmpDir: string;
+    let origCwd: string;
+    let configDir: string;
+    let logSpy: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'keyshelf-secret-set-'));
+        configDir = path.join(tmpDir, '.config');
+        origCwd = process.cwd();
+        process.chdir(tmpDir);
+        fs.mkdirSync(path.join(tmpDir, '.keyshelf', 'environments'), { recursive: true });
+        fs.writeFileSync(
+            path.join(tmpDir, 'keyshelf.yml'),
+            yaml.dump({ name: 'test-project', provider: { adapter: 'local' } })
+        );
+        logSpy = vi.fn();
+        vi.spyOn(SecretSet.prototype, 'log').mockImplementation(logSpy);
+    });
+
+    afterEach(() => {
+        process.chdir(origCwd);
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+        vi.restoreAllMocks();
+    });
+
+    it('sets a secret value for an existing SecretRef', async () => {
+        await saveEnvironment(tmpDir, 'dev', {
+            imports: [],
+            values: { database: { password: new SecretRef('database/password') } }
+        });
+
+        await SecretSet.run([
+            '--env',
+            'dev',
+            'database/password',
+            'mysecret',
+            '--config-dir',
+            configDir
+        ]);
+
+        const provider = new LocalProvider(configDir);
+        const stored = await provider.get('dev', 'database/password');
+        expect(stored).toBe('mysecret');
+    });
+
+    it('creates SecretRef in YAML when path does not exist, then sets value', async () => {
+        await saveEnvironment(tmpDir, 'dev', {
+            imports: [],
+            values: {}
+        });
+
+        await SecretSet.run([
+            '--env',
+            'dev',
+            'database/password',
+            'newpassword',
+            '--config-dir',
+            configDir
+        ]);
+
+        const envDef = await loadEnvironment(tmpDir, 'dev');
+        const { database } = envDef.values as { database: { password: unknown } };
+        expect(database.password).toBeInstanceOf(SecretRef);
+
+        const provider = new LocalProvider(configDir);
+        const stored = await provider.get('dev', 'database/password');
+        expect(stored).toBe('newpassword');
+    });
+
+    it('warns and overwrites when path is a plain value', async () => {
+        await saveEnvironment(tmpDir, 'dev', {
+            imports: [],
+            values: { database: { password: 'plain-text' } }
+        });
+
+        const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+        await SecretSet.run([
+            '--env',
+            'dev',
+            'database/password',
+            'newvalue',
+            '--config-dir',
+            configDir
+        ]);
+
+        expect(stderrSpy).toHaveBeenCalledWith(
+            expect.stringContaining('Overwriting plain value at database/password')
+        );
+
+        const envDef = await loadEnvironment(tmpDir, 'dev');
+        const { database } = envDef.values as { database: { password: unknown } };
+        expect(database.password).toBeInstanceOf(SecretRef);
+
+        const provider = new LocalProvider(configDir);
+        const stored = await provider.get('dev', 'database/password');
+        expect(stored).toBe('newvalue');
+    });
+
+    it('propagates to child environments that import the target env', async () => {
+        await saveEnvironment(tmpDir, 'base', {
+            imports: [],
+            values: { shared: { key: new SecretRef('shared/key') } }
+        });
+        await saveEnvironment(tmpDir, 'dev', {
+            imports: ['base'],
+            values: {}
+        });
+
+        await SecretSet.run([
+            '--env',
+            'base',
+            'shared/key',
+            'propagated-value',
+            '--config-dir',
+            configDir
+        ]);
+
+        const provider = new LocalProvider(configDir);
+        const baseValue = await provider.get('base', 'shared/key');
+        expect(baseValue).toBe('propagated-value');
+
+        const devValue = await provider.get('dev', 'shared/key');
+        expect(devValue).toBe('propagated-value');
+
+        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('dev'));
+        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('shared/key'));
+        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('base'));
+    });
+
+    it('prompts interactively when value arg is omitted', async () => {
+        await saveEnvironment(tmpDir, 'dev', {
+            imports: [],
+            values: { api: { key: new SecretRef('api/key') } }
+        });
+
+        vi.spyOn(inputModule, 'readMaskedLine').mockResolvedValue('prompted-secret');
+
+        await SecretSet.run(['--env', 'dev', 'api/key', '--config-dir', configDir]);
+
+        expect(inputModule.readMaskedLine).toHaveBeenCalledWith(expect.stringContaining('api/key'));
+
+        const provider = new LocalProvider(configDir);
+        const stored = await provider.get('dev', 'api/key');
+        expect(stored).toBe('prompted-secret');
+    });
+
+    it('errors with helpful message if environment does not exist', async () => {
+        await expect(
+            SecretSet.run(['--env', 'nonexistent', 'some/path', 'value', '--config-dir', configDir])
+        ).rejects.toThrow(/nonexistent/);
+    });
+});


### PR DESCRIPTION
## Summary

- Adds `keyshelf secret:set --env <env> <path> [value]` for setting secret values directly
- Auto-creates `!secret` ref in YAML if the path doesn't exist (warns if overwriting a plain value)
- Propagates the value to all environments that transitively import the target env
- Extracts `readMaskedLine` to `src/core/input.ts` for shared use

## Test plan

- [x] Sets value for existing SecretRef
- [x] Creates SecretRef in YAML when path doesn't exist
- [x] Warns and overwrites plain values
- [x] Propagates to child environments
- [x] Interactive prompt when value omitted
- [x] Error on missing environment
- [x] All 276 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)