### PR TITLE
test: add e2e tests for set, get, print with multi-provider support

### DIFF
--- a/test/e2e/get-print.e2e.test.ts
+++ b/test/e2e/get-print.e2e.test.ts
@@ -6,13 +6,14 @@ import yaml from 'js-yaml';
 import Get from '../../src/commands/get.js';
 import Print from '../../src/commands/print.js';
 import { saveEnvironment } from '../../src/core/environment.js';
-import { AwsSmProvider } from '../../src/providers/aws-sm.js';
 import { SecretRef } from '../../src/core/types.js';
+import { SecretProvider } from '../../src/providers/provider.js';
+import { providerConfig, providerLabel, createTestProvider } from './provider-fixture.js';
 
-describe('get and print commands (e2e against real AWS SM)', () => {
+describe(`get and print commands (e2e against ${providerLabel})`, () => {
     let tmpDir: string;
     let origCwd: string;
-    let provider: AwsSmProvider;
+    let provider: SecretProvider;
     let secretsToCleanup: Array<{ env: string; path: string }>;
 
     beforeEach(() => {
@@ -23,9 +24,9 @@ describe('get and print commands (e2e against real AWS SM)', () => {
         fs.mkdirSync(path.join(tmpDir, '.keyshelf', 'environments'), { recursive: true });
         fs.writeFileSync(
             path.join(tmpDir, 'keyshelf.yml'),
-            yaml.dump({ name: projectName, provider: { adapter: 'aws-sm' } })
+            yaml.dump({ name: projectName, provider: providerConfig })
         );
-        provider = new AwsSmProvider({ name: projectName });
+        provider = createTestProvider(projectName);
         secretsToCleanup = [];
     });
 
@@ -44,7 +45,7 @@ describe('get and print commands (e2e against real AWS SM)', () => {
     });
 
     describe('get', () => {
-        it('retrieves a secret value from AWS SM', async () => {
+        it('retrieves a secret value from the provider', async () => {
             secretsToCleanup.push({ env: 'dev', path: 'db/password' });
             await provider.set('dev', 'db/password', 'real-secret-from-aws');
             await saveEnvironment(tmpDir, 'dev', {
@@ -60,7 +61,7 @@ describe('get and print commands (e2e against real AWS SM)', () => {
             expect(logSpy).toHaveBeenCalledWith('real-secret-from-aws');
         });
 
-        it('retrieves an inherited secret from AWS SM', async () => {
+        it('retrieves an inherited secret from the provider', async () => {
             secretsToCleanup.push({ env: 'dev', path: 'shared/key' });
             await provider.set('dev', 'shared/key', 'inherited-aws-secret');
             await saveEnvironment(tmpDir, 'base', {
@@ -82,7 +83,7 @@ describe('get and print commands (e2e against real AWS SM)', () => {
     });
 
     describe('print --reveal', () => {
-        it('reveals secret values from AWS SM in yaml format', async () => {
+        it('reveals secret values in yaml format', async () => {
             secretsToCleanup.push({ env: 'dev', path: 'api/key' });
             await provider.set('dev', 'api/key', 'revealed-aws-secret');
             await saveEnvironment(tmpDir, 'dev', {

--- a/test/e2e/get-print.e2e.test.ts
+++ b/test/e2e/get-print.e2e.test.ts
@@ -13,12 +13,14 @@ import { providerConfig, providerLabel, createTestProvider } from './provider-fi
 describe(`get and print commands (e2e against ${providerLabel})`, () => {
     let tmpDir: string;
     let origCwd: string;
+    let configDir: string;
     let provider: SecretProvider;
     let secretsToCleanup: Array<{ env: string; path: string }>;
 
     beforeEach(() => {
         const projectName = `e2e-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
         tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'keyshelf-e2e-read-'));
+        configDir = path.join(tmpDir, '.config');
         origCwd = process.cwd();
         process.chdir(tmpDir);
         fs.mkdirSync(path.join(tmpDir, '.keyshelf', 'environments'), { recursive: true });
@@ -26,7 +28,7 @@ describe(`get and print commands (e2e against ${providerLabel})`, () => {
             path.join(tmpDir, 'keyshelf.yml'),
             yaml.dump({ name: projectName, provider: providerConfig })
         );
-        provider = createTestProvider(projectName);
+        provider = createTestProvider(projectName, configDir);
         secretsToCleanup = [];
     });
 
@@ -56,7 +58,7 @@ describe(`get and print commands (e2e against ${providerLabel})`, () => {
             const logSpy = vi.fn();
             vi.spyOn(Get.prototype, 'log').mockImplementation(logSpy);
 
-            await Get.run(['--env', 'dev', 'db/password']);
+            await Get.run(['--env', 'dev', '--config-dir', configDir, 'db/password']);
 
             expect(logSpy).toHaveBeenCalledWith('real-secret-from-aws');
         });
@@ -76,7 +78,7 @@ describe(`get and print commands (e2e against ${providerLabel})`, () => {
             const logSpy = vi.fn();
             vi.spyOn(Get.prototype, 'log').mockImplementation(logSpy);
 
-            await Get.run(['--env', 'dev', 'shared/key']);
+            await Get.run(['--env', 'dev', '--config-dir', configDir, 'shared/key']);
 
             expect(logSpy).toHaveBeenCalledWith('inherited-aws-secret');
         });
@@ -97,7 +99,7 @@ describe(`get and print commands (e2e against ${providerLabel})`, () => {
             const logSpy = vi.fn();
             vi.spyOn(Print.prototype, 'log').mockImplementation(logSpy);
 
-            await Print.run(['--env', 'dev', '--reveal']);
+            await Print.run(['--env', 'dev', '--config-dir', configDir, '--reveal']);
 
             const output = logSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n');
             expect(output).toContain('revealed-aws-secret');
@@ -120,7 +122,15 @@ describe(`get and print commands (e2e against ${providerLabel})`, () => {
             const logSpy = vi.fn();
             vi.spyOn(Print.prototype, 'log').mockImplementation(logSpy);
 
-            await Print.run(['--env', 'dev', '--format', 'json', '--reveal']);
+            await Print.run([
+                '--env',
+                'dev',
+                '--config-dir',
+                configDir,
+                '--format',
+                'json',
+                '--reveal'
+            ]);
 
             const output = logSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n');
             const parsed = JSON.parse(output);
@@ -143,7 +153,15 @@ describe(`get and print commands (e2e against ${providerLabel})`, () => {
             const logSpy = vi.fn();
             vi.spyOn(Print.prototype, 'log').mockImplementation(logSpy);
 
-            await Print.run(['--env', 'dev', '--format', 'env', '--reveal']);
+            await Print.run([
+                '--env',
+                'dev',
+                '--config-dir',
+                configDir,
+                '--format',
+                'env',
+                '--reveal'
+            ]);
 
             const output = logSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n');
             expect(output).toContain('API_KEY=env-revealed-secret');

--- a/test/e2e/get-print.e2e.test.ts
+++ b/test/e2e/get-print.e2e.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import yaml from 'js-yaml';
+import Get from '../../src/commands/get.js';
+import Print from '../../src/commands/print.js';
+import { saveEnvironment } from '../../src/core/environment.js';
+import { AwsSmProvider } from '../../src/providers/aws-sm.js';
+import { SecretRef } from '../../src/core/types.js';
+
+describe('get and print commands (e2e against real AWS SM)', () => {
+    let tmpDir: string;
+    let origCwd: string;
+    let provider: AwsSmProvider;
+    let secretsToCleanup: Array<{ env: string; path: string }>;
+
+    beforeEach(() => {
+        const projectName = `e2e-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'keyshelf-e2e-read-'));
+        origCwd = process.cwd();
+        process.chdir(tmpDir);
+        fs.mkdirSync(path.join(tmpDir, '.keyshelf', 'environments'), { recursive: true });
+        fs.writeFileSync(
+            path.join(tmpDir, 'keyshelf.yml'),
+            yaml.dump({ name: projectName, provider: { adapter: 'aws-sm' } })
+        );
+        provider = new AwsSmProvider({ name: projectName });
+        secretsToCleanup = [];
+    });
+
+    afterEach(async () => {
+        process.chdir(origCwd);
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+        vi.restoreAllMocks();
+
+        for (const { env, path: secretPath } of secretsToCleanup) {
+            try {
+                await provider.delete(env, secretPath);
+            } catch {
+                // Ignore
+            }
+        }
+    });
+
+    describe('get', () => {
+        it('retrieves a secret value from AWS SM', async () => {
+            secretsToCleanup.push({ env: 'dev', path: 'db/password' });
+            await provider.set('dev', 'db/password', 'real-secret-from-aws');
+            await saveEnvironment(tmpDir, 'dev', {
+                imports: [],
+                values: { db: { password: new SecretRef('db/password') } }
+            });
+
+            const logSpy = vi.fn();
+            vi.spyOn(Get.prototype, 'log').mockImplementation(logSpy);
+
+            await Get.run(['--env', 'dev', 'db/password']);
+
+            expect(logSpy).toHaveBeenCalledWith('real-secret-from-aws');
+        });
+
+        it('retrieves an inherited secret from AWS SM', async () => {
+            secretsToCleanup.push({ env: 'dev', path: 'shared/key' });
+            await provider.set('dev', 'shared/key', 'inherited-aws-secret');
+            await saveEnvironment(tmpDir, 'base', {
+                imports: [],
+                values: { shared: { key: new SecretRef('shared/key') } }
+            });
+            await saveEnvironment(tmpDir, 'dev', {
+                imports: ['base'],
+                values: {}
+            });
+
+            const logSpy = vi.fn();
+            vi.spyOn(Get.prototype, 'log').mockImplementation(logSpy);
+
+            await Get.run(['--env', 'dev', 'shared/key']);
+
+            expect(logSpy).toHaveBeenCalledWith('inherited-aws-secret');
+        });
+    });
+
+    describe('print --reveal', () => {
+        it('reveals secret values from AWS SM in yaml format', async () => {
+            secretsToCleanup.push({ env: 'dev', path: 'api/key' });
+            await provider.set('dev', 'api/key', 'revealed-aws-secret');
+            await saveEnvironment(tmpDir, 'dev', {
+                imports: [],
+                values: {
+                    api: { key: new SecretRef('api/key') },
+                    app: { name: 'my-app' }
+                }
+            });
+
+            const logSpy = vi.fn();
+            vi.spyOn(Print.prototype, 'log').mockImplementation(logSpy);
+
+            await Print.run(['--env', 'dev', '--reveal']);
+
+            const output = logSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n');
+            expect(output).toContain('revealed-aws-secret');
+            expect(output).toContain('my-app');
+        });
+
+        it('reveals secret values in json format', async () => {
+            secretsToCleanup.push({ env: 'dev', path: 'db/password' });
+            await provider.set('dev', 'db/password', 'json-revealed-secret');
+            await saveEnvironment(tmpDir, 'dev', {
+                imports: [],
+                values: {
+                    db: {
+                        host: 'localhost',
+                        password: new SecretRef('db/password')
+                    }
+                }
+            });
+
+            const logSpy = vi.fn();
+            vi.spyOn(Print.prototype, 'log').mockImplementation(logSpy);
+
+            await Print.run(['--env', 'dev', '--format', 'json', '--reveal']);
+
+            const output = logSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n');
+            const parsed = JSON.parse(output);
+            expect(parsed).toEqual({
+                db: { host: 'localhost', password: 'json-revealed-secret' }
+            });
+        });
+
+        it('reveals secret values in env format', async () => {
+            secretsToCleanup.push({ env: 'dev', path: 'api/key' });
+            await provider.set('dev', 'api/key', 'env-revealed-secret');
+            await saveEnvironment(tmpDir, 'dev', {
+                imports: [],
+                values: {
+                    api: { key: new SecretRef('api/key') },
+                    app: { port: 3000 }
+                }
+            });
+
+            const logSpy = vi.fn();
+            vi.spyOn(Print.prototype, 'log').mockImplementation(logSpy);
+
+            await Print.run(['--env', 'dev', '--format', 'env', '--reveal']);
+
+            const output = logSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n');
+            expect(output).toContain('API_KEY=env-revealed-secret');
+            expect(output).toContain('APP_PORT=3000');
+        });
+    });
+});

--- a/test/e2e/provider-fixture.ts
+++ b/test/e2e/provider-fixture.ts
@@ -9,6 +9,8 @@ function getProviderConfig(): ProviderConfig {
     switch (adapter) {
         case 'aws-sm':
             return { adapter: 'aws-sm' };
+        case 'local':
+            return { adapter: 'local' };
         case 'gcp-sm': {
             const project = process.env.KEYSHELF_E2E_GCP_PROJECT;
             if (!project) {
@@ -25,6 +27,6 @@ export const providerConfig = getProviderConfig();
 
 export const providerLabel = providerConfig.adapter;
 
-export function createTestProvider(projectName: string): SecretProvider {
-    return createProvider(providerConfig, '', projectName);
+export function createTestProvider(projectName: string, configDir: string): SecretProvider {
+    return createProvider(providerConfig, configDir, projectName);
 }

--- a/test/e2e/provider-fixture.ts
+++ b/test/e2e/provider-fixture.ts
@@ -1,0 +1,30 @@
+import { ProviderConfig } from '../../src/core/types.js';
+import { SecretProvider } from '../../src/providers/provider.js';
+import { createProvider } from '../../src/providers/index.js';
+
+type Adapter = ProviderConfig['adapter'];
+
+function getProviderConfig(): ProviderConfig {
+    const adapter = (process.env.KEYSHELF_E2E_PROVIDER ?? 'aws-sm') as Adapter;
+    switch (adapter) {
+        case 'aws-sm':
+            return { adapter: 'aws-sm' };
+        case 'gcp-sm': {
+            const project = process.env.KEYSHELF_E2E_GCP_PROJECT;
+            if (!project) {
+                throw new Error('KEYSHELF_E2E_GCP_PROJECT is required when using gcp-sm provider');
+            }
+            return { adapter: 'gcp-sm', project };
+        }
+        default:
+            throw new Error(`Unsupported e2e provider: ${adapter}`);
+    }
+}
+
+export const providerConfig = getProviderConfig();
+
+export const providerLabel = providerConfig.adapter;
+
+export function createTestProvider(projectName: string): SecretProvider {
+    return createProvider(providerConfig, '', projectName);
+}

--- a/test/e2e/set.e2e.test.ts
+++ b/test/e2e/set.e2e.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import yaml from 'js-yaml';
+import SetCommand from '../../src/commands/set.js';
+import { saveEnvironment, loadEnvironment } from '../../src/core/environment.js';
+import { AwsSmProvider } from '../../src/providers/aws-sm.js';
+import { SecretRef } from '../../src/core/types.js';
+
+describe('set command (e2e against real AWS SM)', () => {
+    let tmpDir: string;
+    let origCwd: string;
+    let provider: AwsSmProvider;
+    let secretsToCleanup: Array<{ env: string; path: string }>;
+
+    beforeEach(() => {
+        const projectName = `e2e-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'keyshelf-e2e-set-'));
+        origCwd = process.cwd();
+        process.chdir(tmpDir);
+        fs.mkdirSync(path.join(tmpDir, '.keyshelf', 'environments'), { recursive: true });
+        fs.writeFileSync(
+            path.join(tmpDir, 'keyshelf.yml'),
+            yaml.dump({ name: projectName, provider: { adapter: 'aws-sm' } })
+        );
+        provider = new AwsSmProvider({ name: projectName });
+        secretsToCleanup = [];
+    });
+
+    afterEach(async () => {
+        process.chdir(origCwd);
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+
+        for (const { env, path: secretPath } of secretsToCleanup) {
+            try {
+                await provider.delete(env, secretPath);
+            } catch {
+                // Ignore — secret may already be deleted or not yet created
+            }
+        }
+    });
+
+    it('sets a secret value in AWS SM', async () => {
+        secretsToCleanup.push({ env: 'dev', path: 'api/key' });
+        await saveEnvironment(tmpDir, 'dev', {
+            imports: [],
+            values: { api: { key: new SecretRef('api/key') } }
+        });
+
+        await SetCommand.run(['--env', 'dev', 'api/key', 'e2e-api-key-value']);
+
+        const value = await provider.get('dev', 'api/key');
+        expect(value).toBe('e2e-api-key-value');
+    });
+
+    it('creates SecretRef in YAML when path does not exist', async () => {
+        secretsToCleanup.push({ env: 'dev', path: 'new/secret' });
+        await saveEnvironment(tmpDir, 'dev', {
+            imports: [],
+            values: {}
+        });
+
+        await SetCommand.run(['--env', 'dev', 'new/secret', 'brand-new-value']);
+
+        const envDef = await loadEnvironment(tmpDir, 'dev');
+        const { new: newNode } = envDef.values as { new: { secret: unknown } };
+        expect(newNode.secret).toBeInstanceOf(SecretRef);
+
+        const value = await provider.get('dev', 'new/secret');
+        expect(value).toBe('brand-new-value');
+    });
+
+    it('propagates secret to child environments in AWS SM', async () => {
+        secretsToCleanup.push(
+            { env: 'base', path: 'shared/token' },
+            { env: 'staging', path: 'shared/token' }
+        );
+        await saveEnvironment(tmpDir, 'base', {
+            imports: [],
+            values: { shared: { token: new SecretRef('shared/token') } }
+        });
+        await saveEnvironment(tmpDir, 'staging', {
+            imports: ['base'],
+            values: {}
+        });
+
+        await SetCommand.run(['--env', 'base', 'shared/token', 'propagated-e2e-value']);
+
+        const baseValue = await provider.get('base', 'shared/token');
+        expect(baseValue).toBe('propagated-e2e-value');
+
+        const stagingValue = await provider.get('staging', 'shared/token');
+        expect(stagingValue).toBe('propagated-e2e-value');
+    });
+});

--- a/test/e2e/set.e2e.test.ts
+++ b/test/e2e/set.e2e.test.ts
@@ -5,13 +5,14 @@ import os from 'node:os';
 import yaml from 'js-yaml';
 import SetCommand from '../../src/commands/set.js';
 import { saveEnvironment, loadEnvironment } from '../../src/core/environment.js';
-import { AwsSmProvider } from '../../src/providers/aws-sm.js';
 import { SecretRef } from '../../src/core/types.js';
+import { SecretProvider } from '../../src/providers/provider.js';
+import { providerConfig, providerLabel, createTestProvider } from './provider-fixture.js';
 
-describe('set command (e2e against real AWS SM)', () => {
+describe(`set command (e2e against ${providerLabel})`, () => {
     let tmpDir: string;
     let origCwd: string;
-    let provider: AwsSmProvider;
+    let provider: SecretProvider;
     let secretsToCleanup: Array<{ env: string; path: string }>;
 
     beforeEach(() => {
@@ -22,9 +23,9 @@ describe('set command (e2e against real AWS SM)', () => {
         fs.mkdirSync(path.join(tmpDir, '.keyshelf', 'environments'), { recursive: true });
         fs.writeFileSync(
             path.join(tmpDir, 'keyshelf.yml'),
-            yaml.dump({ name: projectName, provider: { adapter: 'aws-sm' } })
+            yaml.dump({ name: projectName, provider: providerConfig })
         );
-        provider = new AwsSmProvider({ name: projectName });
+        provider = createTestProvider(projectName);
         secretsToCleanup = [];
     });
 
@@ -41,7 +42,7 @@ describe('set command (e2e against real AWS SM)', () => {
         }
     });
 
-    it('sets a secret value in AWS SM', async () => {
+    it('sets a secret value in the provider', async () => {
         secretsToCleanup.push({ env: 'dev', path: 'api/key' });
         await saveEnvironment(tmpDir, 'dev', {
             imports: [],
@@ -71,7 +72,7 @@ describe('set command (e2e against real AWS SM)', () => {
         expect(value).toBe('brand-new-value');
     });
 
-    it('propagates secret to child environments in AWS SM', async () => {
+    it('propagates secret to child environments', async () => {
         secretsToCleanup.push(
             { env: 'base', path: 'shared/token' },
             { env: 'staging', path: 'shared/token' }

--- a/test/e2e/set.e2e.test.ts
+++ b/test/e2e/set.e2e.test.ts
@@ -12,12 +12,14 @@ import { providerConfig, providerLabel, createTestProvider } from './provider-fi
 describe(`set command (e2e against ${providerLabel})`, () => {
     let tmpDir: string;
     let origCwd: string;
+    let configDir: string;
     let provider: SecretProvider;
     let secretsToCleanup: Array<{ env: string; path: string }>;
 
     beforeEach(() => {
         const projectName = `e2e-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
         tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'keyshelf-e2e-set-'));
+        configDir = path.join(tmpDir, '.config');
         origCwd = process.cwd();
         process.chdir(tmpDir);
         fs.mkdirSync(path.join(tmpDir, '.keyshelf', 'environments'), { recursive: true });
@@ -25,7 +27,7 @@ describe(`set command (e2e against ${providerLabel})`, () => {
             path.join(tmpDir, 'keyshelf.yml'),
             yaml.dump({ name: projectName, provider: providerConfig })
         );
-        provider = createTestProvider(projectName);
+        provider = createTestProvider(projectName, configDir);
         secretsToCleanup = [];
     });
 
@@ -49,7 +51,14 @@ describe(`set command (e2e against ${providerLabel})`, () => {
             values: { api: { key: new SecretRef('api/key') } }
         });
 
-        await SetCommand.run(['--env', 'dev', 'api/key', 'e2e-api-key-value']);
+        await SetCommand.run([
+            '--env',
+            'dev',
+            '--config-dir',
+            configDir,
+            'api/key',
+            'e2e-api-key-value'
+        ]);
 
         const value = await provider.get('dev', 'api/key');
         expect(value).toBe('e2e-api-key-value');
@@ -62,7 +71,14 @@ describe(`set command (e2e against ${providerLabel})`, () => {
             values: {}
         });
 
-        await SetCommand.run(['--env', 'dev', 'new/secret', 'brand-new-value']);
+        await SetCommand.run([
+            '--env',
+            'dev',
+            '--config-dir',
+            configDir,
+            'new/secret',
+            'brand-new-value'
+        ]);
 
         const envDef = await loadEnvironment(tmpDir, 'dev');
         const { new: newNode } = envDef.values as { new: { secret: unknown } };
@@ -86,7 +102,14 @@ describe(`set command (e2e against ${providerLabel})`, () => {
             values: {}
         });
 
-        await SetCommand.run(['--env', 'base', 'shared/token', 'propagated-e2e-value']);
+        await SetCommand.run([
+            '--env',
+            'base',
+            '--config-dir',
+            configDir,
+            'shared/token',
+            'propagated-e2e-value'
+        ]);
 
         const baseValue = await provider.get('base', 'shared/token');
         expect(baseValue).toBe('propagated-e2e-value');

--- a/test/e2e/up.e2e.test.ts
+++ b/test/e2e/up.e2e.test.ts
@@ -12,6 +12,7 @@ import { providerConfig, providerLabel, createTestProvider } from './provider-fi
 describe(`up command (e2e against ${providerLabel})`, () => {
     let tmpDir: string;
     let origCwd: string;
+    let configDir: string;
     let provider: SecretProvider;
     /** Tracks every {env, path} pair that might exist in the provider, for deterministic cleanup. */
     let secretsToCleanup: Array<{ env: string; path: string }>;
@@ -19,6 +20,7 @@ describe(`up command (e2e against ${providerLabel})`, () => {
     beforeEach(() => {
         const projectName = `e2e-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
         tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'keyshelf-e2e-up-'));
+        configDir = path.join(tmpDir, '.config');
         origCwd = process.cwd();
         process.chdir(tmpDir);
         fs.mkdirSync(path.join(tmpDir, '.keyshelf', 'environments'), { recursive: true });
@@ -26,7 +28,7 @@ describe(`up command (e2e against ${providerLabel})`, () => {
             path.join(tmpDir, 'keyshelf.yml'),
             yaml.dump({ name: projectName, provider: providerConfig })
         );
-        provider = createTestProvider(projectName);
+        provider = createTestProvider(projectName, configDir);
         secretsToCleanup = [];
     });
 
@@ -53,7 +55,7 @@ describe(`up command (e2e against ${providerLabel})`, () => {
         const secretsFile = path.join(tmpDir, 'secrets.env');
         fs.writeFileSync(secretsFile, 'db/password=e2e-secret-value\n');
 
-        await Up.run(['--apply', '--from-file', secretsFile]);
+        await Up.run(['--apply', '--config-dir', configDir, '--from-file', secretsFile]);
 
         const value = await provider.get('dev', 'db/password');
         expect(value).toBe('e2e-secret-value');
@@ -72,7 +74,7 @@ describe(`up command (e2e against ${providerLabel})`, () => {
         const secretsFile = path.join(tmpDir, 'secrets.env');
         fs.writeFileSync(secretsFile, '');
 
-        await Up.run(['--apply', '--from-file', secretsFile]);
+        await Up.run(['--apply', '--config-dir', configDir, '--from-file', secretsFile]);
 
         await expect(provider.get('dev', 'old/stale-key')).rejects.toThrow(
             /not found|marked for deletion/
@@ -96,7 +98,7 @@ describe(`up command (e2e against ${providerLabel})`, () => {
             values: { shared: { token: new SecretRef('shared/token') } }
         });
 
-        await Up.run(['--apply']);
+        await Up.run(['--apply', '--config-dir', configDir]);
 
         const value = await provider.get('dev', 'shared/token');
         expect(value).toBe('base-token-value');
@@ -112,7 +114,7 @@ describe(`up command (e2e against ${providerLabel})`, () => {
             values: { db: { password: new SecretRef('db/password') } }
         });
 
-        await Up.run(['--apply']);
+        await Up.run(['--apply', '--config-dir', configDir]);
 
         const value = await provider.get('dev', 'db/password');
         expect(value).toBe('already-set');

--- a/test/e2e/up.e2e.test.ts
+++ b/test/e2e/up.e2e.test.ts
@@ -5,14 +5,15 @@ import os from 'node:os';
 import yaml from 'js-yaml';
 import Up from '../../src/commands/up.js';
 import { saveEnvironment } from '../../src/core/environment.js';
-import { AwsSmProvider } from '../../src/providers/aws-sm.js';
 import { SecretRef } from '../../src/core/types.js';
+import { SecretProvider } from '../../src/providers/provider.js';
+import { providerConfig, providerLabel, createTestProvider } from './provider-fixture.js';
 
-describe('up command (e2e against real AWS SM)', () => {
+describe(`up command (e2e against ${providerLabel})`, () => {
     let tmpDir: string;
     let origCwd: string;
-    let provider: AwsSmProvider;
-    /** Tracks every {env, path} pair that might exist in AWS SM, for deterministic cleanup. */
+    let provider: SecretProvider;
+    /** Tracks every {env, path} pair that might exist in the provider, for deterministic cleanup. */
     let secretsToCleanup: Array<{ env: string; path: string }>;
 
     beforeEach(() => {
@@ -23,9 +24,9 @@ describe('up command (e2e against real AWS SM)', () => {
         fs.mkdirSync(path.join(tmpDir, '.keyshelf', 'environments'), { recursive: true });
         fs.writeFileSync(
             path.join(tmpDir, 'keyshelf.yml'),
-            yaml.dump({ name: projectName, provider: { adapter: 'aws-sm' } })
+            yaml.dump({ name: projectName, provider: providerConfig })
         );
-        provider = new AwsSmProvider({ name: projectName });
+        provider = createTestProvider(projectName);
         secretsToCleanup = [];
     });
 
@@ -42,7 +43,7 @@ describe('up command (e2e against real AWS SM)', () => {
         }
     });
 
-    it('creates new secrets in AWS SM', async () => {
+    it('creates new secrets in the provider', async () => {
         secretsToCleanup.push({ env: 'dev', path: 'db/password' });
         await saveEnvironment(tmpDir, 'dev', {
             imports: [],
@@ -58,7 +59,7 @@ describe('up command (e2e against real AWS SM)', () => {
         expect(value).toBe('e2e-secret-value');
     });
 
-    it('deletes stale secrets from AWS SM', async () => {
+    it('deletes stale secrets from the provider', async () => {
         secretsToCleanup.push({ env: 'dev', path: 'old/stale-key' });
         await provider.set('dev', 'old/stale-key', 'stale-value');
         await waitForSecretInList(provider, 'dev', 'old/stale-key');
@@ -119,7 +120,7 @@ describe('up command (e2e against real AWS SM)', () => {
 });
 
 async function waitForSecretInList(
-    provider: AwsSmProvider,
+    provider: SecretProvider,
     env: string,
     secretPath: string,
     timeoutMs = 30_000


### PR DESCRIPTION
## Summary
- Add e2e tests for `set`, `get`, and `print` commands
- Extract provider setup into a shared fixture (`provider-fixture.ts`) so the same tests run against any provider
- Pass `--config-dir` to all command invocations for local provider isolation

## Usage
```bash
# Default (aws-sm)
npm run test:e2e

# GCP Secret Manager
KEYSHELF_E2E_PROVIDER=gcp-sm KEYSHELF_E2E_GCP_PROJECT=my-project npm run test:e2e

# Local (no cloud credentials needed)
KEYSHELF_E2E_PROVIDER=local npm run test:e2e
```

## Test plan
- [x] All 12 tests pass against `aws-sm`
- [x] All 12 tests pass against `gcp-sm` (staging-480220), zero secrets left behind
- [x] All 12 tests pass against `local` provider (110ms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)