### PR TITLE
feat: set only updates provider values, does not mutate YAML

### DIFF
--- a/src/commands/set.ts
+++ b/src/commands/set.ts
@@ -1,9 +1,9 @@
 import { Args, Command, Flags } from '@oclif/core';
-import { loadEnvironment, saveEnvironment, listEnvironments } from '../core/environment.js';
+import { loadEnvironment, listEnvironments } from '../core/environment.js';
 import { loadConfig, defaultConfigDir } from '../core/config.js';
 import { resolve } from '../core/resolver.js';
 import { PathTree } from '../core/path-tree.js';
-import { SecretRef, EnvironmentDefinition } from '../core/types.js';
+import { SecretRef } from '../core/types.js';
 import { resolveProvider } from '../providers/index.js';
 import { readMaskedLine } from '../core/input.js';
 import { topoSort } from '../core/reconciler/topo-sort.js';
@@ -35,7 +35,13 @@ export default class SetCommand extends Command {
         const resolvedTree = PathTree.fromJSON(resolved.values);
         const existing = resolvedTree.get(args.path);
 
-        await this.ensureSecretRef(cwd, envName, args.path, existing);
+        if (!(existing instanceof SecretRef)) {
+            const msg =
+                existing === undefined
+                    ? `Path "${args.path}" not found in environment "${envName}". Add it to your YAML config and run "keyshelf up" first.`
+                    : `Path "${args.path}" in environment "${envName}" is a plain value, not a secret reference. Change it to a !secret tag and run "keyshelf up" first.`;
+            this.error(msg);
+        }
 
         const value = args.value ?? (await readMaskedLine(`Enter value for "${args.path}": `));
 
@@ -46,35 +52,6 @@ export default class SetCommand extends Command {
         await provider.set(envName, args.path, value);
 
         await this.propagateToImporters(cwd, envName, args.path, value, config, configDir);
-    }
-
-    private async ensureSecretRef(
-        cwd: string,
-        envName: string,
-        secretPath: string,
-        existing: unknown
-    ): Promise<void> {
-        if (existing instanceof SecretRef) return;
-
-        if (existing !== undefined) {
-            process.stderr.write(
-                `Warning: Overwriting plain value at ${secretPath} with a secret reference\n`
-            );
-        }
-
-        await this.addSecretRefToEnv(cwd, envName, secretPath);
-    }
-
-    private async addSecretRefToEnv(
-        cwd: string,
-        envName: string,
-        secretPath: string
-    ): Promise<void> {
-        const envDef = await loadEnvironment(cwd, envName);
-        const tree = PathTree.fromJSON(envDef.values);
-        tree.set(secretPath, new SecretRef(secretPath));
-        const updated: EnvironmentDefinition = { ...envDef, values: tree.toJSON() };
-        await saveEnvironment(cwd, envName, updated);
     }
 
     private async propagateToImporters(

--- a/test/commands/set.test.ts
+++ b/test/commands/set.test.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import os from 'node:os';
 import yaml from 'js-yaml';
 import SetCommand from '../../src/commands/set.js';
-import { saveEnvironment, loadEnvironment } from '../../src/core/environment.js';
+import { saveEnvironment } from '../../src/core/environment.js';
 import { LocalProvider } from '../../src/providers/local.js';
 import { SecretRef } from '../../src/core/types.js';
 import * as inputModule from '../../src/core/input.js';
@@ -55,58 +55,40 @@ describe('set command', () => {
         expect(stored).toBe('mysecret');
     });
 
-    it('creates SecretRef in YAML when path does not exist, then sets value', async () => {
+    it('errors when path does not exist in config', async () => {
         await saveEnvironment(tmpDir, 'dev', {
             imports: [],
             values: {}
         });
 
-        await SetCommand.run([
-            '--env',
-            'dev',
-            'database/password',
-            'newpassword',
-            '--config-dir',
-            configDir
-        ]);
-
-        const envDef = await loadEnvironment(tmpDir, 'dev');
-        const { database } = envDef.values as { database: { password: unknown } };
-        expect(database.password).toBeInstanceOf(SecretRef);
-
-        const provider = new LocalProvider(configDir);
-        const stored = await provider.get('dev', 'database/password');
-        expect(stored).toBe('newpassword');
+        await expect(
+            SetCommand.run([
+                '--env',
+                'dev',
+                'database/password',
+                'newpassword',
+                '--config-dir',
+                configDir
+            ])
+        ).rejects.toThrow(/Path "database\/password" not found in environment "dev"/);
     });
 
-    it('warns and overwrites when path is a plain value', async () => {
+    it('errors when path is a plain value, not a secret', async () => {
         await saveEnvironment(tmpDir, 'dev', {
             imports: [],
             values: { database: { password: 'plain-text' } }
         });
 
-        const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
-
-        await SetCommand.run([
-            '--env',
-            'dev',
-            'database/password',
-            'newvalue',
-            '--config-dir',
-            configDir
-        ]);
-
-        expect(stderrSpy).toHaveBeenCalledWith(
-            expect.stringContaining('Overwriting plain value at database/password')
-        );
-
-        const envDef = await loadEnvironment(tmpDir, 'dev');
-        const { database } = envDef.values as { database: { password: unknown } };
-        expect(database.password).toBeInstanceOf(SecretRef);
-
-        const provider = new LocalProvider(configDir);
-        const stored = await provider.get('dev', 'database/password');
-        expect(stored).toBe('newvalue');
+        await expect(
+            SetCommand.run([
+                '--env',
+                'dev',
+                'database/password',
+                'newvalue',
+                '--config-dir',
+                configDir
+            ])
+        ).rejects.toThrow(/plain value, not a secret reference/);
     });
 
     it('propagates to child environments that import the target env', async () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
     test: {
         globals: true,
         root: '.',
-        exclude: ['test/e2e/**', 'node_modules/**'],
+        exclude: ['test/e2e/**', 'node_modules/**', '.claude/worktrees/**'],
         coverage: {
             provider: 'v8',
             reporter: ['text', 'lcov', 'clover', 'json'],


### PR DESCRIPTION
## Summary

- `keyshelf set` no longer adds `!secret` refs or modifies YAML files — that's `keyshelf up`'s responsibility
- If the path doesn't exist or is a plain value, the command now errors with an actionable message guiding the user to update YAML and run `keyshelf up`
- Excludes `.claude/worktrees/**` from vitest to prevent stale worktree tests from running

## Test plan

- [x] `npm run build` passes
- [x] All 274 tests pass (`npm run test`)
- [x] `npm run lint` passes
- [x] Verified error when path does not exist in config
- [x] Verified error when path is a plain value, not a secret ref
- [x] Verified happy path (existing SecretRef) still works
- [x] Verified propagation to child environments still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)