### PR TITLE
feat!: move env var mapping to consumer-side .env.keyshelf

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,4 +33,5 @@ npm run format:check # prettier --check .
 - Tests in `test/` mirroring `src/` structure, using vitest (`describe`/`it`/`expect`)
 - Config values live in version-controlled YAML; secrets live in external providers
 - YAML files reference secrets via `!secret` custom tags (safe to commit)
+- Env var mappings live in `.env.keyshelf` (consumer-side), not in environment YAML
 - Secret values must never appear in error messages, logs, or stack traces

--- a/README.md
+++ b/README.md
@@ -56,7 +56,11 @@ keyshelf up
 # 9. Apply the reconciliation plan interactively
 keyshelf up --apply
 
-# 10. Run a process with config and secrets injected as env vars
+# 10. Create a .env.keyshelf file to map paths to env var names
+#     echo "DATABASE_HOST=database/host" >> .env.keyshelf
+#     echo "DATABASE_PASSWORD=database/password" >> .env.keyshelf
+
+# 11. Run a process with config and secrets injected as env vars
 keyshelf run --env dev -- node server.js
 ```
 
@@ -121,27 +125,20 @@ A provider is the backend that stores secret values. The provider is declared in
 | `gcp-sm` | GCP Secret Manager                          | Application Default Credentials |
 | `aws-sm` | AWS Secrets Manager                         | Standard AWS credential chain   |
 
-### The `env` Mapping
+### The `.env.keyshelf` Mapping
 
-The `env` field in an environment file defines how paths map to environment variable names. It is bidirectional: when running `keyshelf run` or using the preload module, keyshelf uses this mapping to produce the exact variable names your application expects.
+The `.env.keyshelf` file lives in the project root and defines how keyshelf paths map to environment variable names. This mapping belongs to the consumer (your app), not to the environment definition.
 
-```yaml
-env:
-    DATABASE_HOST: database/host
-    DATABASE_PASSWORD: database/password
-    REDIS_URL: cache/redis/url
-values:
-    database:
-        host: localhost
-        password: !secret database/password
-    cache:
-        redis:
-            url: redis://localhost:6379
+```bash
+# .env.keyshelf
+DATABASE_HOST=database/host
+DATABASE_PASSWORD=database/password
+REDIS_URL=cache/redis/url
 ```
 
-When `env` is defined, **only** the mapped variables are exported. When `env` is absent, all leaf values are exported using auto-generated `UPPER_SNAKE_CASE` names derived from the path (`database/host` becomes `DATABASE_HOST`).
+When `keyshelf run`, `keyshelf print --format env`, or the preload module is used, only the variables listed in `.env.keyshelf` are exported. If the file is absent, no environment variables are injected (a warning is shown).
 
-The `env` mapping is also used by `keyshelf up --from-env`: keyshelf collects mappings across all environments and looks up each secret path by its mapped variable name.
+The mapping is also used by `keyshelf up --from-env`: keyshelf reverse-looks up each secret path by its mapped variable name in the current process environment.
 
 ---
 
@@ -150,6 +147,7 @@ The `env` mapping is also used by `keyshelf up --from-env`: keyshelf collects ma
 ```
 myproject/
 ├── keyshelf.yml                          # Project-level config
+├── .env.keyshelf                         # Env var name → path mapping (consumer-side)
 └── .keyshelf/
     └── environments/
         ├── base.yml                      # Shared base config
@@ -196,12 +194,6 @@ imports:
 provider:
     adapter: gcp-sm
     project: my-prod-project
-
-# Optional: explicit env var name to path mapping
-env:
-    DATABASE_HOST: database/host
-    DATABASE_PASSWORD: database/password
-    APP_SECRET_KEY: app/secret-key
 
 # Required: values for this environment
 values:
@@ -370,7 +362,7 @@ keyshelf print --env dev
 # Print with secrets revealed
 keyshelf print --env dev --reveal
 
-# Print as shell-sourceable KEY=VALUE pairs (requires --reveal for secret values)
+# Print as shell-sourceable KEY=VALUE pairs (uses .env.keyshelf mapping)
 keyshelf print --env dev --format env --reveal
 
 # Print as JSON with secrets split into a separate object (no --reveal)
@@ -386,7 +378,7 @@ When `--format json` is used without `--reveal`, the output is an object with tw
 
 ### `keyshelf run`
 
-Run a command with the resolved environment injected as process environment variables. Resolves secrets from the provider and merges with the current `process.env`.
+Run a command with the resolved environment injected as process environment variables. Requires a `.env.keyshelf` file in the project root to define which paths map to which env var names. Resolves secrets from the provider and merges with the current `process.env`.
 
 ```
 USAGE
@@ -534,7 +526,7 @@ keyshelf up --apply --from-env
 keyshelf up --apply --from-file secrets.env
 ```
 
-`--from-env` works by collecting the `env` mappings from all environment files and looking up each secret path by its corresponding variable name. Ensure the variables are set in the calling shell before running this.
+`--from-env` uses the `.env.keyshelf` mapping to reverse-look up each secret path by its corresponding variable name. Ensure the variables are set in the calling shell before running this.
 
 ### Running processes with secrets
 

--- a/src/commands/print.ts
+++ b/src/commands/print.ts
@@ -7,6 +7,7 @@ import { replaceSecrets, flattenToEnvRecord } from '../core/env-vars.js';
 import { SecretRef } from '../core/types.js';
 import { SecretProvider } from '../providers/provider.js';
 import { resolveProvider } from '../providers/index.js';
+import { loadEnvMapping } from '../core/env-keyshelf.js';
 
 export default class Print extends Command {
     static override description = 'Print resolved environment config';
@@ -60,7 +61,13 @@ export default class Print extends Command {
                 this.log(JSON.stringify(output, null, 2));
                 break;
             case 'env': {
-                const record = flattenToEnvRecord(output, envDef.env);
+                const envMapping = loadEnvMapping(cwd);
+                if (Object.keys(envMapping).length === 0) {
+                    this.warn(
+                        'No .env.keyshelf file found — no environment variables will be injected.'
+                    );
+                }
+                const record = flattenToEnvRecord(output, envMapping);
                 for (const [key, value] of Object.entries(record)) {
                     this.log(`${key}=${value}`);
                 }

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,6 +1,7 @@
 import { Command, Flags } from '@oclif/core';
 import { spawnSync } from 'node:child_process';
 import { resolveEnv } from '../core/resolve-env.js';
+import { loadEnvMapping } from '../core/env-keyshelf.js';
 
 export default class Run extends Command {
     static override description =
@@ -27,10 +28,15 @@ export default class Run extends Command {
         }
 
         const projectDir = process.cwd();
+        const envMapping = loadEnvMapping(projectDir);
+        if (Object.keys(envMapping).length === 0) {
+            this.warn('No .env.keyshelf file found — no environment variables will be injected.');
+        }
         const envRecord = await resolveEnv({
             env: flags.env,
             projectDir,
-            configDir: flags['config-dir']
+            configDir: flags['config-dir'],
+            envMapping
         });
 
         const [cmd, ...args] = command;

--- a/src/commands/up.ts
+++ b/src/commands/up.ts
@@ -12,6 +12,7 @@ import { applyEnvironmentPlan } from '../core/reconciler/apply.js';
 import { makeCollector } from '../core/reconciler/input.js';
 import { renderPlan } from '../core/reconciler/render.js';
 import { parseEnvFile } from '../core/env-file.js';
+import { loadEnvMapping } from '../core/env-keyshelf.js';
 import { ReconciliationPlan, EnvironmentPlan } from '../core/reconciler/types.js';
 
 export default class Up extends Command {
@@ -56,7 +57,7 @@ export default class Up extends Command {
         const sortedNames = topoSort(
             Object.fromEntries(envNames.map((n) => [n, { imports: envDefs.get(n)!.imports }]))
         );
-        const ctx: PlanContext = { envDefs, config, configDir };
+        const ctx: PlanContext = { envDefs, config, configDir, cwd };
         const plan = await buildReconciliationPlan(ctx, sortedNames);
 
         this.log(renderPlan(plan));
@@ -81,7 +82,7 @@ export default class Up extends Command {
             return;
         }
 
-        const collector = await buildCollector(flags['from-env'], flags['from-file'], ctx.envDefs);
+        const collector = await buildCollector(flags['from-env'], flags['from-file'], ctx.cwd);
 
         for (const envPlan of plan.environments) {
             if (envPlan.secretChanges.length === 0) continue;
@@ -120,6 +121,7 @@ interface PlanContext {
     envDefs: Map<string, EnvironmentDefinition>;
     config: KeyshelfConfig;
     configDir: string;
+    cwd: string;
 }
 
 async function buildReconciliationPlan(
@@ -185,7 +187,7 @@ async function confirmApply(): Promise<boolean> {
 async function buildCollector(
     fromEnv: boolean,
     fromFile: string | undefined,
-    envDefs: Map<string, EnvironmentDefinition>
+    cwd: string
 ): Promise<(path: string) => Promise<string>> {
     if (fromFile) {
         const content = await fs.readFile(fromFile, 'utf-8');
@@ -194,21 +196,9 @@ async function buildCollector(
     }
 
     if (fromEnv) {
-        const mapping = buildCombinedEnvMapping(envDefs);
+        const mapping = loadEnvMapping(cwd);
         return makeCollector({ kind: 'env', mapping });
     }
 
     return makeCollector({ kind: 'prompt' });
-}
-
-function buildCombinedEnvMapping(
-    envDefs: Map<string, EnvironmentDefinition>
-): Record<string, string> {
-    const combined: Record<string, string> = {};
-    for (const def of envDefs.values()) {
-        if (def.env) {
-            Object.assign(combined, def.env);
-        }
-    }
-    return combined;
 }

--- a/src/core/env-keyshelf.ts
+++ b/src/core/env-keyshelf.ts
@@ -1,0 +1,20 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { parseEnvFile } from './env-file.js';
+
+export const ENV_KEYSHELF_FILENAME = '.env.keyshelf';
+
+/**
+ * Load env var mappings from a .env.keyshelf file in the project root.
+ * Returns an empty record if the file does not exist.
+ *
+ * @param projectDir - Path to the project root directory
+ * @returns Record mapping env var names to slash-delimited value paths
+ */
+export function loadEnvMapping(projectDir: string): Record<string, string> {
+    const filePath = path.join(projectDir, ENV_KEYSHELF_FILENAME);
+    if (!fs.existsSync(filePath)) {
+        return {};
+    }
+    return parseEnvFile(fs.readFileSync(filePath, 'utf-8'));
+}

--- a/src/core/env-vars.ts
+++ b/src/core/env-vars.ts
@@ -51,53 +51,26 @@ export function lookupPath(obj: Record<string, unknown>, path: string): unknown 
 }
 
 /**
- * Flatten a nested object to a flat Record<string, string>.
+ * Flatten a nested object to a flat Record<string, string> using an explicit mapping.
  *
- * When envMapping is provided, only the mapped variables are returned,
- * with values resolved by path from the object. When absent, all keys
- * are uppercased and underscore-separated.
+ * Only the mapped variables are returned, with values resolved by path from the object.
  *
  * @param obj - The nested object to flatten
- * @param envMapping - Optional mapping of env var name to slash-delimited path
+ * @param envMapping - Mapping of env var name to slash-delimited path
  */
 export function flattenToEnvRecord(
-    obj: Record<string, unknown>,
-    envMapping?: Record<string, string>
-): Record<string, string> {
-    if (envMapping) {
-        return flattenWithMapping(obj, envMapping);
-    }
-    return flattenGeneric(obj);
-}
-
-function flattenWithMapping(
     obj: Record<string, unknown>,
     envMapping: Record<string, string>
 ): Record<string, string> {
     const result: Record<string, string> = {};
-    for (const [varName, path] of Object.entries(envMapping)) {
-        const value = lookupPath(obj, path);
+    for (const [varName, valuePath] of Object.entries(envMapping)) {
+        const value = lookupPath(obj, valuePath);
         if (value === undefined) {
             throw new Error(
-                `Env mapping "${varName}" references path "${path}" which does not exist in resolved values.`
+                `Env mapping "${varName}" references path "${valuePath}" which does not exist in resolved values.`
             );
         }
         result[varName] = String(value);
     }
-    return result;
-}
-
-function flattenGeneric(obj: Record<string, unknown>, prefix = ''): Record<string, string> {
-    const result: Record<string, string> = {};
-
-    for (const [key, value] of Object.entries(obj)) {
-        const envKey = prefix ? `${prefix}_${key}` : key;
-        if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
-            Object.assign(result, flattenGeneric(value as Record<string, unknown>, envKey));
-        } else {
-            result[envKey.toUpperCase()] = String(value);
-        }
-    }
-
     return result;
 }

--- a/src/core/reconciler/input.ts
+++ b/src/core/reconciler/input.ts
@@ -38,7 +38,7 @@ function makeEnvCollector(mapping: Record<string, string>): (path: string) => Pr
         const varName = reverseMapping.get(path);
         if (!varName) {
             throw new Error(
-                `No env var mapped to secret path "${path}". Add it to the env section.`
+                `No env var mapped to secret path "${path}". Add a mapping to .env.keyshelf.`
             );
         }
         const value = process.env[varName];

--- a/src/core/resolve-env.ts
+++ b/src/core/resolve-env.ts
@@ -9,6 +9,7 @@ interface ResolveEnvOptions {
     env: string;
     projectDir: string;
     configDir?: string;
+    envMapping: Record<string, string>;
 }
 
 /**
@@ -17,10 +18,11 @@ interface ResolveEnvOptions {
  * @param options.env - Environment name to resolve
  * @param options.projectDir - Path to project root containing keyshelf.yml
  * @param options.configDir - Override for the provider config directory
- * @returns Flat record of uppercased env var names to string values
+ * @param options.envMapping - Mapping of env var names to slash-delimited value paths
+ * @returns Flat record of env var names to string values
  */
 export async function resolveEnv(options: ResolveEnvOptions): Promise<Record<string, string>> {
-    const { env, projectDir } = options;
+    const { env, projectDir, envMapping } = options;
     const cache = new Map<string, EnvironmentDefinition>();
     const loadFn = async (name: string) => {
         const cached = cache.get(name);
@@ -36,5 +38,5 @@ export async function resolveEnv(options: ResolveEnvOptions): Promise<Record<str
     const configDir = options.configDir ?? defaultConfigDir(config);
     const provider = resolveProvider(envDef, config, configDir);
     const replaced = await replaceSecrets(resolved.values, env, provider, 'reveal');
-    return flattenToEnvRecord(replaced, envDef.env);
+    return flattenToEnvRecord(replaced, envMapping);
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -7,7 +7,6 @@ export class SecretRef {
 export interface EnvironmentDefinition {
     imports: string[];
     provider?: ProviderConfig;
-    env?: Record<string, string>;
     values: Record<string, unknown>;
 }
 

--- a/src/core/yaml.ts
+++ b/src/core/yaml.ts
@@ -26,9 +26,7 @@ export function parseEnvironment(content: string): EnvironmentDefinition {
         provider = parseProviderConfig(doc.provider as Record<string, unknown>, 'environment file');
     }
 
-    const env = doc.env as Record<string, string> | undefined;
-
-    return { imports, provider, env, values };
+    return { imports, provider, values };
 }
 
 /** Serialize an EnvironmentDefinition to YAML with !secret tags preserved. */
@@ -39,9 +37,6 @@ export function serializeEnvironment(def: EnvironmentDefinition): string {
     }
     if (def.provider) {
         doc.provider = def.provider;
-    }
-    if (def.env) {
-        doc.env = def.env;
     }
     doc.values = def.values;
     return yaml.dump(doc, { schema: SCHEMA });

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -1,4 +1,5 @@
 import { resolveEnv } from './core/resolve-env.js';
+import { loadEnvMapping } from './core/env-keyshelf.js';
 
 const env = process.env.KEYSHELF_ENV;
 if (!env) {
@@ -7,7 +8,8 @@ if (!env) {
 
 const projectDir = process.env.KEYSHELF_PROJECT_DIR ?? process.cwd();
 const configDir = process.env.KEYSHELF_CONFIG_DIR;
-const envRecord = await resolveEnv({ env, projectDir, configDir });
+const envMapping = loadEnvMapping(projectDir);
+const envRecord = await resolveEnv({ env, projectDir, configDir, envMapping });
 
 for (const [key, value] of Object.entries(envRecord)) {
     process.env[key] = value;

--- a/test/commands/print.test.ts
+++ b/test/commands/print.test.ts
@@ -167,6 +167,10 @@ describe('print command', () => {
             imports: [],
             values: { database: { host: 'localhost', port: 5432 } }
         });
+        fs.writeFileSync(
+            path.join(tmpDir, '.env.keyshelf'),
+            'DATABASE_HOST=database/host\nDATABASE_PORT=database/port\n'
+        );
 
         await Print.run(['--env', 'dev', '--format', 'env', '--config-dir', configDir]);
 
@@ -185,6 +189,10 @@ describe('print command', () => {
                 api: { key: new SecretRef('api/key') }
             }
         });
+        fs.writeFileSync(
+            path.join(tmpDir, '.env.keyshelf'),
+            'DATABASE_HOST=database/host\nAPI_KEY=api/key\n'
+        );
 
         await Print.run(['--env', 'dev', '--format', 'env', '--config-dir', configDir]);
 
@@ -192,6 +200,21 @@ describe('print command', () => {
         expect(output).toContain('DATABASE_HOST=localhost');
         expect(output).toContain('API_KEY=api/key');
         expect(output).not.toContain('secret-key');
+    });
+
+    it('--format env warns when no .env.keyshelf file is present', async () => {
+        await saveEnvironment(tmpDir, 'dev', {
+            imports: [],
+            values: { key: 'val' }
+        });
+        const warnSpy = vi.fn();
+        vi.spyOn(Print.prototype, 'warn').mockImplementation(warnSpy);
+
+        await Print.run(['--env', 'dev', '--format', 'env', '--config-dir', configDir]);
+
+        expect(warnSpy).toHaveBeenCalledWith(
+            'No .env.keyshelf file found — no environment variables will be injected.'
+        );
     });
 
     it('uses env-level provider over global config', async () => {

--- a/test/commands/run.test.ts
+++ b/test/commands/run.test.ts
@@ -38,6 +38,10 @@ describe('run command', () => {
             imports: [],
             values: { database: { host: 'localhost', port: 5432 } }
         });
+        fs.writeFileSync(
+            path.join(tmpDir, '.env.keyshelf'),
+            'DATABASE_HOST=database/host\nDATABASE_PORT=database/port\n'
+        );
 
         const exitSpy = vi.spyOn(Run.prototype, 'exit').mockImplementation(() => {
             throw new Error('EXIT');
@@ -60,6 +64,7 @@ describe('run command', () => {
                 api: { key: new SecretRef('api/key'), url: 'https://api.example.com' }
             }
         });
+        fs.writeFileSync(path.join(tmpDir, '.env.keyshelf'), 'API_KEY=api/key\nAPI_URL=api/url\n');
 
         const exitSpy = vi.spyOn(Run.prototype, 'exit').mockImplementation(() => {
             throw new Error('EXIT');
@@ -78,6 +83,7 @@ describe('run command', () => {
             imports: [],
             values: { app: 'myapp' }
         });
+        fs.writeFileSync(path.join(tmpDir, '.env.keyshelf'), 'APP=app\n');
 
         const exitSpy = vi.spyOn(Run.prototype, 'exit').mockImplementation(() => {
             throw new Error('EXIT');
@@ -96,6 +102,7 @@ describe('run command', () => {
             imports: [],
             values: { key: 'val' }
         });
+        fs.writeFileSync(path.join(tmpDir, '.env.keyshelf'), 'KEY=key\n');
 
         const exitSpy = vi.spyOn(Run.prototype, 'exit').mockImplementation(() => {
             throw new Error('EXIT');
@@ -113,6 +120,27 @@ describe('run command', () => {
         ]);
 
         expect(exitSpy).toHaveBeenCalledWith(42);
+    });
+
+    it('warns when no .env.keyshelf file is present', async () => {
+        await saveEnvironment(tmpDir, 'dev', {
+            imports: [],
+            values: { key: 'val' }
+        });
+
+        const warnSpy = vi.spyOn(Run.prototype, 'warn').mockImplementation(() => {
+            return undefined as never;
+        });
+        const exitSpy = vi.spyOn(Run.prototype, 'exit').mockImplementation(() => {
+            throw new Error('EXIT');
+        });
+
+        await runAndCatch(['--env', 'dev', '--config-dir', configDir, '--', 'node', '-e', '1']);
+
+        expect(warnSpy).toHaveBeenCalledWith(
+            'No .env.keyshelf file found — no environment variables will be injected.'
+        );
+        expect(exitSpy).toHaveBeenCalledWith(0);
     });
 
     it('errors when no command is provided after --', async () => {
@@ -141,6 +169,7 @@ describe('run command', () => {
             imports: ['base'],
             values: { local: 'from-dev' }
         });
+        fs.writeFileSync(path.join(tmpDir, '.env.keyshelf'), 'SHARED=shared\nLOCAL=local\n');
 
         const exitSpy = vi.spyOn(Run.prototype, 'exit').mockImplementation(() => {
             throw new Error('EXIT');

--- a/test/commands/up.test.ts
+++ b/test/commands/up.test.ts
@@ -156,9 +156,9 @@ describe('up command', () => {
     it('applies new secret from --from-env flag', async () => {
         await saveEnvironment(tmpDir, 'dev', {
             imports: [],
-            env: { MY_DB_PASS: 'db/password' },
             values: { db: { password: new SecretRef('db/password') } }
         });
+        fs.writeFileSync(path.join(tmpDir, '.env.keyshelf'), 'MY_DB_PASS=db/password\n');
 
         const origEnv = process.env;
         process.env = { ...origEnv, MY_DB_PASS: 'env-secret-value' };

--- a/test/core/env-keyshelf.test.ts
+++ b/test/core/env-keyshelf.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { loadEnvMapping, ENV_KEYSHELF_FILENAME } from '../../src/core/env-keyshelf.js';
+
+describe('loadEnvMapping', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'keyshelf-env-keyshelf-'));
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('returns parsed mappings when file exists', () => {
+        fs.writeFileSync(
+            path.join(tmpDir, ENV_KEYSHELF_FILENAME),
+            'DATABASE_URL=database/url\nAPI_KEY=api/key\n'
+        );
+
+        const result = loadEnvMapping(tmpDir);
+
+        expect(result).toEqual({ DATABASE_URL: 'database/url', API_KEY: 'api/key' });
+    });
+
+    it('returns empty record when file does not exist', () => {
+        const result = loadEnvMapping(tmpDir);
+
+        expect(result).toEqual({});
+    });
+
+    it('handles comments and blank lines', () => {
+        fs.writeFileSync(
+            path.join(tmpDir, ENV_KEYSHELF_FILENAME),
+            '# This is a comment\n\nDATABASE_URL=database/url\n\n# Another comment\nAPI_KEY=api/key\n'
+        );
+
+        const result = loadEnvMapping(tmpDir);
+
+        expect(result).toEqual({ DATABASE_URL: 'database/url', API_KEY: 'api/key' });
+    });
+
+    it('strips surrounding quotes from values', () => {
+        fs.writeFileSync(
+            path.join(tmpDir, ENV_KEYSHELF_FILENAME),
+            'MY_VAR="some/path"\nOTHER_VAR=\'other/path\'\n'
+        );
+
+        const result = loadEnvMapping(tmpDir);
+
+        expect(result).toEqual({ MY_VAR: 'some/path', OTHER_VAR: 'other/path' });
+    });
+});

--- a/test/core/env-vars.test.ts
+++ b/test/core/env-vars.test.ts
@@ -78,79 +78,47 @@ describe('lookupPath', () => {
 });
 
 describe('flattenToEnvRecord', () => {
-    it('flattens nested objects with underscore separator and uppercased keys', () => {
+    it('returns only mapped variables', () => {
+        const obj = { database: { host: 'localhost', port: 5432 }, api: { key: 'abc' } };
+        const mapping = { DB_HOST: 'database/host', API_KEY: 'api/key' };
+
+        const result = flattenToEnvRecord(obj, mapping);
+
+        expect(result).toEqual({ DB_HOST: 'localhost', API_KEY: 'abc' });
+    });
+
+    it('converts mapped values to strings', () => {
+        const obj = { db: { port: 5432 } };
+        const mapping = { DB_PORT: 'db/port' };
+
+        const result = flattenToEnvRecord(obj, mapping);
+
+        expect(result).toEqual({ DB_PORT: '5432' });
+    });
+
+    it('uses exact var names from mapping without uppercasing', () => {
+        const obj = { api: { url: 'https://example.com' } };
+        const mapping = { my_custom_var: 'api/url' };
+
+        const result = flattenToEnvRecord(obj, mapping);
+
+        expect(result).toEqual({ my_custom_var: 'https://example.com' });
+    });
+
+    it('returns empty record when mapping is empty', () => {
         const obj = { database: { host: 'localhost', port: 5432 } };
 
-        const result = flattenToEnvRecord(obj);
+        const result = flattenToEnvRecord(obj, {});
 
-        expect(result).toEqual({
-            DATABASE_HOST: 'localhost',
-            DATABASE_PORT: '5432'
-        });
+        expect(result).toEqual({});
     });
 
-    it('handles flat objects', () => {
-        const obj = { name: 'myapp', version: '1.0' };
+    it('throws when mapping references a non-existent path', () => {
+        const obj = { api: {} };
+        const mapping = { MISSING: 'api/key' };
 
-        const result = flattenToEnvRecord(obj);
-
-        expect(result).toEqual({
-            NAME: 'myapp',
-            VERSION: '1.0'
-        });
-    });
-
-    it('handles deeply nested objects', () => {
-        const obj = { a: { b: { c: 'deep' } } };
-
-        const result = flattenToEnvRecord(obj);
-
-        expect(result).toEqual({ A_B_C: 'deep' });
-    });
-
-    it('converts all values to strings', () => {
-        const obj = { count: 42, enabled: true };
-
-        const result = flattenToEnvRecord(obj);
-
-        expect(result).toEqual({ COUNT: '42', ENABLED: 'true' });
-    });
-
-    describe('with envMapping', () => {
-        it('returns only mapped variables', () => {
-            const obj = { database: { host: 'localhost', port: 5432 }, api: { key: 'abc' } };
-            const mapping = { DB_HOST: 'database/host', API_KEY: 'api/key' };
-
-            const result = flattenToEnvRecord(obj, mapping);
-
-            expect(result).toEqual({ DB_HOST: 'localhost', API_KEY: 'abc' });
-        });
-
-        it('converts mapped values to strings', () => {
-            const obj = { db: { port: 5432 } };
-            const mapping = { DB_PORT: 'db/port' };
-
-            const result = flattenToEnvRecord(obj, mapping);
-
-            expect(result).toEqual({ DB_PORT: '5432' });
-        });
-
-        it('uses exact var names from mapping without uppercasing', () => {
-            const obj = { api: { url: 'https://example.com' } };
-            const mapping = { my_custom_var: 'api/url' };
-
-            const result = flattenToEnvRecord(obj, mapping);
-
-            expect(result).toEqual({ my_custom_var: 'https://example.com' });
-        });
-
-        it('throws when mapping references a non-existent path', () => {
-            const obj = { api: {} };
-            const mapping = { MISSING: 'api/key' };
-
-            expect(() => flattenToEnvRecord(obj, mapping)).toThrow(
-                /Env mapping "MISSING" references path "api\/key" which does not exist/
-            );
-        });
+        expect(() => flattenToEnvRecord(obj, mapping)).toThrow(
+            /Env mapping "MISSING" references path "api\/key" which does not exist/
+        );
     });
 });

--- a/test/core/resolve-env.test.ts
+++ b/test/core/resolve-env.test.ts
@@ -32,7 +32,12 @@ describe('resolveEnv', () => {
             values: { database: { host: 'localhost', port: 5432 } }
         });
 
-        const result = await resolveEnv({ env: 'dev', projectDir: tmpDir, configDir });
+        const result = await resolveEnv({
+            env: 'dev',
+            projectDir: tmpDir,
+            configDir,
+            envMapping: { DATABASE_HOST: 'database/host', DATABASE_PORT: 'database/port' }
+        });
 
         expect(result).toEqual({
             DATABASE_HOST: 'localhost',
@@ -51,7 +56,12 @@ describe('resolveEnv', () => {
             }
         });
 
-        const result = await resolveEnv({ env: 'prod', projectDir: tmpDir, configDir });
+        const result = await resolveEnv({
+            env: 'prod',
+            projectDir: tmpDir,
+            configDir,
+            envMapping: { API_KEY: 'api/key', API_URL: 'api/url' }
+        });
 
         expect(result).toEqual({
             API_KEY: 'super-secret-key',
@@ -69,7 +79,12 @@ describe('resolveEnv', () => {
             values: { local: 'from-dev' }
         });
 
-        const result = await resolveEnv({ env: 'dev', projectDir: tmpDir, configDir });
+        const result = await resolveEnv({
+            env: 'dev',
+            projectDir: tmpDir,
+            configDir,
+            envMapping: { SHARED: 'shared', LOCAL: 'local' }
+        });
 
         expect(result).toEqual({
             SHARED: 'from-base',
@@ -87,14 +102,35 @@ describe('resolveEnv', () => {
             values: { setting: 'dev-value' }
         });
 
-        const result = await resolveEnv({ env: 'dev', projectDir: tmpDir, configDir });
+        const result = await resolveEnv({
+            env: 'dev',
+            projectDir: tmpDir,
+            configDir,
+            envMapping: { SETTING: 'setting' }
+        });
 
         expect(result).toEqual({ SETTING: 'dev-value' });
     });
 
+    it('returns empty record when envMapping is empty', async () => {
+        await saveEnvironment(tmpDir, 'dev', {
+            imports: [],
+            values: { database: { host: 'localhost', port: 5432 } }
+        });
+
+        const result = await resolveEnv({
+            env: 'dev',
+            projectDir: tmpDir,
+            configDir,
+            envMapping: {}
+        });
+
+        expect(result).toEqual({});
+    });
+
     it('throws when environment does not exist', async () => {
         await expect(
-            resolveEnv({ env: 'nonexistent', projectDir: tmpDir, configDir })
+            resolveEnv({ env: 'nonexistent', projectDir: tmpDir, configDir, envMapping: {} })
         ).rejects.toThrow(/Environment "nonexistent" not found/);
     });
 
@@ -104,7 +140,7 @@ describe('resolveEnv', () => {
             fs.mkdirSync(path.join(noConfigDir, '.keyshelf', 'environments'), { recursive: true });
             await saveEnvironment(noConfigDir, 'dev', { imports: [], values: { key: 'val' } });
             await expect(
-                resolveEnv({ env: 'dev', projectDir: noConfigDir, configDir })
+                resolveEnv({ env: 'dev', projectDir: noConfigDir, configDir, envMapping: {} })
             ).rejects.toThrow(/keyshelf.yml not found/);
         } finally {
             fs.rmSync(noConfigDir, { recursive: true, force: true });

--- a/test/core/yaml.test.ts
+++ b/test/core/yaml.test.ts
@@ -118,54 +118,6 @@ describe('YAML parser', () => {
         });
     });
 
-    describe('env section', () => {
-        it('parses env section into Record<string, string>', () => {
-            const result = parseEnvironment(
-                'env:\n  DATABASE_URL: database/url\n  API_KEY: api/key\nvalues:\n  key: val'
-            );
-            expect(result.env).toEqual({ DATABASE_URL: 'database/url', API_KEY: 'api/key' });
-        });
-
-        it('returns undefined env when env section is absent', () => {
-            const result = parseEnvironment('values:\n  key: val');
-            expect(result.env).toBeUndefined();
-        });
-
-        it('serializes env section between provider and values', () => {
-            const serialized = serializeEnvironment({
-                imports: [],
-                env: { DATABASE_URL: 'database/url' },
-                values: { key: 'val' }
-            });
-            expect(serialized).toContain('DATABASE_URL: database/url');
-            const providerIdx = serialized.indexOf('provider:');
-            const envIdx = serialized.indexOf('env:');
-            const valuesIdx = serialized.indexOf('values:');
-            // env comes after provider (or start) and before values
-            expect(envIdx).toBeLessThan(valuesIdx);
-            if (providerIdx !== -1) {
-                expect(envIdx).toBeGreaterThan(providerIdx);
-            }
-        });
-
-        it('omits env key when env is undefined', () => {
-            const serialized = serializeEnvironment({ imports: [], values: { key: 'val' } });
-            expect(serialized).not.toContain('env:');
-        });
-
-        it('round-trips env section', () => {
-            const original: Parameters<typeof serializeEnvironment>[0] = {
-                imports: [],
-                env: { DATABASE_URL: 'database/url', API_KEY: 'api/key' },
-                values: { host: 'localhost' }
-            };
-            const serialized = serializeEnvironment(original);
-            const reparsed = parseEnvironment(serialized);
-            expect(reparsed.env).toEqual({ DATABASE_URL: 'database/url', API_KEY: 'api/key' });
-            expect(reparsed.values).toEqual({ host: 'localhost' });
-        });
-    });
-
     describe('round-trip', () => {
         it('parse then serialize preserves !secret refs', () => {
             const original = 'values:\n  password: !secret database/password\n';

--- a/test/preload.test.ts
+++ b/test/preload.test.ts
@@ -52,6 +52,10 @@ describe('keyshelf/preload', () => {
             imports: [],
             values: { database: { host: 'localhost', port: 5432 } }
         });
+        fs.writeFileSync(
+            path.join(tmpDir, '.env.keyshelf'),
+            'DATABASE_HOST=database/host\nDATABASE_PORT=database/port\n'
+        );
 
         const script = `import fs from "node:fs"; fs.writeFileSync(${JSON.stringify(outFile)}, process.env.DATABASE_HOST + ":" + process.env.DATABASE_PORT)`;
         const result = runPreload(script, {
@@ -73,6 +77,7 @@ describe('keyshelf/preload', () => {
                 api: { key: new SecretRef('api/key'), url: 'https://api.example.com' }
             }
         });
+        fs.writeFileSync(path.join(tmpDir, '.env.keyshelf'), 'API_KEY=api/key\nAPI_URL=api/url\n');
 
         const script = `import fs from "node:fs"; fs.writeFileSync(${JSON.stringify(outFile)}, process.env.API_KEY + "|" + process.env.API_URL)`;
         const result = runPreload(script, {
@@ -104,6 +109,7 @@ describe('keyshelf/preload', () => {
             imports: ['base'],
             values: { local: 'from-dev' }
         });
+        fs.writeFileSync(path.join(tmpDir, '.env.keyshelf'), 'SHARED=shared\nLOCAL=local\n');
 
         const script = `import fs from "node:fs"; fs.writeFileSync(${JSON.stringify(outFile)}, process.env.SHARED + "|" + process.env.LOCAL)`;
         const result = runPreload(script, {


### PR DESCRIPTION
## Summary

- Moves the `env:` mapping from environment YAML files to a `.env.keyshelf` file in the project root
- The mapping now belongs to the consumer (the app), not the environment definition — different apps can define their own mappings for the same environment
- Removes the `flattenGeneric` auto-uppercase fallback; env vars are only injected when `.env.keyshelf` exists (warns when absent)

## Breaking changes

- The `env:` field in environment YAML files is no longer recognized
- Auto-generated `UPPER_SNAKE_CASE` env var names (when no mapping was present) are removed
- Users must create a `.env.keyshelf` file with `VAR_NAME=path/to/value` mappings

## Test plan

- [x] `loadEnvMapping` returns parsed mappings, empty record when file absent, handles comments
- [x] `flattenToEnvRecord` requires explicit mapping, errors on missing paths
- [x] `resolveEnv` threads `envMapping` through the pipeline
- [x] `run` and `print --format env` load `.env.keyshelf` and warn when absent
- [x] `up --from-env` uses `.env.keyshelf` for reverse-mapping
- [x] YAML parsing/serialization no longer includes `env:` field
- [x] All 273 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)