### PR TITLE
feat!: remove --from-env flag from up command

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,6 @@ REDIS_URL=cache/redis/url
 
 When `keyshelf run`, `keyshelf print --format env`, or the preload module is used, only the variables listed in `.env.keyshelf` are exported. If the file is absent, no environment variables are injected (a warning is shown).
 
-The mapping is also used by `keyshelf up --from-env`: keyshelf reverse-looks up each secret path by its mapped variable name in the current process environment.
-
 ---
 
 ## File Structure
@@ -440,7 +438,6 @@ USAGE
 
 FLAGS
   --apply              Skip the y/N confirmation prompt  [default: false]
-  --from-env           Read new secret values from process environment variables  [default: false]
   --from-file=<value>  Read new secret values from a KEY=VALUE file
 ```
 
@@ -450,9 +447,6 @@ keyshelf up
 
 # Skip confirmation prompt, then prompt for each new secret value
 keyshelf up --apply
-
-# Skip confirmation, reading new values from the current process environment
-keyshelf up --apply --from-env
 
 # Skip confirmation, reading new values from a file
 keyshelf up --apply --from-file .env.secrets
@@ -519,14 +513,9 @@ keyshelf up
 # Apply with interactive prompts for each new secret value
 keyshelf up --apply
 
-# Apply using values already present in CI environment variables
-keyshelf up --apply --from-env
-
 # Apply using a secrets export file
 keyshelf up --apply --from-file secrets.env
 ```
-
-`--from-env` uses the `.env.keyshelf` mapping to reverse-look up each secret path by its corresponding variable name. Ensure the variables are set in the calling shell before running this.
 
 ### Running processes with secrets
 

--- a/src/commands/up.ts
+++ b/src/commands/up.ts
@@ -12,7 +12,6 @@ import { applyEnvironmentPlan } from '../core/reconciler/apply.js';
 import { makeCollector } from '../core/reconciler/input.js';
 import { renderPlan } from '../core/reconciler/render.js';
 import { parseEnvFile } from '../core/env-file.js';
-import { loadEnvMapping } from '../core/env-keyshelf.js';
 import { ReconciliationPlan, EnvironmentPlan } from '../core/reconciler/types.js';
 
 export default class Up extends Command {
@@ -22,17 +21,12 @@ export default class Up extends Command {
     static override examples = [
         '<%= config.bin %> up',
         '<%= config.bin %> up --apply',
-        '<%= config.bin %> up --apply --from-env',
         '<%= config.bin %> up --apply --from-file .env.secrets'
     ];
 
     static override flags = {
         apply: Flags.boolean({
             description: 'Apply changes without interactive confirmation',
-            default: false
-        }),
-        'from-env': Flags.boolean({
-            description: 'Read new secret values from process environment variables',
             default: false
         }),
         'from-file': Flags.string({
@@ -72,7 +66,7 @@ export default class Up extends Command {
     }
 
     private async confirmAndApply(
-        flags: { apply: boolean; 'from-env': boolean; 'from-file': string | undefined },
+        flags: { apply: boolean; 'from-file': string | undefined },
         plan: ReconciliationPlan,
         ctx: PlanContext
     ): Promise<void> {
@@ -82,7 +76,7 @@ export default class Up extends Command {
             return;
         }
 
-        const collector = await buildCollector(flags['from-env'], flags['from-file'], ctx.cwd);
+        const collector = await buildCollector(flags['from-file']);
 
         for (const envPlan of plan.environments) {
             if (envPlan.secretChanges.length === 0) continue;
@@ -185,19 +179,12 @@ async function confirmApply(): Promise<boolean> {
 }
 
 async function buildCollector(
-    fromEnv: boolean,
-    fromFile: string | undefined,
-    cwd: string
+    fromFile: string | undefined
 ): Promise<(path: string) => Promise<string>> {
     if (fromFile) {
         const content = await fs.readFile(fromFile, 'utf-8');
         const values = parseEnvFile(content);
         return makeCollector({ kind: 'file', values });
-    }
-
-    if (fromEnv) {
-        const mapping = loadEnvMapping(cwd);
-        return makeCollector({ kind: 'env', mapping });
     }
 
     return makeCollector({ kind: 'prompt' });

--- a/src/core/reconciler/input.ts
+++ b/src/core/reconciler/input.ts
@@ -2,16 +2,12 @@ import { readMaskedLine } from '../input.js';
 
 export { readMaskedLine };
 
-type ValueSource =
-    | { kind: 'prompt' }
-    | { kind: 'env'; mapping: Record<string, string> }
-    | { kind: 'file'; values: Record<string, string> };
+type ValueSource = { kind: 'prompt' } | { kind: 'file'; values: Record<string, string> };
 
 /**
  * Create a value collector function for the given source.
  *
  * - 'prompt': reads from stdin with masked input
- * - 'env': reverse-looks up the path in the mapping to find a var name, then reads process.env
  * - 'file': direct lookup by path in the provided values record
  *
  * @param source - The value source configuration
@@ -21,8 +17,6 @@ export function makeCollector(source: ValueSource): (path: string) => Promise<st
     switch (source.kind) {
         case 'prompt':
             return promptCollector;
-        case 'env':
-            return makeEnvCollector(source.mapping);
         case 'file':
             return makeFileCollector(source.values);
     }
@@ -30,33 +24,6 @@ export function makeCollector(source: ValueSource): (path: string) => Promise<st
 
 async function promptCollector(path: string): Promise<string> {
     return readMaskedLine(`Enter value for "${path}": `);
-}
-
-function makeEnvCollector(mapping: Record<string, string>): (path: string) => Promise<string> {
-    const reverseMapping = buildReverseMapping(mapping);
-    return async (path: string) => {
-        const varName = reverseMapping.get(path);
-        if (!varName) {
-            throw new Error(
-                `No env var mapped to secret path "${path}". Add a mapping to .env.keyshelf.`
-            );
-        }
-        const value = process.env[varName];
-        if (value === undefined) {
-            throw new Error(
-                `Environment variable "${varName}" is not set. It is required for secret "${path}".`
-            );
-        }
-        return value;
-    };
-}
-
-function buildReverseMapping(mapping: Record<string, string>): Map<string, string> {
-    const reverse = new Map<string, string>();
-    for (const [varName, path] of Object.entries(mapping)) {
-        reverse.set(path, varName);
-    }
-    return reverse;
 }
 
 function makeFileCollector(values: Record<string, string>): (path: string) => Promise<string> {

--- a/test/commands/up.test.ts
+++ b/test/commands/up.test.ts
@@ -154,33 +154,6 @@ describe('up command', () => {
         expect(devToken).toBe('base-token');
     });
 
-    it('applies new secret from --from-env flag', async () => {
-        await saveEnvironment(tmpDir, 'dev', {
-            imports: [],
-            values: { db: { password: new SecretRef('db/password') } }
-        });
-        fs.writeFileSync(path.join(tmpDir, '.env.keyshelf'), 'MY_DB_PASS=db/password\n');
-
-        const origEnv = process.env;
-        process.env = { ...origEnv, MY_DB_PASS: 'env-secret-value' };
-
-        const logs: string[] = [];
-        vi.spyOn(Up.prototype, 'log').mockImplementation((msg = '') => {
-            logs.push(msg);
-        });
-
-        try {
-            await Up.run(['--apply', '--from-env', '--config-dir', configDir]);
-        } finally {
-            process.env = origEnv;
-        }
-
-        expect(logs.some((l) => l.includes('Done.'))).toBe(true);
-        const provider = new LocalProvider(configDir);
-        const value = await provider.get('dev', 'db/password');
-        expect(value).toBe('env-secret-value');
-    });
-
     it('does not apply changes when --apply is not passed and user declines', async () => {
         await saveEnvironment(tmpDir, 'dev', {
             imports: [],

--- a/test/core/reconciler/input.test.ts
+++ b/test/core/reconciler/input.test.ts
@@ -36,45 +36,6 @@ describe('readMaskedLine', () => {
 });
 
 describe('makeCollector', () => {
-    describe('env source', () => {
-        const originalEnv = process.env;
-
-        beforeEach(() => {
-            process.env = { ...originalEnv };
-        });
-
-        afterEach(() => {
-            process.env = originalEnv;
-        });
-
-        it('returns value from process.env for mapped path', async () => {
-            process.env.DATABASE_URL = 'postgres://localhost/test';
-            const collect = makeCollector({
-                kind: 'env',
-                mapping: { DATABASE_URL: 'database/url' }
-            });
-
-            const value = await collect('database/url');
-            expect(value).toBe('postgres://localhost/test');
-        });
-
-        it('throws when path has no mapping', async () => {
-            const collect = makeCollector({ kind: 'env', mapping: {} });
-
-            await expect(collect('unmapped/path')).rejects.toThrow(/unmapped\/path/);
-        });
-
-        it('throws when env var is not set', async () => {
-            delete process.env.DATABASE_URL;
-            const collect = makeCollector({
-                kind: 'env',
-                mapping: { DATABASE_URL: 'database/url' }
-            });
-
-            await expect(collect('database/url')).rejects.toThrow(/DATABASE_URL/);
-        });
-    });
-
     describe('prompt source', () => {
         it('reads value from stdin with a prompt derived from the secret path', async () => {
             const mockStdin = {


### PR DESCRIPTION
## Summary
- Remove the `--from-env` flag from `keyshelf up`, including the env collector, reverse-mapping logic, and all associated tests/docs
- The `--from-file` flag already covers the same use case more directly (no indirection through `.env.keyshelf` reverse lookup)
- `.env.keyshelf` and `loadEnvMapping` are untouched — still used by `run`, `print`, and `preload`

## Test plan
- [x] All 273 tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)