### PR TITLE
feat: auto-create SecretRef in YAML on keyshelf set

### DIFF
--- a/src/commands/set.ts
+++ b/src/commands/set.ts
@@ -1,5 +1,5 @@
 import { Args, Command, Flags } from '@oclif/core';
-import { loadEnvironment, listEnvironments } from '../core/environment.js';
+import { loadEnvironment, saveEnvironment, listEnvironments } from '../core/environment.js';
 import { loadConfig, defaultConfigDir } from '../core/config.js';
 import { resolve } from '../core/resolver.js';
 import { PathTree } from '../core/path-tree.js';
@@ -35,12 +35,17 @@ export default class SetCommand extends Command {
         const resolvedTree = PathTree.fromJSON(resolved.values);
         const existing = resolvedTree.get(args.path);
 
-        if (!(existing instanceof SecretRef)) {
-            const msg =
-                existing === undefined
-                    ? `Path "${args.path}" not found in environment "${envName}". Add it to your YAML config and run "keyshelf up" first.`
-                    : `Path "${args.path}" in environment "${envName}" is a plain value, not a secret reference. Change it to a !secret tag and run "keyshelf up" first.`;
-            this.error(msg);
+        if (existing !== undefined && !(existing instanceof SecretRef)) {
+            this.error(
+                `Path "${args.path}" in environment "${envName}" is a plain value, not a secret reference. Change it to a !secret tag first.`
+            );
+        }
+
+        if (existing === undefined) {
+            const envDef = await loadEnvironment(cwd, envName);
+            const tree = PathTree.fromJSON(envDef.values);
+            tree.set(args.path, new SecretRef(args.path));
+            await saveEnvironment(cwd, envName, { ...envDef, values: tree.toJSON() });
         }
 
         const value = args.value ?? (await readMaskedLine(`Enter value for "${args.path}": `));

--- a/test/commands/set.test.ts
+++ b/test/commands/set.test.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import os from 'node:os';
 import yaml from 'js-yaml';
 import SetCommand from '../../src/commands/set.js';
-import { saveEnvironment } from '../../src/core/environment.js';
+import { saveEnvironment, loadEnvironment } from '../../src/core/environment.js';
 import { LocalProvider } from '../../src/providers/local.js';
 import { SecretRef } from '../../src/core/types.js';
 import * as inputModule from '../../src/core/input.js';
@@ -55,22 +55,27 @@ describe('set command', () => {
         expect(stored).toBe('mysecret');
     });
 
-    it('errors when path does not exist in config', async () => {
+    it('creates SecretRef in YAML and sets value when path does not exist', async () => {
         await saveEnvironment(tmpDir, 'dev', {
             imports: [],
             values: {}
         });
 
-        await expect(
-            SetCommand.run([
-                '--env',
-                'dev',
-                'database/password',
-                'newpassword',
-                '--config-dir',
-                configDir
-            ])
-        ).rejects.toThrow(/Path "database\/password" not found in environment "dev"/);
+        await SetCommand.run([
+            '--env',
+            'dev',
+            'database/password',
+            'newpassword',
+            '--config-dir',
+            configDir
+        ]);
+
+        const envDef = await loadEnvironment(tmpDir, 'dev');
+        const { database } = envDef.values as { database: { password: unknown } };
+        expect(database.password).toBeInstanceOf(SecretRef);
+
+        const provider = new LocalProvider(configDir);
+        expect(await provider.get('dev', 'database/password')).toBe('newpassword');
     });
 
     it('errors when path is a plain value, not a secret', async () => {


### PR DESCRIPTION
## Summary
- `keyshelf set` now auto-creates the `!secret` tag in the environment YAML when the target path doesn't exist, then sets the value in the provider
- Removes the requirement to manually edit YAML before running `set` — reduces friction while keeping config as the source of truth
- Still errors when the path exists as a plain value (not a secret reference)

## Test plan
- [x] Unit tests updated and passing (273/273)
- [x] E2e tests passing against AWS SM (3/3), including the previously-failing "creates SecretRef in YAML when path does not exist" test

🤖 Generated with [Claude Code](https://claude.com/claude-code)