### PR TITLE
test: add secret propagation coverage for edge cases

### DIFF
--- a/test/commands/set.test.ts
+++ b/test/commands/set.test.ts
@@ -196,4 +196,103 @@ describe('set command', () => {
             ])
         ).rejects.toThrow(/nonexistent/);
     });
+
+    it('propagates through a 3-level chain (base → staging → prod)', async () => {
+        await saveEnvironment(tmpDir, 'base', {
+            imports: [],
+            values: { shared: { key: new SecretRef('shared/key') } }
+        });
+        await saveEnvironment(tmpDir, 'staging', {
+            imports: ['base'],
+            values: {}
+        });
+        await saveEnvironment(tmpDir, 'prod', {
+            imports: ['staging'],
+            values: {}
+        });
+
+        await SetCommand.run([
+            '--env',
+            'base',
+            'shared/key',
+            'deep-propagated',
+            '--config-dir',
+            configDir
+        ]);
+
+        const provider = new LocalProvider(configDir);
+        expect(await provider.get('base', 'shared/key')).toBe('deep-propagated');
+        expect(await provider.get('staging', 'shared/key')).toBe('deep-propagated');
+        expect(await provider.get('prod', 'shared/key')).toBe('deep-propagated');
+    });
+
+    it('propagates through diamond dependency without duplicating writes', async () => {
+        await saveEnvironment(tmpDir, 'base', {
+            imports: [],
+            values: { shared: { token: new SecretRef('shared/token') } }
+        });
+        await saveEnvironment(tmpDir, 'shared', {
+            imports: ['base'],
+            values: {}
+        });
+        await saveEnvironment(tmpDir, 'staging', {
+            imports: ['base'],
+            values: {}
+        });
+        await saveEnvironment(tmpDir, 'prod', {
+            imports: ['shared', 'staging'],
+            values: {}
+        });
+
+        const setSpy = vi.spyOn(LocalProvider.prototype, 'set');
+
+        await SetCommand.run([
+            '--env',
+            'base',
+            'shared/token',
+            'diamond-value',
+            '--config-dir',
+            configDir
+        ]);
+
+        const provider = new LocalProvider(configDir);
+        expect(await provider.get('base', 'shared/token')).toBe('diamond-value');
+        expect(await provider.get('shared', 'shared/token')).toBe('diamond-value');
+        expect(await provider.get('staging', 'shared/token')).toBe('diamond-value');
+        expect(await provider.get('prod', 'shared/token')).toBe('diamond-value');
+
+        const prodWrites = setSpy.mock.calls.filter(
+            ([env, secretPath]) => env === 'prod' && secretPath === 'shared/token'
+        );
+        expect(prodWrites).toHaveLength(1);
+    });
+
+    it('stops propagation mid-chain when provider.set throws', async () => {
+        await saveEnvironment(tmpDir, 'base', {
+            imports: [],
+            values: { db: { pass: new SecretRef('db/pass') } }
+        });
+        await saveEnvironment(tmpDir, 'staging', {
+            imports: ['base'],
+            values: {}
+        });
+        await saveEnvironment(tmpDir, 'prod', {
+            imports: ['staging'],
+            values: {}
+        });
+
+        const realSet = LocalProvider.prototype.set.bind(new LocalProvider(configDir));
+        vi.spyOn(LocalProvider.prototype, 'set').mockImplementation(
+            async (env, secretPath, value) => {
+                if (env === 'staging') {
+                    throw new Error('Provider unavailable for staging');
+                }
+                return realSet(env, secretPath, value);
+            }
+        );
+
+        await expect(
+            SetCommand.run(['--env', 'base', 'db/pass', 'secret', '--config-dir', configDir])
+        ).rejects.toThrow(/Provider unavailable for staging/);
+    });
 });

--- a/test/commands/up.test.ts
+++ b/test/commands/up.test.ts
@@ -197,4 +197,164 @@ describe('up command', () => {
         const devIdx = allOutput.indexOf('Environment: dev');
         expect(baseIdx).toBeLessThan(devIdx);
     });
+
+    it('copies secret from grandparent through intermediate when intermediate already has it in provider', async () => {
+        const provider = new LocalProvider(configDir);
+        await provider.set('base', 'shared/token', 'grandparent-token');
+        // staging already has the token (from a previous up run or set) so prod can copy from it
+        await provider.set('staging', 'shared/token', 'grandparent-token');
+
+        await saveEnvironment(tmpDir, 'base', {
+            imports: [],
+            values: { shared: { token: new SecretRef('shared/token') } }
+        });
+        await saveEnvironment(tmpDir, 'staging', {
+            imports: ['base'],
+            values: { shared: { token: new SecretRef('shared/token') } }
+        });
+        await saveEnvironment(tmpDir, 'prod', {
+            imports: ['staging'],
+            values: { shared: { token: new SecretRef('shared/token') } }
+        });
+
+        vi.spyOn(Up.prototype, 'log').mockImplementation(() => {});
+
+        await Up.run(['--apply', '--config-dir', configDir]);
+
+        const prodToken = await provider.get('prod', 'shared/token');
+        expect(prodToken).toBe('grandparent-token');
+    });
+
+    it('removes secret from all inheriting children when removed from parent YAML', async () => {
+        const provider = new LocalProvider(configDir);
+        await provider.set('base', 'old/secret', 'stale-value');
+        await provider.set('staging', 'old/secret', 'stale-value');
+        await provider.set('prod', 'old/secret', 'stale-value');
+
+        // Parent no longer has the secret ref — it was removed from the YAML
+        await saveEnvironment(tmpDir, 'base', {
+            imports: [],
+            values: { other: { key: 'plain-value' } }
+        });
+        await saveEnvironment(tmpDir, 'staging', {
+            imports: ['base'],
+            values: {}
+        });
+        await saveEnvironment(tmpDir, 'prod', {
+            imports: ['staging'],
+            values: {}
+        });
+
+        vi.spyOn(Up.prototype, 'log').mockImplementation(() => {});
+
+        await Up.run(['--apply', '--config-dir', configDir]);
+
+        await expect(provider.get('base', 'old/secret')).rejects.toThrow(/not found/);
+        await expect(provider.get('staging', 'old/secret')).rejects.toThrow(/not found/);
+        await expect(provider.get('prod', 'old/secret')).rejects.toThrow(/not found/);
+    });
+
+    it('uses first parent as copy source when multiple parents export the same secret path', async () => {
+        const provider = new LocalProvider(configDir);
+        await provider.set('shared', 'api/key', 'value-from-shared');
+        await provider.set('staging', 'api/key', 'value-from-staging');
+
+        await saveEnvironment(tmpDir, 'shared', {
+            imports: [],
+            values: { api: { key: new SecretRef('api/key') } }
+        });
+        await saveEnvironment(tmpDir, 'staging', {
+            imports: [],
+            values: { api: { key: new SecretRef('api/key') } }
+        });
+        // prod imports shared first, then staging — shared should win
+        await saveEnvironment(tmpDir, 'prod', {
+            imports: ['shared', 'staging'],
+            values: { api: { key: new SecretRef('api/key') } }
+        });
+
+        vi.spyOn(Up.prototype, 'log').mockImplementation(() => {});
+
+        await Up.run(['--apply', '--config-dir', configDir]);
+
+        const prodValue = await provider.get('prod', 'api/key');
+        expect(prodValue).toBe('value-from-shared');
+    });
+
+    it('copies from direct parent in a 3-level chain when each level is pre-populated', async () => {
+        const provider = new LocalProvider(configDir);
+        // base and staging are already reconciled; prod needs to be populated from staging
+        await provider.set('base', 'db/password', 'base-secret');
+        await provider.set('staging', 'db/password', 'base-secret');
+
+        await saveEnvironment(tmpDir, 'base', {
+            imports: [],
+            values: { db: { password: new SecretRef('db/password') } }
+        });
+        await saveEnvironment(tmpDir, 'staging', {
+            imports: ['base'],
+            values: { db: { password: new SecretRef('db/password') } }
+        });
+        await saveEnvironment(tmpDir, 'prod', {
+            imports: ['staging'],
+            values: { db: { password: new SecretRef('db/password') } }
+        });
+
+        vi.spyOn(Up.prototype, 'log').mockImplementation(() => {});
+
+        await Up.run(['--apply', '--config-dir', configDir]);
+
+        expect(await provider.get('prod', 'db/password')).toBe('base-secret');
+    });
+
+    it('propagates apply through diamond dependency when intermediates already have the secret', async () => {
+        const provider = new LocalProvider(configDir);
+        await provider.set('base', 'shared/token', 'base-token');
+        // infra and app already have the token so prod can copy from its direct parents
+        await provider.set('infra', 'shared/token', 'base-token');
+        await provider.set('app', 'shared/token', 'base-token');
+
+        await saveEnvironment(tmpDir, 'base', {
+            imports: [],
+            values: { shared: { token: new SecretRef('shared/token') } }
+        });
+        await saveEnvironment(tmpDir, 'infra', {
+            imports: ['base'],
+            values: { shared: { token: new SecretRef('shared/token') } }
+        });
+        await saveEnvironment(tmpDir, 'app', {
+            imports: ['base'],
+            values: { shared: { token: new SecretRef('shared/token') } }
+        });
+        await saveEnvironment(tmpDir, 'prod', {
+            imports: ['infra', 'app'],
+            values: { shared: { token: new SecretRef('shared/token') } }
+        });
+
+        vi.spyOn(Up.prototype, 'log').mockImplementation(() => {});
+
+        await Up.run(['--apply', '--config-dir', configDir]);
+
+        expect(await provider.get('prod', 'shared/token')).toBe('base-token');
+    });
+
+    it('surfaces provider error when set throws during apply', async () => {
+        await saveEnvironment(tmpDir, 'dev', {
+            imports: [],
+            values: { db: { password: new SecretRef('db/password') } }
+        });
+
+        vi.spyOn(LocalProvider.prototype, 'set').mockRejectedValue(
+            new Error('Provider connection refused')
+        );
+
+        vi.spyOn(Up.prototype, 'log').mockImplementation(() => {});
+
+        const secretsFile = path.join(tmpDir, 'secrets.env');
+        fs.writeFileSync(secretsFile, 'db/password=test-value\n');
+
+        await expect(
+            Up.run(['--apply', '--from-file', secretsFile, '--config-dir', configDir])
+        ).rejects.toThrow(/Provider connection refused/);
+    });
 });


### PR DESCRIPTION
## Summary
- Add tests for **3-level chain propagation** (`base → staging → prod`) via `set` command
- Add tests for **diamond dependency propagation** ensuring no duplicate writes
- Add tests for **partial failure handling** when provider errors mid-propagation
- Add tests for **secret removal across inheritance chains** via `up --apply`
- Add tests for **grandparent copy** and **multi-parent source disambiguation**
- Add tests for **provider error surfacing** during `up --apply`

9 new tests across `test/commands/set.test.ts` and `test/commands/up.test.ts`.

## Test plan
- [x] All 282 tests pass locally (`npm run test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)