### PR TITLE
fix: validate names and harden input handling

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -81,6 +81,12 @@ export function loadConfig(projectRoot: string): KeyshelfConfig {
         throw new Error('Invalid keyshelf.yml: missing required field "name".');
     }
 
+    if (!/^[a-zA-Z0-9_-]+$/.test(obj.name)) {
+        throw new Error(
+            `Invalid keyshelf.yml: "name" value "${obj.name}" contains unsafe characters. Names must match /^[a-zA-Z0-9_-]+$/.`
+        );
+    }
+
     if (!obj.provider || typeof obj.provider !== 'object' || Array.isArray(obj.provider)) {
         throw new Error('Invalid keyshelf.yml: missing required field "provider".');
     }

--- a/src/core/environment.ts
+++ b/src/core/environment.ts
@@ -4,8 +4,16 @@ import { EnvironmentDefinition } from './types.js';
 import { parseEnvironment, serializeEnvironment } from './yaml.js';
 
 const ENVIRONMENTS_DIR = path.join('.keyshelf', 'environments');
+const SAFE_NAME_RE = /^[a-zA-Z0-9_-]+$/;
+
+function assertSafeEnvName(name: string): void {
+    if (!SAFE_NAME_RE.test(name)) {
+        throw new Error(`Invalid environment name "${name}". Names must match /^[a-zA-Z0-9_-]+$/.`);
+    }
+}
 
 function envFilePath(projectRoot: string, name: string): string {
+    assertSafeEnvName(name);
     return path.join(projectRoot, ENVIRONMENTS_DIR, `${name}.yml`);
 }
 

--- a/src/core/input.ts
+++ b/src/core/input.ts
@@ -30,6 +30,13 @@ export function readMaskedLine(prompt: string): Promise<string> {
                     reject(new Error('Aborted by user'));
                     return;
                 }
+                if (char === '\u007f' || char === '\b') {
+                    if (value.length > 0) {
+                        value = value.slice(0, -1);
+                        process.stdout.write('\b \b');
+                    }
+                    continue;
+                }
                 value += char;
                 process.stdout.write('*');
             }

--- a/src/core/yaml.ts
+++ b/src/core/yaml.ts
@@ -13,7 +13,7 @@ const secretType = new yaml.Type('!secret', {
     }
 });
 
-const SCHEMA = yaml.DEFAULT_SCHEMA.extend([secretType]);
+const SCHEMA = yaml.CORE_SCHEMA.extend([secretType]);
 
 /** Parse a YAML environment file into an EnvironmentDefinition. */
 export function parseEnvironment(content: string): EnvironmentDefinition {

--- a/test/core/config.test.ts
+++ b/test/core/config.test.ts
@@ -47,6 +47,35 @@ describe('config validation', () => {
         expect(() => loadConfig(tmpDir)).toThrow(/missing required field "name"/);
     });
 
+    it('name with path traversal characters is rejected', () => {
+        fs.writeFileSync(
+            path.join(tmpDir, 'keyshelf.yml'),
+            yaml.dump({ name: '../../.ssh', provider: { adapter: 'local' } })
+        );
+
+        expect(() => loadConfig(tmpDir)).toThrow(/unsafe characters/);
+        expect(() => loadConfig(tmpDir)).toThrow(/name/);
+    });
+
+    it('name with spaces is rejected', () => {
+        fs.writeFileSync(
+            path.join(tmpDir, 'keyshelf.yml'),
+            yaml.dump({ name: 'my project', provider: { adapter: 'local' } })
+        );
+
+        expect(() => loadConfig(tmpDir)).toThrow(/unsafe characters/);
+    });
+
+    it('name with hyphens and underscores is accepted', () => {
+        fs.writeFileSync(
+            path.join(tmpDir, 'keyshelf.yml'),
+            yaml.dump({ name: 'my-project_v2', provider: { adapter: 'local' } })
+        );
+
+        const config = loadConfig(tmpDir);
+        expect(config.name).toBe('my-project_v2');
+    });
+
     it('missing provider field shows specific error', () => {
         fs.writeFileSync(path.join(tmpDir, 'keyshelf.yml'), yaml.dump({ name: 'test' }));
 

--- a/test/core/environment.test.ts
+++ b/test/core/environment.test.ts
@@ -59,6 +59,24 @@ describe('environment I/O', () => {
         await expect(loadEnvironment(tmpDir, 'nonexistent')).rejects.toThrow(/nonexistent/);
     });
 
+    it('loadEnvironment rejects path traversal via env name', async () => {
+        await expect(loadEnvironment(tmpDir, '../../etc/cron.d/evil')).rejects.toThrow(
+            /Invalid environment name/
+        );
+    });
+
+    it('saveEnvironment rejects path traversal via env name', async () => {
+        await expect(
+            saveEnvironment(tmpDir, '../../etc/cron.d/evil', { imports: [], values: {} })
+        ).rejects.toThrow(/Invalid environment name/);
+    });
+
+    it('loadEnvironment accepts names with letters, digits, hyphens, underscores', async () => {
+        await saveEnvironment(tmpDir, 'prod-v2_us', { imports: [], values: { key: 'val' } });
+        const loaded = await loadEnvironment(tmpDir, 'prod-v2_us');
+        expect(loaded.values).toEqual({ key: 'val' });
+    });
+
     it('list environments returns names from .keyshelf/environments/', async () => {
         await saveEnvironment(tmpDir, 'dev', { imports: [], values: {} });
         await saveEnvironment(tmpDir, 'staging', { imports: [], values: {} });

--- a/test/core/input.test.ts
+++ b/test/core/input.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { readMaskedLine } from '../../src/core/input.js';
+
+function setupMockIO() {
+    const mockStdin = {
+        setRawMode: vi.fn(),
+        on: vi.fn(),
+        removeListener: vi.fn(),
+        resume: vi.fn(),
+        pause: vi.fn()
+    };
+    const mockStdout = { write: vi.fn() };
+
+    const originalStdin = process.stdin;
+    const originalStdout = process.stdout;
+    Object.defineProperty(process, 'stdin', { value: mockStdin, configurable: true });
+    Object.defineProperty(process, 'stdout', { value: mockStdout, configurable: true });
+
+    let capturedHandler: ((chunk: Buffer) => void) | undefined;
+    mockStdin.on.mockImplementation((_event: string, handler: (chunk: Buffer) => void) => {
+        capturedHandler = handler;
+    });
+
+    return {
+        mockStdin,
+        mockStdout,
+        getHandler: () => capturedHandler!,
+        restore() {
+            Object.defineProperty(process, 'stdin', { value: originalStdin, configurable: true });
+            Object.defineProperty(process, 'stdout', {
+                value: originalStdout,
+                configurable: true
+            });
+        }
+    };
+}
+
+describe('readMaskedLine', () => {
+    let io: ReturnType<typeof setupMockIO>;
+
+    beforeEach(() => {
+        io = setupMockIO();
+    });
+
+    afterEach(() => {
+        io.restore();
+        vi.restoreAllMocks();
+    });
+
+    it('resolves with typed value on newline', async () => {
+        const resultPromise = readMaskedLine('Password: ');
+        io.getHandler()(Buffer.from('hello\n'));
+        expect(await resultPromise).toBe('hello');
+    });
+
+    it('writes a * for each typed character', async () => {
+        const resultPromise = readMaskedLine('Password: ');
+        io.getHandler()(Buffer.from('abc\n'));
+        await resultPromise;
+        const writes = (io.mockStdout.write as ReturnType<typeof vi.fn>).mock.calls.map(
+            (c) => c[0]
+        );
+        expect(writes.filter((w) => w === '*')).toHaveLength(3);
+    });
+
+    it('backspace (DEL \\u007f) removes the last character', async () => {
+        const resultPromise = readMaskedLine('Password: ');
+        io.getHandler()(Buffer.from('ab\u007fc\n'));
+        expect(await resultPromise).toBe('ac');
+    });
+
+    it('backspace (\\b) removes the last character', async () => {
+        const resultPromise = readMaskedLine('Password: ');
+        io.getHandler()(Buffer.from('ab\bc\n'));
+        expect(await resultPromise).toBe('ac');
+    });
+
+    it('backspace at empty input does not corrupt value', async () => {
+        const resultPromise = readMaskedLine('Password: ');
+        io.getHandler()(Buffer.from('\u007fab\n'));
+        expect(await resultPromise).toBe('ab');
+    });
+
+    it('backspace writes \\b \\b to stdout to erase the asterisk', async () => {
+        const resultPromise = readMaskedLine('Password: ');
+        io.getHandler()(Buffer.from('a\u007f\n'));
+        await resultPromise;
+        const writes = (io.mockStdout.write as ReturnType<typeof vi.fn>).mock.calls.map(
+            (c) => c[0]
+        );
+        expect(writes).toContain('\b \b');
+    });
+
+    it('rejects with abort error on Ctrl-C', async () => {
+        const resultPromise = readMaskedLine('Password: ');
+        io.getHandler()(Buffer.from('\u0003'));
+        await expect(resultPromise).rejects.toThrow(/Aborted/);
+    });
+});

--- a/test/core/yaml.test.ts
+++ b/test/core/yaml.test.ts
@@ -9,6 +9,18 @@ describe('YAML parser', () => {
             expect(result.values).toEqual({ database: { host: 'localhost' } });
         });
 
+        it('does not coerce ISO date strings to Date objects', () => {
+            const result = parseEnvironment('values:\n  created: "2024-01-15T10:00:00Z"');
+            expect(typeof result.values.created).toBe('string');
+            expect(result.values.created).toBe('2024-01-15T10:00:00Z');
+        });
+
+        it('does not coerce unquoted date-like strings to Date objects', () => {
+            const result = parseEnvironment('values:\n  date: 2024-01-15');
+            expect(typeof result.values.date).toBe('string');
+            expect(result.values.date).toBe('2024-01-15');
+        });
+
         it('parses !secret tag into SecretRef', () => {
             const result = parseEnvironment('values:\n  password: !secret database/password');
             expect(result.values.password).toBeInstanceOf(SecretRef);


### PR DESCRIPTION
## Summary
- **Path traversal prevention**: Validate environment names and project names against `/^[a-zA-Z0-9_-]+$/` to prevent directory traversal attacks via crafted `--env` flags or malicious `keyshelf.yml` files
- **Masked input fix**: Handle backspace (`\u007f`/`\b`) in `readMaskedLine` instead of appending control characters as literal bytes (caused silent secret corruption)
- **YAML schema hardening**: Use `CORE_SCHEMA` instead of `DEFAULT_SCHEMA` to prevent silent coercion of ISO date strings to `Date` objects and `!!binary` decoding

## Test plan
- [x] 3 new tests for environment name validation (path traversal rejection, valid names)
- [x] 3 new tests for project name validation (path traversal, spaces, valid names)
- [x] 7 new tests for masked input (backspace DEL, backspace BS, empty backspace, Ctrl-C)
- [x] 2 new tests for YAML type coercion prevention (quoted and unquoted dates)
- [x] All 288 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)