### PR TITLE
feat: walk-up directory discovery for monorepo support

### DIFF
--- a/src/commands/env/create.ts
+++ b/src/commands/env/create.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { saveEnvironment } from '../../core/environment.js';
 import { EnvironmentDefinition, ProviderConfig } from '../../core/types.js';
+import { findProjectRoot } from '../../core/config.js';
 
 export default class EnvCreate extends Command {
     static override description = 'Create a new environment';
@@ -35,8 +36,11 @@ export default class EnvCreate extends Command {
 
     async run(): Promise<void> {
         const { args, flags } = await this.parse(EnvCreate);
-        const cwd = process.cwd();
-        const envPath = path.join(cwd, '.keyshelf', 'environments', `${args.name}.yml`);
+        const projectRoot = findProjectRoot(process.cwd());
+        if (!projectRoot) {
+            this.error('keyshelf.yml not found in current directory or any parent directory.');
+        }
+        const envPath = path.join(projectRoot, '.keyshelf', 'environments', `${args.name}.yml`);
 
         if (fs.existsSync(envPath)) {
             this.error(`Environment "${args.name}" already exists at ${envPath}.`);
@@ -65,7 +69,7 @@ export default class EnvCreate extends Command {
             provider
         };
 
-        await saveEnvironment(cwd, args.name, def);
+        await saveEnvironment(projectRoot, args.name, def);
 
         this.log(`Created environment "${args.name}"`);
     }

--- a/src/commands/get.ts
+++ b/src/commands/get.ts
@@ -1,6 +1,6 @@
 import { Args, Command, Flags } from '@oclif/core';
 import { loadEnvironment } from '../core/environment.js';
-import { loadConfig, defaultConfigDir } from '../core/config.js';
+import { loadConfig, defaultConfigDir, findProjectRoot } from '../core/config.js';
 import { resolve } from '../core/resolver.js';
 import { PathTree } from '../core/path-tree.js';
 import { SecretRef } from '../core/types.js';
@@ -22,9 +22,12 @@ export default class Get extends Command {
 
     async run(): Promise<void> {
         const { args, flags } = await this.parse(Get);
-        const cwd = process.cwd();
+        const projectRoot = findProjectRoot(process.cwd());
+        if (!projectRoot) {
+            this.error('keyshelf.yml not found in current directory or any parent directory.');
+        }
 
-        const resolved = await resolve(flags.env, (name) => loadEnvironment(cwd, name));
+        const resolved = await resolve(flags.env, (name) => loadEnvironment(projectRoot, name));
         const tree = PathTree.fromJSON(resolved.values);
         const value = tree.get(args.path);
 
@@ -39,8 +42,8 @@ export default class Get extends Command {
         }
 
         if (value instanceof SecretRef) {
-            const envDef = await loadEnvironment(cwd, flags.env);
-            const config = loadConfig(cwd);
+            const envDef = await loadEnvironment(projectRoot, flags.env);
+            const config = loadConfig(projectRoot);
             const configDir = flags['config-dir'] ?? defaultConfigDir(config);
             const provider = resolveProvider(envDef, config, configDir);
             const secret = await provider.get(flags.env, value.path);

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -1,9 +1,7 @@
 import { Args, Command, Flags } from '@oclif/core';
-import path from 'node:path';
-import os from 'node:os';
 import fs from 'node:fs';
 import { loadEnvironment, saveEnvironment } from '../core/environment.js';
-import { loadConfig } from '../core/config.js';
+import { loadConfig, defaultConfigDir, findProjectRoot } from '../core/config.js';
 import { PathTree } from '../core/path-tree.js';
 import { SecretRef } from '../core/types.js';
 import { resolveProvider } from '../providers/index.js';
@@ -34,7 +32,10 @@ export default class Import extends Command {
 
     async run(): Promise<void> {
         const { args, flags } = await this.parse(Import);
-        const cwd = process.cwd();
+        const projectRoot = findProjectRoot(process.cwd());
+        if (!projectRoot) {
+            this.error('keyshelf.yml not found in current directory or any parent directory.');
+        }
 
         if (!fs.existsSync(args.file)) {
             this.error(`File not found: ${args.file}`);
@@ -44,14 +45,14 @@ export default class Import extends Command {
         const fileValues = parseEnvFile(content);
         const entries = Object.entries(fileValues);
 
-        const def = await loadEnvironment(cwd, flags.env);
+        const def = await loadEnvironment(projectRoot, flags.env);
         const tree = PathTree.fromJSON(def.values);
 
         let provider = null;
         if (flags.secrets) {
-            const config = loadConfig(cwd);
+            const config = loadConfig(projectRoot);
             const configDir =
-                flags['config-dir'] ?? path.join(os.homedir(), '.config', 'keyshelf', config.name);
+                flags['config-dir'] ?? defaultConfigDir(config);
             provider = resolveProvider(def, config, configDir);
         }
 
@@ -66,7 +67,7 @@ export default class Import extends Command {
             }
         }
 
-        await saveEnvironment(cwd, flags.env, { ...def, values: tree.toJSON() });
+        await saveEnvironment(projectRoot, flags.env, { ...def, values: tree.toJSON() });
         this.log(`Loaded ${entries.length} entries into "${flags.env}"`);
     }
 }

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -51,8 +51,7 @@ export default class Import extends Command {
         let provider = null;
         if (flags.secrets) {
             const config = loadConfig(projectRoot);
-            const configDir =
-                flags['config-dir'] ?? defaultConfigDir(config);
+            const configDir = flags['config-dir'] ?? defaultConfigDir(config);
             provider = resolveProvider(def, config, configDir);
         }
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -2,6 +2,7 @@ import { Command, Flags } from '@oclif/core';
 import fs from 'node:fs';
 import path from 'node:path';
 import yaml from 'js-yaml';
+import { findProjectRoot } from '../core/config.js';
 
 export default class Init extends Command {
     static override description = 'Initialize a new keyshelf project';
@@ -27,6 +28,13 @@ export default class Init extends Command {
 
         if (fs.existsSync(configPath) && !flags.force) {
             this.error('keyshelf.yml already exists (use --force to overwrite)');
+        }
+
+        const existingRoot = findProjectRoot(path.dirname(cwd));
+        if (existingRoot) {
+            this.error(
+                `keyshelf.yml already exists at ${existingRoot}. Nested keyshelf projects are not supported.`
+            );
         }
 
         let provider: Record<string, string>;

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -3,6 +3,7 @@ import { loadEnvironment } from '../core/environment.js';
 import { resolve } from '../core/resolver.js';
 import { PathTree } from '../core/path-tree.js';
 import { SecretRef } from '../core/types.js';
+import { findProjectRoot } from '../core/config.js';
 
 export default class List extends Command {
     static override description = 'List all paths in an environment';
@@ -15,9 +16,12 @@ export default class List extends Command {
 
     async run(): Promise<void> {
         const { flags } = await this.parse(List);
-        const cwd = process.cwd();
+        const projectRoot = findProjectRoot(process.cwd());
+        if (!projectRoot) {
+            this.error('keyshelf.yml not found in current directory or any parent directory.');
+        }
 
-        const resolved = await resolve(flags.env, (name) => loadEnvironment(cwd, name));
+        const resolved = await resolve(flags.env, (name) => loadEnvironment(projectRoot, name));
         const tree = PathTree.fromJSON(resolved.values);
         const paths = tree.list();
 

--- a/src/commands/print.ts
+++ b/src/commands/print.ts
@@ -1,7 +1,7 @@
 import { Command, Flags } from '@oclif/core';
 import yamlLib from 'js-yaml';
 import { loadEnvironment } from '../core/environment.js';
-import { loadConfig, defaultConfigDir } from '../core/config.js';
+import { loadConfig, defaultConfigDir, findProjectRoot } from '../core/config.js';
 import { resolve } from '../core/resolver.js';
 import { replaceSecrets, flattenToEnvRecord } from '../core/env-vars.js';
 import { SecretRef } from '../core/types.js';
@@ -32,11 +32,14 @@ export default class Print extends Command {
 
     async run(): Promise<void> {
         const { flags } = await this.parse(Print);
-        const cwd = process.cwd();
+        const projectRoot = findProjectRoot(process.cwd());
+        if (!projectRoot) {
+            this.error('keyshelf.yml not found in current directory or any parent directory.');
+        }
 
-        const envDef = await loadEnvironment(cwd, flags.env);
-        const resolved = await resolve(flags.env, (name) => loadEnvironment(cwd, name));
-        const config = loadConfig(cwd);
+        const envDef = await loadEnvironment(projectRoot, flags.env);
+        const resolved = await resolve(flags.env, (name) => loadEnvironment(projectRoot, name));
+        const config = loadConfig(projectRoot);
         const configDirPath = flags['config-dir'] ?? defaultConfigDir(config);
         const provider = resolveProvider(envDef, config, configDirPath);
 
@@ -61,7 +64,7 @@ export default class Print extends Command {
                 this.log(JSON.stringify(output, null, 2));
                 break;
             case 'env': {
-                const envMapping = loadEnvMapping(cwd);
+                const envMapping = loadEnvMapping(process.cwd());
                 if (Object.keys(envMapping).length === 0) {
                     this.warn(
                         'No .env.keyshelf file found — no environment variables will be injected.'

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -2,6 +2,7 @@ import { Command, Flags } from '@oclif/core';
 import { spawnSync } from 'node:child_process';
 import { resolveEnv } from '../core/resolve-env.js';
 import { loadEnvMapping } from '../core/env-keyshelf.js';
+import { findProjectRoot } from '../core/config.js';
 
 export default class Run extends Command {
     static override description =
@@ -27,14 +28,17 @@ export default class Run extends Command {
             this.error('No command specified. Provide a command after "--".');
         }
 
-        const projectDir = process.cwd();
-        const envMapping = loadEnvMapping(projectDir);
+        const projectRoot = findProjectRoot(process.cwd());
+        if (!projectRoot) {
+            this.error('keyshelf.yml not found in current directory or any parent directory.');
+        }
+        const envMapping = loadEnvMapping(process.cwd());
         if (Object.keys(envMapping).length === 0) {
             this.warn('No .env.keyshelf file found — no environment variables will be injected.');
         }
         const envRecord = await resolveEnv({
             env: flags.env,
-            projectDir,
+            projectDir: projectRoot,
             configDir: flags['config-dir'],
             envMapping
         });

--- a/src/commands/set.ts
+++ b/src/commands/set.ts
@@ -1,6 +1,6 @@
 import { Args, Command, Flags } from '@oclif/core';
 import { loadEnvironment, saveEnvironment, listEnvironments } from '../core/environment.js';
-import { loadConfig, defaultConfigDir } from '../core/config.js';
+import { loadConfig, defaultConfigDir, findProjectRoot } from '../core/config.js';
 import { resolve } from '../core/resolver.js';
 import { PathTree } from '../core/path-tree.js';
 import { SecretRef } from '../core/types.js';
@@ -28,10 +28,13 @@ export default class SetCommand extends Command {
 
     async run(): Promise<void> {
         const { args, flags } = await this.parse(SetCommand);
-        const cwd = process.cwd();
+        const projectRoot = findProjectRoot(process.cwd());
+        if (!projectRoot) {
+            this.error('keyshelf.yml not found in current directory or any parent directory.');
+        }
         const envName = flags.env;
 
-        const resolved = await resolve(envName, (name) => loadEnvironment(cwd, name));
+        const resolved = await resolve(envName, (name) => loadEnvironment(projectRoot, name));
         const resolvedTree = PathTree.fromJSON(resolved.values);
         const existing = resolvedTree.get(args.path);
 
@@ -42,21 +45,21 @@ export default class SetCommand extends Command {
         }
 
         if (existing === undefined) {
-            const envDef = await loadEnvironment(cwd, envName);
+            const envDef = await loadEnvironment(projectRoot, envName);
             const tree = PathTree.fromJSON(envDef.values);
             tree.set(args.path, new SecretRef(args.path));
-            await saveEnvironment(cwd, envName, { ...envDef, values: tree.toJSON() });
+            await saveEnvironment(projectRoot, envName, { ...envDef, values: tree.toJSON() });
         }
 
         const value = args.value ?? (await readMaskedLine(`Enter value for "${args.path}": `));
 
-        const config = loadConfig(cwd);
+        const config = loadConfig(projectRoot);
         const configDir = flags['config-dir'] ?? defaultConfigDir(config);
-        const envDef = await loadEnvironment(cwd, envName);
+        const envDef = await loadEnvironment(projectRoot, envName);
         const provider = resolveProvider(envDef, config, configDir);
         await provider.set(envName, args.path, value);
 
-        await this.propagateToImporters(cwd, envName, args.path, value, config, configDir);
+        await this.propagateToImporters(projectRoot, envName, args.path, value, config, configDir);
     }
 
     private async propagateToImporters(

--- a/src/commands/up.ts
+++ b/src/commands/up.ts
@@ -2,7 +2,7 @@ import { Command, Flags } from '@oclif/core';
 import fs from 'node:fs/promises';
 import readline from 'node:readline';
 import { listEnvironments, loadEnvironment } from '../core/environment.js';
-import { loadConfig, defaultConfigDir } from '../core/config.js';
+import { loadConfig, defaultConfigDir, findProjectRoot } from '../core/config.js';
 import { resolve as resolveEnv } from '../core/resolver.js';
 import { resolveProvider } from '../providers/index.js';
 import { EnvironmentDefinition, KeyshelfConfig } from '../core/types.js';
@@ -37,21 +37,24 @@ export default class Up extends Command {
 
     async run(): Promise<void> {
         const { flags } = await this.parse(Up);
-        const cwd = process.cwd();
-        const config = loadConfig(cwd);
+        const projectRoot = findProjectRoot(process.cwd());
+        if (!projectRoot) {
+            this.error('keyshelf.yml not found in current directory or any parent directory.');
+        }
+        const config = loadConfig(projectRoot);
         const configDir = flags['config-dir'] ?? defaultConfigDir(config);
 
-        const envNames = await listEnvironments(cwd);
+        const envNames = await listEnvironments(projectRoot);
         if (envNames.length === 0) {
             this.log('No environments found.');
             return;
         }
 
-        const envDefs = await loadAllEnvDefs(cwd, envNames);
+        const envDefs = await loadAllEnvDefs(projectRoot, envNames);
         const sortedNames = topoSort(
             Object.fromEntries(envNames.map((n) => [n, { imports: envDefs.get(n)!.imports }]))
         );
-        const ctx: PlanContext = { envDefs, config, configDir, cwd };
+        const ctx: PlanContext = { envDefs, config, configDir, projectRoot };
         const plan = await buildReconciliationPlan(ctx, sortedNames);
 
         this.log(renderPlan(plan));
@@ -102,11 +105,11 @@ export default class Up extends Command {
 }
 
 async function loadAllEnvDefs(
-    cwd: string,
+    projectRoot: string,
     envNames: string[]
 ): Promise<Map<string, EnvironmentDefinition>> {
     const entries = await Promise.all(
-        envNames.map(async (name) => [name, await loadEnvironment(cwd, name)] as const)
+        envNames.map(async (name) => [name, await loadEnvironment(projectRoot, name)] as const)
     );
     return new Map(entries);
 }
@@ -115,7 +118,7 @@ interface PlanContext {
     envDefs: Map<string, EnvironmentDefinition>;
     config: KeyshelfConfig;
     configDir: string;
-    cwd: string;
+    projectRoot: string;
 }
 
 async function buildReconciliationPlan(

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -48,6 +48,22 @@ export function defaultConfigDir(config: KeyshelfConfig): string {
     return path.join(os.homedir(), '.config', 'keyshelf', config.name);
 }
 
+/**
+ * Walk up from startDir until a directory containing `keyshelf.yml` is found.
+ *
+ * @param startDir - Directory to begin searching from
+ * @returns Absolute path to the first ancestor directory containing `keyshelf.yml`, or null
+ */
+export function findProjectRoot(startDir: string): string | null {
+    let dir = path.resolve(startDir);
+    while (true) {
+        if (fs.existsSync(path.join(dir, 'keyshelf.yml'))) return dir;
+        const parent = path.dirname(dir);
+        if (parent === dir) return null;
+        dir = parent;
+    }
+}
+
 /** Load and validate keyshelf.yml from a project root directory. */
 export function loadConfig(projectRoot: string): KeyshelfConfig {
     const configPath = path.join(projectRoot, 'keyshelf.yml');

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -1,14 +1,18 @@
 import { resolveEnv } from './core/resolve-env.js';
 import { loadEnvMapping } from './core/env-keyshelf.js';
+import { findProjectRoot } from './core/config.js';
 
 const env = process.env.KEYSHELF_ENV;
 if (!env) {
     throw new Error('KEYSHELF_ENV is required when using keyshelf/preload');
 }
 
-const projectDir = process.env.KEYSHELF_PROJECT_DIR ?? process.cwd();
+const projectDir = process.env.KEYSHELF_PROJECT_DIR ?? findProjectRoot(process.cwd());
+if (!projectDir) {
+    throw new Error('keyshelf.yml not found in current directory or any parent directory.');
+}
 const configDir = process.env.KEYSHELF_CONFIG_DIR;
-const envMapping = loadEnvMapping(projectDir);
+const envMapping = loadEnvMapping(process.cwd());
 const envRecord = await resolveEnv({ env, projectDir, configDir, envMapping });
 
 for (const [key, value] of Object.entries(envRecord)) {

--- a/test/commands/env/create.test.ts
+++ b/test/commands/env/create.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
+import yaml from 'js-yaml';
 import Create from '../../../src/commands/env/create.js';
 import { loadEnvironment } from '../../../src/core/environment.js';
 
@@ -14,6 +15,10 @@ describe('env:create command', () => {
         origCwd = process.cwd();
         process.chdir(tmpDir);
         fs.mkdirSync(path.join(tmpDir, '.keyshelf', 'environments'), { recursive: true });
+        fs.writeFileSync(
+            path.join(tmpDir, 'keyshelf.yml'),
+            yaml.dump({ name: 'test-project', provider: { adapter: 'local' } })
+        );
     });
 
     afterEach(() => {

--- a/test/commands/init.test.ts
+++ b/test/commands/init.test.ts
@@ -74,4 +74,24 @@ describe('init command', () => {
         const config = yaml.load(content) as Record<string, unknown>;
         expect(config.provider).toEqual({ adapter: 'aws-sm' });
     });
+
+    it('errors when a parent directory already has keyshelf.yml (nested projects)', async () => {
+        fs.writeFileSync(path.join(tmpDir, 'keyshelf.yml'), 'existing: true');
+        const subDir = path.join(tmpDir, 'packages', 'app');
+        fs.mkdirSync(subDir, { recursive: true });
+        process.chdir(subDir);
+
+        await expect(Init.run([])).rejects.toThrow(/Nested keyshelf projects are not supported/);
+    });
+
+    it('--force does not bypass ancestor keyshelf.yml check', async () => {
+        fs.writeFileSync(path.join(tmpDir, 'keyshelf.yml'), 'existing: true');
+        const subDir = path.join(tmpDir, 'packages', 'app');
+        fs.mkdirSync(subDir, { recursive: true });
+        process.chdir(subDir);
+
+        await expect(Init.run(['--force'])).rejects.toThrow(
+            /Nested keyshelf projects are not supported/
+        );
+    });
 });

--- a/test/commands/print.test.ts
+++ b/test/commands/print.test.ts
@@ -273,3 +273,62 @@ describe('print command', () => {
         expect(output).toContain('local: from-dev');
     });
 });
+
+describe('walk-up discovery (print command)', () => {
+    let tmpDir: string;
+    let origCwd: string;
+    let logSpy: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'keyshelf-print-walkup-'));
+        origCwd = process.cwd();
+        fs.mkdirSync(path.join(tmpDir, '.keyshelf', 'environments'), { recursive: true });
+        fs.writeFileSync(
+            path.join(tmpDir, 'keyshelf.yml'),
+            yaml.dump({ name: 'test-project', provider: { adapter: 'local' } })
+        );
+        logSpy = vi.fn();
+        vi.spyOn(Print.prototype, 'log').mockImplementation(logSpy);
+    });
+
+    afterEach(() => {
+        process.chdir(origCwd);
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+        vi.restoreAllMocks();
+    });
+
+    it('--format env from a subdirectory uses the subdirectory .env.keyshelf', async () => {
+        await saveEnvironment(tmpDir, 'dev', {
+            imports: [],
+            values: { app: { name: 'myapp', port: 3000 } }
+        });
+
+        const subDir = path.join(tmpDir, 'packages', 'web');
+        fs.mkdirSync(subDir, { recursive: true });
+        fs.writeFileSync(path.join(subDir, '.env.keyshelf'), 'APP_PORT=app/port\n');
+        process.chdir(subDir);
+
+        await Print.run(['--env', 'dev', '--format', 'env']);
+
+        const output = logSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n');
+        expect(output).toContain('APP_PORT=3000');
+        expect(output).not.toContain('APP_NAME');
+    });
+
+    it('yaml format from a subdirectory resolves config from the project root', async () => {
+        await saveEnvironment(tmpDir, 'dev', {
+            imports: [],
+            values: { database: { host: 'db.internal', port: 5432 } }
+        });
+
+        const subDir = path.join(tmpDir, 'packages', 'web');
+        fs.mkdirSync(subDir, { recursive: true });
+        process.chdir(subDir);
+
+        await Print.run(['--env', 'dev']);
+
+        const output = logSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n');
+        expect(output).toContain('host: db.internal');
+        expect(output).toContain('port: 5432');
+    });
+});

--- a/test/commands/run.test.ts
+++ b/test/commands/run.test.ts
@@ -202,6 +202,92 @@ describe('run command', () => {
     });
 });
 
+describe('walk-up discovery', () => {
+    let tmpDir: string;
+    let origCwd: string;
+    let outFile: string;
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'keyshelf-run-walkup-'));
+        outFile = path.join(tmpDir, 'output.txt');
+        origCwd = process.cwd();
+        fs.mkdirSync(path.join(tmpDir, '.keyshelf', 'environments'), { recursive: true });
+        fs.writeFileSync(
+            path.join(tmpDir, 'keyshelf.yml'),
+            yaml.dump({ name: 'test-project', provider: { adapter: 'local' } })
+        );
+    });
+
+    afterEach(() => {
+        process.chdir(origCwd);
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+        vi.restoreAllMocks();
+    });
+
+    it('resolves config from project root and env mapping from cwd when run from a subdirectory', async () => {
+        await saveEnvironment(tmpDir, 'dev', {
+            imports: [],
+            values: { database: { host: 'localhost' } }
+        });
+
+        const subDir = path.join(tmpDir, 'packages', 'api');
+        fs.mkdirSync(subDir, { recursive: true });
+        fs.writeFileSync(path.join(subDir, '.env.keyshelf'), 'DATABASE_HOST=database/host\n');
+        process.chdir(subDir);
+
+        const exitSpy = vi.spyOn(Run.prototype, 'exit').mockImplementation(() => {
+            throw new Error('EXIT');
+        });
+
+        const script = `require("fs").writeFileSync(${JSON.stringify(outFile)}, process.env.DATABASE_HOST)`;
+        await runAndCatch(['--env', 'dev', '--', 'node', '-e', script]);
+
+        const output = fs.readFileSync(outFile, 'utf-8');
+        expect(output).toBe('localhost');
+        expect(exitSpy).toHaveBeenCalledWith(0);
+    });
+
+    it('does not load .env.keyshelf from the project root when run from a subdirectory without one', async () => {
+        await saveEnvironment(tmpDir, 'dev', {
+            imports: [],
+            values: { database: { host: 'localhost' } }
+        });
+
+        fs.writeFileSync(path.join(tmpDir, '.env.keyshelf'), 'ROOT_VAR=database/host\n');
+
+        const subDir = path.join(tmpDir, 'packages', 'api');
+        fs.mkdirSync(subDir, { recursive: true });
+        process.chdir(subDir);
+
+        const warnSpy = vi.spyOn(Run.prototype, 'warn').mockImplementation(() => {
+            return undefined as never;
+        });
+        const exitSpy = vi.spyOn(Run.prototype, 'exit').mockImplementation(() => {
+            throw new Error('EXIT');
+        });
+
+        await runAndCatch(['--env', 'dev', '--', 'node', '-e', '1']);
+
+        expect(warnSpy).toHaveBeenCalledWith(
+            'No .env.keyshelf file found — no environment variables will be injected.'
+        );
+        expect(exitSpy).toHaveBeenCalledWith(0);
+    });
+
+    it('errors when no keyshelf.yml exists anywhere up the tree', async () => {
+        const emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'keyshelf-no-config-'));
+        process.chdir(emptyDir);
+
+        try {
+            await expect(Run.run(['--env', 'dev', '--', 'node', '-e', '1'])).rejects.toThrow(
+                /keyshelf\.yml not found/
+            );
+        } finally {
+            fs.rmSync(emptyDir, { recursive: true, force: true });
+        }
+    });
+});
+
 async function runAndCatch(argv: string[]): Promise<void> {
     try {
         await Run.run(argv);

--- a/test/core/config.test.ts
+++ b/test/core/config.test.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import yaml from 'js-yaml';
-import { loadConfig, parseProviderConfig } from '../../src/core/config.js';
+import { loadConfig, parseProviderConfig, findProjectRoot } from '../../src/core/config.js';
 
 describe('config validation', () => {
     let tmpDir: string;
@@ -129,6 +129,55 @@ describe('config validation', () => {
 
         const config = loadConfig(tmpDir);
         expect(config.provider).toEqual({ adapter: 'aws-sm' });
+    });
+});
+
+describe('findProjectRoot', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'keyshelf-find-root-'));
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('finds keyshelf.yml in startDir itself', () => {
+        fs.writeFileSync(path.join(tmpDir, 'keyshelf.yml'), 'name: test\n');
+
+        const result = findProjectRoot(tmpDir);
+        expect(result).toBe(path.resolve(tmpDir));
+    });
+
+    it('finds keyshelf.yml two levels up', () => {
+        fs.writeFileSync(path.join(tmpDir, 'keyshelf.yml'), 'name: test\n');
+        const subDir = path.join(tmpDir, 'packages', 'app');
+        fs.mkdirSync(subDir, { recursive: true });
+
+        const result = findProjectRoot(subDir);
+        expect(result).toBe(path.resolve(tmpDir));
+    });
+
+    it('returns null when keyshelf.yml is not found anywhere', () => {
+        const subDir = path.join(tmpDir, 'some', 'deep', 'dir');
+        fs.mkdirSync(subDir, { recursive: true });
+
+        // Use a sub-path of tmpDir that has no keyshelf.yml, but we cannot
+        // guarantee tmpDir ancestors don't have one, so use a fresh isolated path.
+        // We test with a non-existent start to ensure null is returned when walking
+        // up finds nothing. Instead, we write keyshelf.yml nowhere and start from
+        // a deep subdir — if the test machine's tmpdir ancestors don't have keyshelf.yml
+        // (they won't), this returns null.
+        const result = findProjectRoot(subDir);
+        expect(result).toBeNull();
+    });
+
+    it('returns the resolved absolute path', () => {
+        fs.writeFileSync(path.join(tmpDir, 'keyshelf.yml'), 'name: test\n');
+
+        const result = findProjectRoot(tmpDir);
+        expect(path.isAbsolute(result!)).toBe(true);
     });
 });
 

--- a/test/preload.test.ts
+++ b/test/preload.test.ts
@@ -62,10 +62,11 @@ describe('keyshelf/preload', () => {
         );
 
         const script = `import fs from "node:fs"; fs.writeFileSync(${JSON.stringify(outFile)}, process.env.DATABASE_HOST + ":" + process.env.DATABASE_PORT)`;
-        const result = runPreload(script, {
-            KEYSHELF_ENV: 'dev',
-            KEYSHELF_PROJECT_DIR: tmpDir
-        });
+        const result = runPreload(
+            script,
+            { KEYSHELF_ENV: 'dev', KEYSHELF_PROJECT_DIR: tmpDir },
+            tmpDir
+        );
 
         expect(result.status, result.stderr).toBe(0);
         expect(result.output).toBe('localhost:5432');
@@ -84,11 +85,11 @@ describe('keyshelf/preload', () => {
         fs.writeFileSync(path.join(tmpDir, '.env.keyshelf'), 'API_KEY=api/key\nAPI_URL=api/url\n');
 
         const script = `import fs from "node:fs"; fs.writeFileSync(${JSON.stringify(outFile)}, process.env.API_KEY + "|" + process.env.API_URL)`;
-        const result = runPreload(script, {
-            KEYSHELF_ENV: 'prod',
-            KEYSHELF_PROJECT_DIR: tmpDir,
-            KEYSHELF_CONFIG_DIR: configDir
-        });
+        const result = runPreload(
+            script,
+            { KEYSHELF_ENV: 'prod', KEYSHELF_PROJECT_DIR: tmpDir, KEYSHELF_CONFIG_DIR: configDir },
+            tmpDir
+        );
 
         expect(result.status, result.stderr).toBe(0);
         expect(result.output).toBe('super-secret-key|https://api.example.com');
@@ -116,10 +117,11 @@ describe('keyshelf/preload', () => {
         fs.writeFileSync(path.join(tmpDir, '.env.keyshelf'), 'SHARED=shared\nLOCAL=local\n');
 
         const script = `import fs from "node:fs"; fs.writeFileSync(${JSON.stringify(outFile)}, process.env.SHARED + "|" + process.env.LOCAL)`;
-        const result = runPreload(script, {
-            KEYSHELF_ENV: 'dev',
-            KEYSHELF_PROJECT_DIR: tmpDir
-        });
+        const result = runPreload(
+            script,
+            { KEYSHELF_ENV: 'dev', KEYSHELF_PROJECT_DIR: tmpDir },
+            tmpDir
+        );
 
         expect(result.status, result.stderr).toBe(0);
         expect(result.output).toBe('from-base|from-dev');
@@ -141,5 +143,44 @@ describe('keyshelf/preload', () => {
 
         expect(result.status, result.stderr).toBe(0);
         expect(result.output).toBe('from-cwd');
+    });
+
+    it('walks up from a subdirectory to find keyshelf.yml when KEYSHELF_PROJECT_DIR is not set', async () => {
+        await saveEnvironment(tmpDir, 'dev', {
+            imports: [],
+            values: { service: { name: 'walked-up' } }
+        });
+
+        const subDir = path.join(tmpDir, 'packages', 'myapp');
+        fs.mkdirSync(subDir, { recursive: true });
+        // .env.keyshelf is package-local — it lives in the package subdirectory
+        fs.writeFileSync(path.join(subDir, '.env.keyshelf'), 'SERVICE_NAME=service/name\n');
+
+        const script = `import fs from "node:fs"; fs.writeFileSync(${JSON.stringify(outFile)}, process.env.SERVICE_NAME)`;
+        const result = runPreload(
+            script,
+            { KEYSHELF_ENV: 'dev', KEYSHELF_PROJECT_DIR: undefined },
+            subDir
+        );
+
+        expect(result.status, result.stderr).toBe(0);
+        expect(result.output).toBe('walked-up');
+    });
+
+    it('throws a clear error when keyshelf.yml is not found in cwd or any ancestor', async () => {
+        const isolatedDir = fs.mkdtempSync(path.join(os.tmpdir(), 'keyshelf-no-config-'));
+        try {
+            const script = `console.log("should not reach")`;
+            const result = runPreload(
+                script,
+                { KEYSHELF_ENV: 'dev', KEYSHELF_PROJECT_DIR: undefined },
+                isolatedDir
+            );
+
+            expect(result.status).not.toBe(0);
+            expect(result.stderr).toMatch(/keyshelf\.yml not found/);
+        } finally {
+            fs.rmSync(isolatedDir, { recursive: true, force: true });
+        }
     });
 });


### PR DESCRIPTION
## Summary

- Add `findProjectRoot()` that walks up from `process.cwd()` to find `keyshelf.yml`, similar to how Node resolves `node_modules`
- All commands use walk-up discovery instead of assuming `keyshelf.yml` is in cwd
- `.env.keyshelf` stays cwd-relative — each package in a monorepo maintains its own env var mapping
- `init` blocks nested projects by checking for ancestor `keyshelf.yml`
- Preload uses walk-up as fallback when `KEYSHELF_PROJECT_DIR` is unset

## Test plan

- [ ] Unit tests for `findProjectRoot` (found in cwd, found two levels up, returns null)
- [ ] `init` rejects nested projects, `--force` does not bypass
- [ ] `run` from subdirectory: config from root, `.env.keyshelf` from cwd
- [ ] `run` from subdirectory: root's `.env.keyshelf` is ignored
- [ ] `run` errors when no `keyshelf.yml` found anywhere
- [ ] `print --format env` from subdirectory uses cwd's mapping
- [ ] `print` yaml from subdirectory resolves config from project root
- [ ] Preload walks up from subdirectory
- [ ] Preload errors when no config found

🤖 Generated with [Claude Code](https://claude.com/claude-code)