### PR TITLE
feat: add `rm` command to remove secrets and config values

### DIFF
--- a/src/commands/rm.test.ts
+++ b/src/commands/rm.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createCli } from "@/commands/test-helpers";
+
+let tempDir: string;
+let cli: ReturnType<typeof createCli>;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), "keyshelf-rm-test-"));
+  cli = createCli(tempDir);
+  cli(["init", "test-app"]);
+});
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+describe("keyshelf rm (plaintext)", () => {
+  it("removes a value for the default env", async () => {
+    cli(["set", "database/url", "postgres://localhost/db"]);
+    cli(["rm", "database/url", "--yes"]);
+
+    const yaml = await readFile(join(tempDir, "keyshelf.yaml"), "utf-8");
+    expect(yaml).not.toContain("database/url");
+  });
+
+  it("removes a value for a specific env while leaving others intact", async () => {
+    cli(["set", "api/key", "default-value"]);
+    cli(["set", "api/key", "staging-value", "--env", "staging"]);
+    cli(["rm", "api/key", "--env", "staging", "--yes"]);
+
+    const yaml = await readFile(join(tempDir, "keyshelf.yaml"), "utf-8");
+    expect(yaml).toContain("api/key");
+    expect(yaml).not.toContain("staging-value");
+    expect(yaml).toContain("default-value");
+  });
+
+  it("removes the entire key entry when the last env value is deleted", async () => {
+    cli(["set", "api/key", "only-value"]);
+    cli(["rm", "api/key", "--yes"]);
+
+    const yaml = await readFile(join(tempDir, "keyshelf.yaml"), "utf-8");
+    expect(yaml).not.toContain("api/key");
+  });
+});
+
+describe("keyshelf rm (error cases)", () => {
+  it("errors when key doesn't exist", () => {
+    expect(() => cli(["rm", "nonexistent/key", "--yes"])).toThrow();
+  });
+
+  it("errors when env doesn't exist on key", () => {
+    cli(["set", "api/key", "some-value"]);
+    expect(() => cli(["rm", "api/key", "--env", "nonexistent", "--yes"])).toThrow();
+  });
+
+  it("errors when no keyshelf.yaml exists", async () => {
+    const emptyDir = await mkdtemp(join(tmpdir(), "keyshelf-rm-noinit-"));
+    const emptyCli = createCli(emptyDir);
+    try {
+      expect(() => emptyCli(["rm", "api/key", "--yes"])).toThrow();
+    } finally {
+      await rm(emptyDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("keyshelf rm (round-trip)", () => {
+  it("set then rm then get should error with not found", () => {
+    cli(["set", "database/url", "postgres://localhost/db"]);
+    cli(["rm", "database/url", "--yes"]);
+    expect(() => cli(["get", "database/url"])).toThrow();
+  });
+});

--- a/src/commands/rm.ts
+++ b/src/commands/rm.ts
@@ -1,0 +1,64 @@
+import { defineCommand } from "citty";
+import { createInterface } from "node:readline";
+import { findSchemaPath, readSchema, writeSchema } from "@/schema";
+
+async function confirmRemoval(key: string, env: string): Promise<boolean> {
+  const rl = createInterface({ input: process.stdin, output: process.stderr });
+  return new Promise((resolve) => {
+    rl.question(`Remove '${key}' for env '${env}'? (y/N) `, (answer) => {
+      rl.close();
+      resolve(answer.toLowerCase() === "y" || answer.toLowerCase() === "yes");
+    });
+  });
+}
+
+export const rmCommand = defineCommand({
+  meta: { description: "Remove a value for a specific environment" },
+  args: {
+    key: {
+      type: "positional",
+      description: "Key path (e.g. database/url)",
+      required: true
+    },
+    env: {
+      type: "string",
+      description: "Target environment",
+      default: "default"
+    },
+    yes: {
+      type: "boolean",
+      alias: "y",
+      description: "Skip confirmation prompt",
+      default: false
+    }
+  },
+  async run({ args }) {
+    const filePath = findSchemaPath();
+    const schema = await readSchema(filePath);
+
+    if (!schema.keys[args.key]) {
+      throw new Error(`Key '${args.key}' not found in keyshelf.yaml.`);
+    }
+
+    if (schema.keys[args.key][args.env] === undefined) {
+      throw new Error(`Key '${args.key}' has no value for env '${args.env}'.`);
+    }
+
+    if (!args.yes) {
+      const confirmed = await confirmRemoval(args.key, args.env);
+      if (!confirmed) {
+        process.stderr.write("Aborted.\n");
+        return;
+      }
+    }
+
+    delete schema.keys[args.key][args.env];
+
+    if (Object.keys(schema.keys[args.key]).length === 0) {
+      delete schema.keys[args.key];
+    }
+
+    await writeSchema(schema, filePath);
+    console.log(`Removed '${args.key}' for env '${args.env}'.`);
+  }
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { defineCommand, runMain } from "citty";
 import { initCommand } from "@/commands/init";
 import { setCommand } from "@/commands/set";
 import { getCommand } from "@/commands/get";
+import { rmCommand } from "@/commands/rm";
 import { runCommand } from "@/commands/run";
 import { exportCommand } from "@/commands/export";
 
@@ -15,6 +16,7 @@ const main = defineCommand({
     init: initCommand,
     set: setCommand,
     get: getCommand,
+    rm: rmCommand,
     run: runCommand,
     export: exportCommand
   }


### PR DESCRIPTION
## Summary
- Adds `keyshelf rm <key> [--env <env>] [--yes/-y]` to remove a specific env value from a key in `keyshelf.yaml`
- Prompts for confirmation unless `--yes`/`-y` is passed (defaults to "no")
- Automatically cleans up the entire key entry when its last env value is removed
- Errors on missing key or missing env value

## Test plan
- [x] 7 integration tests added covering happy paths, error cases, and set/rm/get round-trip
- [x] All 115 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)