### PR TITLE
feat: add `ls` command to list keys and their environments

### DIFF
--- a/src/commands/ls.test.ts
+++ b/src/commands/ls.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createCli } from "@/commands/test-helpers";
+
+let tempDir: string;
+let cli: ReturnType<typeof createCli>;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), "keyshelf-ls-test-"));
+  cli = createCli(tempDir);
+  cli(["init", "test-app"]);
+});
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+describe("keyshelf ls", () => {
+  it("shows nothing when there are no keys", () => {
+    const output = cli(["ls"]);
+    expect(output.trim()).toBe("No keys found.");
+  });
+
+  it("lists a single plain key", () => {
+    cli(["set", "database/url", "postgres://localhost/db"]);
+    const output = cli(["ls"]);
+    expect(output).toContain("database/url");
+    expect(output).toContain("default (plain)");
+  });
+
+  it("lists an age-encrypted key", () => {
+    cli(["set", "--provider", "age", "api/key"], { input: "secret" });
+    const output = cli(["ls"]);
+    expect(output).toContain("api/key");
+    expect(output).toContain("default (!age)");
+  });
+
+  it("lists multiple keys with multiple environments", () => {
+    cli(["set", "database/url", "localhost"]);
+    cli(["set", "database/url", "staging-db", "--env", "staging"]);
+    cli(["set", "--provider", "age", "api/key"], { input: "secret" });
+
+    const output = cli(["ls"]);
+    expect(output).toContain("database/url");
+    expect(output).toContain("default (plain)");
+    expect(output).toContain("staging (plain)");
+    expect(output).toContain("api/key");
+    expect(output).toContain("default (!age)");
+  });
+
+  it("shows default environment before others", () => {
+    cli(["set", "app/port", "3000", "--env", "staging"]);
+    cli(["set", "app/port", "8080"]);
+
+    const output = cli(["ls"]);
+    const line = output.split("\n").find((l) => l.includes("app/port"))!;
+    const defaultIdx = line.indexOf("default");
+    const stagingIdx = line.indexOf("staging");
+    expect(defaultIdx).toBeLessThan(stagingIdx);
+  });
+});

--- a/src/commands/ls.ts
+++ b/src/commands/ls.ts
@@ -1,0 +1,42 @@
+import { defineCommand } from "citty";
+import { readSchema } from "@/schema";
+import { isTaggedValue } from "@/types";
+
+/** Sort environments: "default" first, then alphabetical */
+function sortEnvs(envs: string[]): string[] {
+  return envs.sort((a, b) => {
+    if (a === "default") return -1;
+    if (b === "default") return 1;
+    return a.localeCompare(b);
+  });
+}
+
+export const lsCommand = defineCommand({
+  meta: { description: "List all keys and their environments" },
+  async run() {
+    const schema = await readSchema();
+    const entries = Object.entries(schema.keys);
+
+    if (entries.length === 0) {
+      process.stdout.write("No keys found.\n");
+      return;
+    }
+
+    const rows = entries.map(([keyPath, entry]) => {
+      const envs = sortEnvs(Object.keys(entry));
+      const envLabels = envs.map((env) => {
+        const value = entry[env];
+        const provider = isTaggedValue(value) ? value._tag : "plain";
+        return `${env} (${provider})`;
+      });
+      return { key: keyPath, envs: envLabels.join(", ") };
+    });
+
+    const maxKeyLen = Math.max(...rows.map((r) => r.key.length), 3);
+    const header = `${"KEY".padEnd(maxKeyLen)}  ENVIRONMENTS`;
+    const separator = `${"─".repeat(maxKeyLen)}  ${"─".repeat(40)}`;
+    const lines = rows.map((r) => `${r.key.padEnd(maxKeyLen)}  ${r.envs}`);
+
+    process.stdout.write([header, separator, ...lines, ""].join("\n"));
+  }
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { getCommand } from "@/commands/get";
 import { rmCommand } from "@/commands/rm";
 import { runCommand } from "@/commands/run";
 import { exportCommand } from "@/commands/export";
+import { lsCommand } from "@/commands/ls";
 
 const main = defineCommand({
   meta: {
@@ -17,6 +18,7 @@ const main = defineCommand({
     set: setCommand,
     get: getCommand,
     rm: rmCommand,
+    ls: lsCommand,
     run: runCommand,
     export: exportCommand
   }


### PR DESCRIPTION
## Summary

- Adds `keyshelf ls` command that reads `keyshelf.yaml` and prints a table of all keys with their environments and provider tags
- Output format: `KEY  ENVIRONMENTS` with entries like `default (plain)`, `staging (!awssm)`, `default (!age)`
- Default environment is always listed first, remaining environments sorted alphabetically

## Test plan

- [x] Empty project shows "No keys found."
- [x] Single plain key shows `default (plain)`
- [x] Age-encrypted key shows `default (!age)`
- [x] Multiple keys with multiple environments render correctly
- [x] Default environment appears before other environments
- [x] All existing tests still pass (112/112)

🤖 Generated with [Claude Code](https://claude.com/claude-code)