### PR TITLE
feat: support .env.keyshelf mapping file for custom env var names

### DIFF
--- a/src/commands/export.test.ts
+++ b/src/commands/export.test.ts
@@ -3,8 +3,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { createCli } from "@/commands/test-helpers";
-import { rmSync } from "node:fs";
-import { mkdtempSync } from "node:fs";
+import { rmSync, mkdtempSync, writeFileSync } from "node:fs";
 
 let tempDir: string;
 let cli: ReturnType<typeof createCli>;
@@ -75,5 +74,28 @@ describe("keyshelf export", () => {
     } finally {
       rmSync(emptyDir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("keyshelf export with .env.keyshelf", () => {
+  it("exports only mapped keys in dotenv format", () => {
+    writeFileSync(join(tempDir, ".env.keyshelf"), "MY_API=api/key\n");
+    const output = cli(["export", "--env", "default"]);
+    expect(output).toContain('MY_API="secret-123"');
+    expect(output).not.toContain("DATABASE_URL");
+    expect(output).not.toContain("API_KEY");
+  });
+
+  it("exports only mapped keys in json format", () => {
+    writeFileSync(join(tempDir, ".env.keyshelf"), "DB=database/url\n");
+    const output = cli(["export", "--env", "default", "--format", "json"]);
+    const parsed = JSON.parse(output);
+    expect(parsed.DB).toBe("postgres://localhost/db");
+    expect(parsed.API_KEY).toBeUndefined();
+  });
+
+  it("errors when .env.keyshelf references a nonexistent key", () => {
+    writeFileSync(join(tempDir, ".env.keyshelf"), "MISSING=no/such/key\n");
+    expect(() => cli(["export", "--env", "default"])).toThrow();
   });
 });

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -1,6 +1,7 @@
 import { defineCommand } from "citty";
 import { readSchema } from "@/schema";
-import { resolveAllKeys } from "@/resolver";
+import { resolveAllKeys, resolveMappedKeys } from "@/resolver";
+import { readEnvKeyshelf } from "@/env-keyshelf";
 
 function formatDotenv(record: Record<string, string>): string {
   return Object.entries(record)
@@ -24,7 +25,10 @@ export const exportCommand = defineCommand({
   },
   async run({ args }) {
     const schema = await readSchema();
-    const resolved = await resolveAllKeys(schema, args.env);
+    const mapping = await readEnvKeyshelf();
+    const resolved = mapping
+      ? await resolveMappedKeys(schema, args.env, mapping)
+      : await resolveAllKeys(schema, args.env);
 
     if (args.format === "json") {
       process.stdout.write(JSON.stringify(resolved, null, 2));

--- a/src/commands/run.test.ts
+++ b/src/commands/run.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { writeFileSync } from "node:fs";
 import { createCli } from "@/commands/test-helpers";
 
 let tempDir: string;
@@ -81,5 +82,36 @@ describe("keyshelf run", () => {
     ]);
     delete process.env.MY_TOKEN;
     expect(output).toBe("overridden-value");
+  });
+});
+
+describe("keyshelf run with .env.keyshelf", () => {
+  it("injects only mapped keys with custom env var names", () => {
+    writeFileSync(join(tempDir, ".env.keyshelf"), "MY_API=api/key\n");
+    const output = cli(["run", "--env", "default", "--", "env"]);
+    expect(output).toContain("MY_API=secret-123");
+    expect(output).not.toContain("DATABASE_URL=");
+    expect(output).not.toContain("API_KEY=");
+  });
+
+  it("excludes unmapped keys from the subprocess env", () => {
+    writeFileSync(join(tempDir, ".env.keyshelf"), "DB=database/url\n");
+    const output = cli([
+      "run",
+      "--env",
+      "default",
+      "--",
+      "node",
+      "-e",
+      "process.stdout.write(JSON.stringify({ DB: process.env.DB, API_KEY: process.env.API_KEY }))"
+    ]);
+    const parsed = JSON.parse(output);
+    expect(parsed.DB).toBe("postgres://localhost/db");
+    expect(parsed.API_KEY).toBeUndefined();
+  });
+
+  it("errors when .env.keyshelf references a nonexistent key", () => {
+    writeFileSync(join(tempDir, ".env.keyshelf"), "MISSING=no/such/key\n");
+    expect(() => cli(["run", "--env", "default", "--", "env"])).toThrow();
   });
 });

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,7 +1,8 @@
 import { defineCommand } from "citty";
 import { spawnSync } from "node:child_process";
 import { readSchema } from "@/schema";
-import { resolveAllKeys } from "@/resolver";
+import { resolveAllKeys, resolveMappedKeys } from "@/resolver";
+import { readEnvKeyshelf } from "@/env-keyshelf";
 
 export const runCommand = defineCommand({
   meta: { description: "Inject resolved values as env vars and run a command" },
@@ -20,7 +21,10 @@ export const runCommand = defineCommand({
     }
 
     const schema = await readSchema();
-    const resolved = await resolveAllKeys(schema, args.env);
+    const mapping = await readEnvKeyshelf();
+    const resolved = mapping
+      ? await resolveMappedKeys(schema, args.env, mapping)
+      : await resolveAllKeys(schema, args.env);
 
     const result = spawnSync(cmd[0], cmd.slice(1), {
       env: { ...process.env, ...resolved },

--- a/src/env-keyshelf.test.ts
+++ b/src/env-keyshelf.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { parseEnvKeyshelf, findEnvKeyshelfPath } from "@/env-keyshelf";
+
+describe("parseEnvKeyshelf", () => {
+  it("parses valid key=value lines into a mapping", () => {
+    const content = "DB_PASSWORD=database.password\nAPI_KEY=api.key";
+    expect(parseEnvKeyshelf(content)).toEqual({
+      DB_PASSWORD: "database.password",
+      API_KEY: "api.key"
+    });
+  });
+
+  it("skips blank lines and comments", () => {
+    const content = [
+      "# this is a comment",
+      "",
+      "DB_PASSWORD=database.password",
+      "  ",
+      "  # indented comment",
+      "API_KEY=api.key"
+    ].join("\n");
+    expect(parseEnvKeyshelf(content)).toEqual({
+      DB_PASSWORD: "database.password",
+      API_KEY: "api.key"
+    });
+  });
+
+  it("trims whitespace around = sign", () => {
+    const content = "  DB_PASSWORD  =  database.password  ";
+    expect(parseEnvKeyshelf(content)).toEqual({
+      DB_PASSWORD: "database.password"
+    });
+  });
+
+  it("throws on line with no = sign", () => {
+    expect(() => parseEnvKeyshelf("INVALID_LINE")).toThrow(
+      "Malformed line 1 in .env.keyshelf: missing '='"
+    );
+  });
+
+  it("throws on empty env var name", () => {
+    expect(() => parseEnvKeyshelf("=database.password")).toThrow(
+      "Malformed line 1 in .env.keyshelf: empty env var name"
+    );
+  });
+
+  it("throws on empty key path", () => {
+    expect(() => parseEnvKeyshelf("DB_PASSWORD=")).toThrow(
+      "Malformed line 1 in .env.keyshelf: empty key path"
+    );
+  });
+
+  it("allows duplicate env var names (last wins)", () => {
+    const content = "DB_URL=database.url\nDB_URL=database.connection";
+    expect(parseEnvKeyshelf(content)).toEqual({
+      DB_URL: "database.connection"
+    });
+  });
+
+  it("allows same key path mapped to multiple env vars", () => {
+    const content = "SUPABASE_URL=supabase.url\nEXPO_PUBLIC_SUPABASE_URL=supabase.url";
+    expect(parseEnvKeyshelf(content)).toEqual({
+      SUPABASE_URL: "supabase.url",
+      EXPO_PUBLIC_SUPABASE_URL: "supabase.url"
+    });
+  });
+
+  it("returns empty record for file with only comments and blanks", () => {
+    const content = "# just a comment\n\n  \n";
+    expect(parseEnvKeyshelf(content)).toEqual({});
+  });
+});
+
+describe("findEnvKeyshelfPath", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "keyshelf-envfile-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("finds .env.keyshelf in the given directory", async () => {
+    const filePath = join(tempDir, ".env.keyshelf");
+    await writeFile(filePath, "DB_URL=database.url");
+
+    expect(findEnvKeyshelfPath(tempDir)).toBe(filePath);
+  });
+
+  it("finds .env.keyshelf in an ancestor directory", async () => {
+    const filePath = join(tempDir, ".env.keyshelf");
+    await writeFile(filePath, "DB_URL=database.url");
+
+    const subDir = join(tempDir, "sub", "deep");
+    await mkdir(subDir, { recursive: true });
+
+    expect(findEnvKeyshelfPath(subDir)).toBe(filePath);
+  });
+
+  it("returns null when no .env.keyshelf exists", () => {
+    expect(findEnvKeyshelfPath(tempDir)).toBeNull();
+  });
+});

--- a/src/env-keyshelf.ts
+++ b/src/env-keyshelf.ts
@@ -1,0 +1,57 @@
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { resolve, dirname } from "node:path";
+
+const ENV_KEYSHELF_FILENAME = ".env.keyshelf";
+
+/** Walk up from `from` looking for `.env.keyshelf`. Returns path or `null`. */
+export function findEnvKeyshelfPath(from: string = process.cwd()): string | null {
+  let dir = resolve(from);
+  while (true) {
+    const candidate = resolve(dir, ENV_KEYSHELF_FILENAME);
+    if (existsSync(candidate)) return candidate;
+
+    const parent = dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+/** Parse `.env.keyshelf` content into `{ ENV_VAR: "key.path" }`. */
+export function parseEnvKeyshelf(content: string): Record<string, string> {
+  const result: Record<string, string> = {};
+
+  for (const [i, raw] of content.split("\n").entries()) {
+    const trimmed = raw.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+
+    const lineNumber = i + 1;
+    const eqIndex = trimmed.indexOf("=");
+    if (eqIndex === -1) {
+      throw new Error(`Malformed line ${lineNumber} in .env.keyshelf: missing '='`);
+    }
+
+    const envVar = trimmed.slice(0, eqIndex).trim();
+    const keyPath = trimmed.slice(eqIndex + 1).trim();
+
+    if (!envVar) {
+      throw new Error(`Malformed line ${lineNumber} in .env.keyshelf: empty env var name`);
+    }
+    if (!keyPath) {
+      throw new Error(`Malformed line ${lineNumber} in .env.keyshelf: empty key path`);
+    }
+
+    result[envVar] = keyPath;
+  }
+
+  return result;
+}
+
+/** Find and read `.env.keyshelf`, returning the parsed mapping or `null`. */
+export async function readEnvKeyshelf(from?: string): Promise<Record<string, string> | null> {
+  const filePath = findEnvKeyshelfPath(from);
+  if (!filePath) return null;
+
+  const content = await readFile(filePath, "utf-8");
+  return parseEnvKeyshelf(content);
+}

--- a/src/resolver.test.ts
+++ b/src/resolver.test.ts
@@ -3,7 +3,13 @@ import { rm } from "node:fs/promises";
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { generateKeyPair, ageProvider } from "@/providers/age";
-import { keyToEnvVar, resolveValue, resolveAllKeys, PROVIDERS } from "@/resolver";
+import {
+  keyToEnvVar,
+  resolveValue,
+  resolveAllKeys,
+  resolveMappedKeys,
+  PROVIDERS
+} from "@/resolver";
 import type { KeyshelfSchema, ProviderContext } from "@/types";
 
 const TEST_PROJECT = `keyshelf-resolver-test-${Date.now()}`;
@@ -143,6 +149,97 @@ describe("resolveValue", () => {
 
     await expect(resolveValue({ _tag: "!unknown", value: "ref" }, context)).rejects.toThrow(
       "Unknown provider '!unknown'"
+    );
+  });
+});
+
+describe("resolveMappedKeys", () => {
+  it("resolves mapped keys with custom env var names", async () => {
+    const schema: KeyshelfSchema = {
+      project: TEST_PROJECT,
+      publicKey,
+      keys: {
+        "database/url": { default: "postgres://localhost/db" },
+        "api/key": { default: "secret-123" }
+      }
+    };
+    const mapping = { DB_CONNECTION: "database/url", MY_API_KEY: "api/key" };
+
+    const result = await resolveMappedKeys(schema, "default", mapping);
+    expect(result).toEqual({
+      DB_CONNECTION: "postgres://localhost/db",
+      MY_API_KEY: "secret-123"
+    });
+  });
+
+  it("only returns mapped keys, not all schema keys", async () => {
+    const schema: KeyshelfSchema = {
+      project: TEST_PROJECT,
+      publicKey,
+      keys: {
+        "database/url": { default: "postgres://localhost/db" },
+        "api/key": { default: "secret-123" }
+      }
+    };
+    const mapping = { DB_CONNECTION: "database/url" };
+
+    const result = await resolveMappedKeys(schema, "default", mapping);
+    expect(Object.keys(result)).toEqual(["DB_CONNECTION"]);
+  });
+
+  it("picks env-specific value over default", async () => {
+    const schema: KeyshelfSchema = {
+      project: TEST_PROJECT,
+      publicKey,
+      keys: {
+        "database/url": { default: "postgres://localhost/db", staging: "postgres://staging/db" }
+      }
+    };
+    const mapping = { DB_URL: "database/url" };
+
+    const result = await resolveMappedKeys(schema, "staging", mapping);
+    expect(result).toEqual({ DB_URL: "postgres://staging/db" });
+  });
+
+  it("falls back to default when env value is missing", async () => {
+    const schema: KeyshelfSchema = {
+      project: TEST_PROJECT,
+      publicKey,
+      keys: {
+        "database/url": { default: "postgres://localhost/db" }
+      }
+    };
+    const mapping = { DB_URL: "database/url" };
+
+    const result = await resolveMappedKeys(schema, "staging", mapping);
+    expect(result).toEqual({ DB_URL: "postgres://localhost/db" });
+  });
+
+  it("throws when key path is not in schema", async () => {
+    const schema: KeyshelfSchema = {
+      project: TEST_PROJECT,
+      publicKey,
+      keys: {}
+    };
+    const mapping = { DB_URL: "database/url" };
+
+    await expect(resolveMappedKeys(schema, "default", mapping)).rejects.toThrow(
+      "Key 'database/url' referenced in .env.keyshelf not found in keyshelf.yaml"
+    );
+  });
+
+  it("throws when key has no value for env and no default", async () => {
+    const schema: KeyshelfSchema = {
+      project: TEST_PROJECT,
+      publicKey,
+      keys: {
+        "api/key": { staging: "only-staging" }
+      }
+    };
+    const mapping = { MY_KEY: "api/key" };
+
+    await expect(resolveMappedKeys(schema, "prod", mapping)).rejects.toThrow(
+      "Key 'api/key' has no value for env 'prod' and no default"
     );
   });
 });

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -30,6 +30,39 @@ export async function resolveValue(
   return provider.get(value.value, context);
 }
 
+/** Resolve only keys referenced in a `.env.keyshelf` mapping, using custom env var names */
+export async function resolveMappedKeys(
+  schema: KeyshelfSchema,
+  env: string,
+  mapping: Record<string, string>
+): Promise<Record<string, string>> {
+  const result: Record<string, string> = {};
+
+  const entries = Object.entries(mapping).map(async ([envVarName, keyPath]) => {
+    const entry = schema.keys[keyPath];
+    if (!entry) {
+      throw new Error(`Key '${keyPath}' referenced in .env.keyshelf not found in keyshelf.yaml`);
+    }
+
+    const value = entry[env] ?? entry.default;
+    if (value === undefined) {
+      throw new Error(`Key '${keyPath}' has no value for env '${env}' and no default.`);
+    }
+
+    const context: ProviderContext = {
+      projectName: schema.project,
+      publicKey: schema.publicKey,
+      keyPath,
+      env
+    };
+
+    result[envVarName] = await resolveValue(value, context);
+  });
+
+  await Promise.all(entries);
+  return result;
+}
+
 /** Resolve all keys for a given environment, returning env var name → plaintext */
 export async function resolveAllKeys(
   schema: KeyshelfSchema,


### PR DESCRIPTION
## Summary

- Adds `.env.keyshelf` file support that maps keyshelf keys to custom env var names
- When present, `run` and `export` resolve only the mapped keys with the specified names
- When absent, behavior is unchanged (all keys with auto-derived names)
- Enables different consuming projects to map the same keyshelf keys to project-specific env var names (e.g. mobile app uses `EXPO_PUBLIC_SUPABASE_URL`, backend uses `SUPABASE_URL`)

### Format
```
# .env.keyshelf
EXPO_PUBLIC_SUPABASE_URL=supabase.url
DB_PASSWORD=database.password
```

### New files
- `src/env-keyshelf.ts` — discovery, parsing, and reading of `.env.keyshelf`
- `src/env-keyshelf.test.ts` — 12 unit tests

### Modified files
- `src/resolver.ts` — new `resolveMappedKeys()` function
- `src/commands/run.ts` / `export.ts` — auto-detect `.env.keyshelf` and use mapped resolution
- Tests for all of the above

## Test plan

- [x] Unit tests for `.env.keyshelf` parsing (valid content, comments, blanks, malformed lines)
- [x] Unit tests for file discovery (current dir, ancestor dir, missing)
- [x] Unit tests for `resolveMappedKeys` (custom names, missing key, env fallback, subset-only)
- [x] Integration tests for `run` with `.env.keyshelf` (mapped keys only, unmapped excluded, error on missing key)
- [x] Integration tests for `export` with `.env.keyshelf` (dotenv format, json format, error on missing key)
- [x] All 131 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)