### PR TITLE
fix: drop `projects/` prefix from gcsm references

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ keys:
       -----END AGE ENCRYPTED FILE-----
 
   auth/token:
-    production: !gcsm projects/my-gcp-project/secrets/my-app__production__auth__token
+    production: !gcsm my-gcp-project/secrets/my-app__production__auth__token
 ```
 
 | Field       | Description                                                                              |

--- a/src/providers/gcp-sm.test.ts
+++ b/src/providers/gcp-sm.test.ts
@@ -70,7 +70,7 @@ describe("getGcpProject", () => {
 describe("gcpSmProvider.get", () => {
   it("returns the secret string value", async () => {
     process.env.GOOGLE_CLOUD_PROJECT = "my-gcp-project";
-    const reference = "projects/my-gcp-project/secrets/my-app__production__database__password";
+    const reference = "my-gcp-project/secrets/my-app__production__database__password";
 
     const mockAccessSecretVersion = vi
       .fn()
@@ -85,7 +85,7 @@ describe("gcpSmProvider.get", () => {
   });
 
   it("throws when payload is empty", async () => {
-    const reference = "projects/my-gcp-project/secrets/my-app__production__database__password";
+    const reference = "my-gcp-project/secrets/my-app__production__database__password";
 
     vi.mocked(SecretManagerServiceClient).mockImplementationOnce(
       () =>
@@ -98,7 +98,7 @@ describe("gcpSmProvider.get", () => {
   });
 
   it("throws when SDK errors", async () => {
-    const reference = "projects/my-gcp-project/secrets/my-app__production__database__password";
+    const reference = "my-gcp-project/secrets/my-app__production__database__password";
 
     vi.mocked(SecretManagerServiceClient).mockImplementationOnce(
       () =>
@@ -129,7 +129,7 @@ describe("gcpSmProvider.set", () => {
     );
 
     const ref = await gcpSmProvider.set!("my-secret-value", context);
-    expect(ref).toBe("projects/my-gcp-project/secrets/my-app__production__database__password");
+    expect(ref).toBe("my-gcp-project/secrets/my-app__production__database__password");
     expect(mockCreateSecret).toHaveBeenCalledTimes(1);
     expect(mockAddSecretVersion).toHaveBeenCalledTimes(1);
   });
@@ -148,7 +148,7 @@ describe("gcpSmProvider.set", () => {
     );
 
     const ref = await gcpSmProvider.set!("my-secret-value", context);
-    expect(ref).toBe("projects/my-gcp-project/secrets/my-app__production__database__password");
+    expect(ref).toBe("my-gcp-project/secrets/my-app__production__database__password");
     expect(mockCreateSecret).toHaveBeenCalledTimes(1);
     expect(mockAddSecretVersion).toHaveBeenCalledTimes(1);
   });
@@ -201,7 +201,7 @@ describe("gcpSmProvider.set", () => {
 
 describe("gcpSmProvider.remove", () => {
   it("deletes the secret by reference", async () => {
-    const reference = "projects/my-gcp-project/secrets/my-app__production__database__password";
+    const reference = "my-gcp-project/secrets/my-app__production__database__password";
     const mockDeleteSecret = vi.fn().mockResolvedValueOnce([{}]);
 
     vi.mocked(SecretManagerServiceClient).mockImplementationOnce(
@@ -209,11 +209,11 @@ describe("gcpSmProvider.remove", () => {
     );
 
     await gcpSmProvider.remove!(reference, context);
-    expect(mockDeleteSecret).toHaveBeenCalledWith({ name: reference });
+    expect(mockDeleteSecret).toHaveBeenCalledWith({ name: `projects/${reference}` });
   });
 
   it("throws when SDK errors", async () => {
-    const reference = "projects/my-gcp-project/secrets/my-app__production__database__password";
+    const reference = "my-gcp-project/secrets/my-app__production__database__password";
 
     vi.mocked(SecretManagerServiceClient).mockImplementationOnce(
       () =>

--- a/src/providers/gcp-sm.ts
+++ b/src/providers/gcp-sm.ts
@@ -26,7 +26,8 @@ export function buildSecretId(context: ProviderContext): string {
 
 async function getSecret(reference: string): Promise<string> {
   const client = new SecretManagerServiceClient();
-  const [version] = await client.accessSecretVersion({ name: `${reference}/versions/latest` });
+  const name = `projects/${reference}/versions/latest`;
+  const [version] = await client.accessSecretVersion({ name });
 
   const payload = version.payload?.data?.toString();
   if (!payload) {
@@ -51,7 +52,7 @@ async function upsertSecret(secretId: string, value: string, gcpProject: string)
   }
 
   await client.addSecretVersion({ parent: name, payload: { data: Buffer.from(value) } });
-  return name;
+  return `${gcpProject}/secrets/${secretId}`;
 }
 
 /** GCP Secret Manager provider */
@@ -74,6 +75,6 @@ export const gcpSmProvider: Provider = {
 
   async remove(reference: string, _context: ProviderContext): Promise<void> {
     const client = new SecretManagerServiceClient();
-    await client.deleteSecret({ name: reference });
+    await client.deleteSecret({ name: `projects/${reference}` });
   }
 };


### PR DESCRIPTION
## Summary
- Store GCP Secret Manager references as `<project>/secrets/<id>` instead of `projects/<project>/secrets/<id>`
- Reconstruct the `projects/` prefix at API call time in `get`, `set`, and `remove`
- Update README example to reflect the new format

## Test plan
- [x] All existing gcp-sm unit tests pass with updated reference format

🤖 Generated with [Claude Code](https://claude.com/claude-code)