### PR TITLE
fix: make app mapping file optional when using --env

### DIFF
--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -66,11 +66,15 @@ export async function loadConfig(
     appMapping = parseAppMapping(mappingContent);
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") {
-      throw new Error(`App mapping file not found: ${mappingPath}`, {
-        cause: err
-      });
+      if (options?.mappingFile) {
+        throw new Error(`App mapping file not found: ${mappingPath}`, {
+          cause: err
+        });
+      }
+      appMapping = [];
+    } else {
+      throw err;
     }
-    throw err;
   }
 
   // Merge global provider config with env-level provider config

--- a/test/integration/loader.test.ts
+++ b/test/integration/loader.test.ts
@@ -76,12 +76,17 @@ describe("loadConfig", () => {
     await expect(loadConfig(appDir, "staging")).rejects.toThrow("Environment file not found");
   });
 
-  it("throws for missing app mapping file", async () => {
+  it("returns empty app mapping when default file is missing", async () => {
     const noMappingDir = join(root, "apps", "other");
     await mkdir(noMappingDir, { recursive: true });
-    await expect(loadConfig(noMappingDir, "production")).rejects.toThrow(
-      "App mapping file not found"
-    );
+    const config = await loadConfig(noMappingDir, "production");
+    expect(config.appMapping).toEqual([]);
+  });
+
+  it("throws when explicit mappingFile is missing", async () => {
+    await expect(
+      loadConfig(appDir, "production", { mappingFile: "/no/such/file" })
+    ).rejects.toThrow("App mapping file not found");
   });
 
   it("loads mapping from custom mappingFile path", async () => {


### PR DESCRIPTION
## Summary
- The default `.env.keyshelf` mapping file is no longer required when running commands with `--env`. If missing, an empty mapping is used instead of throwing.
- An explicit `--map <file>` still errors if the specified file doesn't exist.

## Test plan
- [x] Updated integration test: missing default mapping returns empty array
- [x] Added integration test: explicit `--map` with missing file still throws
- [x] All 15 loader integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)