### PR TITLE
feat: add `keyshelf rm` command

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3,6 +3,7 @@ import { runCommand } from "./run.js";
 import { setCommand } from "./set.js";
 import { importCommand } from "./import.js";
 import { lsCommand } from "./ls.js";
+import { rmCommand } from "./rm.js";
 
 export function createProgram(): Command {
   const program = new Command("keyshelf")
@@ -13,6 +14,7 @@ export function createProgram(): Command {
   program.addCommand(setCommand);
   program.addCommand(importCommand);
   program.addCommand(lsCommand);
+  program.addCommand(rmCommand);
 
   return program;
 }

--- a/src/cli/rm.ts
+++ b/src/cli/rm.ts
@@ -1,0 +1,96 @@
+import { Command } from "commander";
+import { readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import yaml from "js-yaml";
+import { findRootDir } from "../config/loader.js";
+import { parseSchema } from "../config/schema.js";
+import { parseProviderBlock } from "../config/environment.js";
+import { createDefaultRegistry } from "../providers/setup.js";
+import { KEYSHELF_SCHEMA, isTaggedValue } from "../config/yaml-tags.js";
+import { flattenKeys, deleteNestedValue } from "../utils/paths.js";
+
+export const rmCommand = new Command("rm")
+  .description("Remove a config or secret value from an environment")
+  .requiredOption("--env <env>", "Environment name")
+  .argument("<key>", "Key path (e.g. db/password)")
+  .action(async (keyPath: string, opts: { env: string }) => {
+    const rootDir = findRootDir(process.cwd());
+    const envFilePath = join(rootDir, ".keyshelf", `${opts.env}.yaml`);
+
+    // Load env file
+    let envDoc: Record<string, unknown>;
+    try {
+      const content = await readFile(envFilePath, "utf-8");
+      envDoc = (yaml.load(content, { schema: KEYSHELF_SCHEMA }) ?? {}) as Record<string, unknown>;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        throw new Error(`Environment file not found: ${envFilePath}`);
+      }
+      throw err;
+    }
+
+    // Find override in env file
+    const keysBlock = (envDoc.keys ?? {}) as Record<string, unknown>;
+    const flat = flattenKeys(keysBlock);
+    const override = flat[keyPath];
+    const hasOverride = keyPath in flat;
+
+    // Load schema to check if key is a secret with default-provider
+    const schemaContent = await readFile(join(rootDir, "keyshelf.yaml"), "utf-8");
+    const schema = parseSchema(schemaContent);
+    const keyDef = schema.keys.find((k) => k.path === keyPath);
+
+    // Determine default provider config (same merge logic as loader)
+    const envProvider = parseProviderBlock(envDoc["default-provider"]);
+    const globalProvider = schema.config.provider;
+    let defaultProvider = envProvider;
+    if (!defaultProvider && globalProvider) {
+      defaultProvider = globalProvider;
+    } else if (defaultProvider && globalProvider && defaultProvider.name === globalProvider.name) {
+      defaultProvider = {
+        name: defaultProvider.name,
+        options: { ...globalProvider.options, ...defaultProvider.options }
+      };
+    }
+
+    const registry = createDefaultRegistry();
+
+    // Delete from provider if needed
+    if (hasOverride && isTaggedValue(override)) {
+      // Provider-tagged override — delete from provider
+      const provider = registry.get(override.tag);
+      const baseConfig =
+        defaultProvider?.name === override.tag ? { ...defaultProvider.options } : {};
+      const ctx = {
+        keyPath,
+        envName: opts.env,
+        config: { ...baseConfig, ...override.config }
+      };
+      await provider.delete(ctx);
+    } else if (!hasOverride && keyDef?.isSecret && defaultProvider) {
+      // Secret using default provider — delete from provider
+      const provider = registry.get(defaultProvider.name);
+      const ctx = {
+        keyPath,
+        envName: opts.env,
+        config: { ...defaultProvider.options }
+      };
+      await provider.delete(ctx);
+    } else if (!hasOverride) {
+      throw new Error(`Key "${keyPath}" not found in ${opts.env} environment`);
+    }
+
+    // Remove from env file if it was there
+    if (hasOverride) {
+      deleteNestedValue(keysBlock, keyPath);
+
+      // Clean up empty keys block
+      if (Object.keys(keysBlock).length === 0) {
+        delete envDoc.keys;
+      }
+
+      await writeFile(envFilePath, yaml.dump(envDoc, { schema: KEYSHELF_SCHEMA }), "utf-8");
+    }
+
+    console.log(`Removed "${keyPath}" from ${opts.env}`);
+  });

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,6 @@ export { AgeProvider, generateIdentity, identityToRecipient } from "./providers/
 export { GcpSmProvider, type GcpSmProviderOptions } from "./providers/gcp-sm.js";
 export { createDefaultRegistry } from "./providers/setup.js";
 
-export { flattenKeys, setNestedValue } from "./utils/paths.js";
+export { flattenKeys, setNestedValue, deleteNestedValue } from "./utils/paths.js";
 
 export { createProgram } from "./cli/index.js";

--- a/src/providers/age.ts
+++ b/src/providers/age.ts
@@ -1,4 +1,4 @@
-import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { readFile, writeFile, mkdir, unlink } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { Encrypter, Decrypter, generateIdentity, identityToRecipient } from "age-encryption";
 import type { Provider, ProviderContext } from "./types.js";
@@ -72,6 +72,12 @@ export class AgeProvider implements Provider {
     const filePath = secretFilePath(opts.secretsDir, ctx.keyPath);
     await mkdir(dirname(filePath), { recursive: true });
     await writeFile(filePath, ciphertext);
+  }
+
+  async delete(ctx: ProviderContext): Promise<void> {
+    const opts = this.resolveOptions(ctx);
+    const filePath = secretFilePath(opts.secretsDir, ctx.keyPath);
+    await unlink(filePath);
   }
 }
 

--- a/src/providers/gcp-sm.ts
+++ b/src/providers/gcp-sm.ts
@@ -84,4 +84,12 @@ export class GcpSmProvider implements Provider {
       payload: { data: Buffer.from(value, "utf-8") }
     });
   }
+
+  async delete(ctx: ProviderContext): Promise<void> {
+    const opts = this.resolveOptions(ctx);
+    const secretId = toSecretId(ctx.envName, ctx.keyPath);
+    await this.client.deleteSecret({
+      name: `projects/${opts.project}/secrets/${secretId}`
+    });
+  }
 }

--- a/src/providers/plaintext.ts
+++ b/src/providers/plaintext.ts
@@ -18,4 +18,8 @@ export class PlaintextProvider implements Provider {
   async set(): Promise<void> {
     // No-op: plaintext values are stored directly in env files
   }
+
+  async delete(): Promise<void> {
+    // No-op: plaintext values are stored directly in env files
+  }
 }

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -9,4 +9,5 @@ export interface Provider {
   resolve(ctx: ProviderContext): Promise<string>;
   validate(ctx: ProviderContext): Promise<boolean>;
   set(ctx: ProviderContext, value: string): Promise<void>;
+  delete(ctx: ProviderContext): Promise<void>;
 }

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -33,3 +33,37 @@ export function setNestedValue(obj: Record<string, unknown>, path: string, value
 
   current[parts[parts.length - 1]] = value;
 }
+
+export function deleteNestedValue(obj: Record<string, unknown>, path: string): boolean {
+  const parts = path.split("/");
+  const stack: { parent: Record<string, unknown>; key: string }[] = [];
+  let current = obj;
+
+  for (let i = 0; i < parts.length - 1; i++) {
+    const key = parts[i];
+    if (current[key] === undefined || current[key] === null || typeof current[key] !== "object") {
+      return false;
+    }
+    stack.push({ parent: current, key });
+    current = current[key] as Record<string, unknown>;
+  }
+
+  const lastKey = parts[parts.length - 1];
+  if (!(lastKey in current)) {
+    return false;
+  }
+
+  delete current[lastKey];
+
+  // Clean up empty parent objects
+  for (let i = stack.length - 1; i >= 0; i--) {
+    const { parent, key } = stack[i];
+    if (Object.keys(parent[key] as Record<string, unknown>).length === 0) {
+      delete parent[key];
+    } else {
+      break;
+    }
+  }
+
+  return true;
+}

--- a/test/e2e/rm.test.ts
+++ b/test/e2e/rm.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { writeAgeFixture } from "./helpers/age.js";
+
+const CLI = join(import.meta.dirname, "..", "..", "bin", "keyshelf.ts");
+const TSX = join(import.meta.dirname, "..", "..", "node_modules", ".bin", "tsx");
+
+describe("keyshelf rm (age)", () => {
+  let root: string;
+  let secretsDir: string;
+  const envName = "age-rm-test";
+
+  beforeAll(async () => {
+    root = await mkdtemp(join(tmpdir(), "keyshelf-e2e-age-rm-"));
+    await writeAgeFixture(root, envName);
+    secretsDir = join(root, ".keyshelf", "secrets");
+  });
+
+  it("removes a secret stored via provider", async () => {
+    // First set a secret
+    execFileSync(
+      TSX,
+      [CLI, "set", "--env", envName, "--provider", "age", "--value", "to-delete", "db/password"],
+      { cwd: root, encoding: "utf-8" }
+    );
+
+    expect(existsSync(join(secretsDir, "db_password.age"))).toBe(true);
+
+    // Now remove it
+    const output = execFileSync(TSX, [CLI, "rm", "--env", envName, "db/password"], {
+      cwd: root,
+      encoding: "utf-8"
+    });
+
+    expect(output).toContain("Removed");
+    expect(existsSync(join(secretsDir, "db_password.age"))).toBe(false);
+  });
+
+  it("removes a plaintext override from env file", async () => {
+    const output = execFileSync(TSX, [CLI, "rm", "--env", envName, "db/host"], {
+      cwd: root,
+      encoding: "utf-8"
+    });
+
+    expect(output).toContain("Removed");
+
+    const envContent = await readFile(join(root, ".keyshelf", `${envName}.yaml`), "utf-8");
+    expect(envContent).not.toContain("host");
+  });
+
+  it("errors when key does not exist", () => {
+    expect(() =>
+      execFileSync(TSX, [CLI, "rm", "--env", envName, "nonexistent/key"], {
+        cwd: root,
+        encoding: "utf-8",
+        stdio: "pipe"
+      })
+    ).toThrow();
+  });
+});

--- a/test/unit/providers/age.test.ts
+++ b/test/unit/providers/age.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { mkdtemp, writeFile } from "node:fs/promises";
+import { mkdtemp, writeFile, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { AgeProvider, generateIdentity } from "../../../src/providers/age.js";
@@ -87,5 +87,18 @@ describe("AgeProvider", () => {
     const special = 'p@$$w0rd!#%^&*()_+{}|:"<>?`~';
     await provider.set(ctx("special"), special);
     expect(await provider.resolve(ctx("special"))).toBe(special);
+  });
+
+  it("delete removes the .age file", async () => {
+    await provider.set(ctx("db/password"), "supersecret");
+    const filePath = join(secretsDir, "db_password.age");
+    await expect(readFile(filePath)).resolves.toBeDefined();
+
+    await provider.delete(ctx("db/password"));
+    await expect(readFile(filePath)).rejects.toThrow();
+  });
+
+  it("delete throws for missing secret", async () => {
+    await expect(provider.delete(ctx("missing/key"))).rejects.toThrow();
   });
 });

--- a/test/unit/providers/gcp-sm.test.ts
+++ b/test/unit/providers/gcp-sm.test.ts
@@ -7,7 +7,8 @@ function mockClient() {
     accessSecretVersion: vi.fn(),
     getSecret: vi.fn(),
     createSecret: vi.fn(),
-    addSecretVersion: vi.fn()
+    addSecretVersion: vi.fn(),
+    deleteSecret: vi.fn()
   };
 }
 
@@ -132,6 +133,24 @@ describe("GcpSmProvider", () => {
       client.createSecret.mockRejectedValue(permDenied);
 
       await expect(provider.set(ctx("db/password"), "val")).rejects.toThrow("PERMISSION_DENIED");
+    });
+  });
+
+  describe("delete", () => {
+    it("deletes the secret", async () => {
+      client.deleteSecret.mockResolvedValue([{}]);
+
+      await provider.delete(ctx("db/password"));
+
+      expect(client.deleteSecret).toHaveBeenCalledWith({
+        name: "projects/my-proj/secrets/keyshelf__prod__db__password"
+      });
+    });
+
+    it("propagates errors", async () => {
+      client.deleteSecret.mockRejectedValue(new Error("NOT_FOUND"));
+
+      await expect(provider.delete(ctx("db/password"))).rejects.toThrow("NOT_FOUND");
     });
   });
 });

--- a/test/unit/providers/plaintext.test.ts
+++ b/test/unit/providers/plaintext.test.ts
@@ -30,4 +30,8 @@ describe("PlaintextProvider", () => {
   it("set is a no-op", async () => {
     await expect(provider.set({ keyPath: "k", config: {} }, "v")).resolves.toBeUndefined();
   });
+
+  it("delete is a no-op", async () => {
+    await expect(provider.delete({ keyPath: "k", config: {} })).resolves.toBeUndefined();
+  });
 });

--- a/test/unit/utils/paths.test.ts
+++ b/test/unit/utils/paths.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { flattenKeys, setNestedValue } from "../../../src/utils/paths.js";
+import { flattenKeys, setNestedValue, deleteNestedValue } from "../../../src/utils/paths.js";
 
 describe("flattenKeys", () => {
   it("flattens nested objects to /-separated paths", () => {
@@ -98,5 +98,56 @@ describe("setNestedValue", () => {
     const obj: Record<string, unknown> = { db: "scalar" };
     setNestedValue(obj, "db/host", "localhost");
     expect(obj).toEqual({ db: { host: "localhost" } });
+  });
+});
+
+describe("deleteNestedValue", () => {
+  it("deletes a top-level key", () => {
+    const obj: Record<string, unknown> = { key: "value", other: "keep" };
+    const result = deleteNestedValue(obj, "key");
+    expect(result).toBe(true);
+    expect(obj).toEqual({ other: "keep" });
+  });
+
+  it("deletes a nested key", () => {
+    const obj: Record<string, unknown> = { db: { host: "localhost", port: 5432 } };
+    const result = deleteNestedValue(obj, "db/host");
+    expect(result).toBe(true);
+    expect(obj).toEqual({ db: { port: 5432 } });
+  });
+
+  it("cleans up empty parent objects", () => {
+    const obj: Record<string, unknown> = { db: { password: "secret" }, other: "keep" };
+    const result = deleteNestedValue(obj, "db/password");
+    expect(result).toBe(true);
+    expect(obj).toEqual({ other: "keep" });
+  });
+
+  it("cleans up deeply nested empty parents", () => {
+    const obj: Record<string, unknown> = { a: { b: { c: "deep" } } };
+    const result = deleteNestedValue(obj, "a/b/c");
+    expect(result).toBe(true);
+    expect(obj).toEqual({});
+  });
+
+  it("returns false for missing key", () => {
+    const obj: Record<string, unknown> = { db: { host: "localhost" } };
+    const result = deleteNestedValue(obj, "db/password");
+    expect(result).toBe(false);
+    expect(obj).toEqual({ db: { host: "localhost" } });
+  });
+
+  it("returns false for missing intermediate path", () => {
+    const obj: Record<string, unknown> = { other: "value" };
+    const result = deleteNestedValue(obj, "db/host");
+    expect(result).toBe(false);
+    expect(obj).toEqual({ other: "value" });
+  });
+
+  it("preserves siblings when cleaning parents", () => {
+    const obj: Record<string, unknown> = { a: { b: { c: "delete" }, d: "keep" } };
+    const result = deleteNestedValue(obj, "a/b/c");
+    expect(result).toBe(true);
+    expect(obj).toEqual({ a: { d: "keep" } });
   });
 });


### PR DESCRIPTION
## Summary

- Adds `keyshelf rm <key> --env <env>` command — the inverse of `keyshelf set`
- Removes values from the env file override and cleans up provider backends (age files, GCP secrets) automatically
- Adds `delete` method to the `Provider` interface, implemented on all providers
- Adds `deleteNestedValue` utility that removes keys and cleans up empty parent objects

## Test plan

- [x] Unit tests for `deleteNestedValue` (7 cases: top-level, nested, empty parent cleanup, missing keys)
- [x] Unit tests for `delete` on age, gcp-sm, and plaintext providers
- [x] E2E tests: set then rm age secret, rm plaintext override, error on nonexistent key
- [x] All 172 tests pass, build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)