### PR TITLE
fix: use default env provider for secret keys in set and import

### DIFF
--- a/src/cli/import.ts
+++ b/src/cli/import.ts
@@ -82,17 +82,17 @@ export const importCommand = new Command("import")
       }
 
       const isSecret = secretPaths.has(keyPath);
+      const providerName =
+        opts.provider ?? (isSecret ? config?.env.defaultProvider?.name : undefined);
 
-      if (isSecret && opts.provider) {
-        const provider = registry.get(opts.provider);
-        const providerBlock = envDoc["default-provider"] as Record<string, unknown> | undefined;
+      if (isSecret && providerName) {
+        const provider = registry.get(providerName);
         const providerConfig: Record<string, unknown> = {};
-        if (providerBlock && providerBlock.name === opts.provider) {
-          Object.assign(providerConfig, providerBlock);
-          delete providerConfig.name;
+        if (config?.env.defaultProvider && config.env.defaultProvider.name === providerName) {
+          Object.assign(providerConfig, config.env.defaultProvider.options);
         }
         await provider.set({ keyPath, envName: opts.env, config: providerConfig }, value);
-        console.log(`  secret: ${envVar} -> ${keyPath} (via ${opts.provider})`);
+        console.log(`  secret: ${envVar} -> ${keyPath} (via ${providerName})`);
       } else {
         setNestedValue(envDoc, keyPath, value);
         console.log(`  config: ${envVar} -> ${keyPath}`);

--- a/src/cli/set.ts
+++ b/src/cli/set.ts
@@ -2,7 +2,7 @@ import { Command } from "commander";
 import { readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import yaml from "js-yaml";
-import { findRootDir } from "../config/loader.js";
+import { findRootDir, loadConfig } from "../config/loader.js";
 import { createDefaultRegistry } from "../providers/setup.js";
 import { KEYSHELF_SCHEMA } from "../config/yaml-tags.js";
 import { setNestedValue } from "../utils/paths.js";
@@ -53,33 +53,30 @@ export const setCommand = new Command("set")
       value = await readHiddenInput(`Enter value for ${keyPath}: `);
     }
 
-    // If provider specified, store via provider
-    if (opts.provider) {
+    // Load config to check if key is a secret and resolve provider
+    const config = await loadConfig(rootDir, opts.env).catch(() => null);
+    const keyDef = config?.schema.find((k) => k.path === keyPath);
+    const isSecret = keyDef?.isSecret ?? false;
+
+    // Resolve provider: explicit --provider flag, or default-provider (if key is secret)
+    const providerName =
+      opts.provider ?? (isSecret ? config?.env.defaultProvider?.name : undefined);
+
+    if (providerName) {
       const registry = createDefaultRegistry();
-      const provider = registry.get(opts.provider);
+      const provider = registry.get(providerName);
 
-      // Load existing env file to get provider config
-      let envDoc: Record<string, unknown> = {};
-      try {
-        const content = await readFile(envFilePath, "utf-8");
-        envDoc = (yaml.load(content, { schema: KEYSHELF_SCHEMA }) ?? {}) as Record<string, unknown>;
-      } catch {
-        // File doesn't exist yet, start fresh
-      }
-
-      const providerBlock = envDoc["default-provider"] as Record<string, unknown> | undefined;
       const providerConfig: Record<string, unknown> = {};
-      if (providerBlock && providerBlock.name === opts.provider) {
-        Object.assign(providerConfig, providerBlock);
-        delete providerConfig.name;
+      if (config?.env.defaultProvider && config.env.defaultProvider.name === providerName) {
+        Object.assign(providerConfig, config.env.defaultProvider.options);
       }
 
       await provider.set({ keyPath, envName: opts.env, config: providerConfig }, value);
-      console.log(`Stored "${keyPath}" via ${opts.provider} provider for ${opts.env}`);
+      console.log(`Stored "${keyPath}" via ${providerName} provider for ${opts.env}`);
       return;
     }
 
-    // Otherwise store as plaintext in env file
+    // No provider, store as plaintext in env file
     let envDoc: Record<string, unknown> = {};
     try {
       const content = await readFile(envFilePath, "utf-8");
@@ -88,7 +85,6 @@ export const setCommand = new Command("set")
       // File doesn't exist yet, start fresh
     }
 
-    // Set the value using nested path
     setNestedValue(envDoc, keyPath, value);
 
     await writeFile(envFilePath, yaml.dump(envDoc), "utf-8");

--- a/test/e2e/import.test.ts
+++ b/test/e2e/import.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { execFileSync } from "node:child_process";
+import { Decrypter } from "age-encryption";
+import { writeAgeFixture } from "./helpers/age.js";
+
+const CLI = join(import.meta.dirname, "..", "..", "bin", "keyshelf.ts");
+const TSX = join(import.meta.dirname, "..", "..", "node_modules", ".bin", "tsx");
+
+describe("keyshelf import (age)", () => {
+  let root: string;
+  let identityFile: string;
+  let secretsDir: string;
+  const envName = "age-test";
+
+  beforeAll(async () => {
+    root = await mkdtemp(join(tmpdir(), "keyshelf-e2e-age-import-"));
+    await writeAgeFixture(root, envName);
+    identityFile = join(root, "key.txt");
+    secretsDir = join(root, ".keyshelf", "secrets");
+  });
+
+  async function decryptFile(filePath: string): Promise<string> {
+    const identity = await readFile(identityFile, "utf-8");
+    const ciphertext = await readFile(filePath);
+    const decrypter = new Decrypter();
+    decrypter.addIdentity(identity.trim());
+    return await decrypter.decrypt(ciphertext, "text");
+  }
+
+  it("uses default provider for secret keys when --provider is omitted", async () => {
+    const dotenvPath = join(root, ".env");
+    await writeFile(dotenvPath, "DB_HOST=imported-host\nDB_PASSWORD=imported-secret\n");
+
+    execFileSync(TSX, [CLI, "import", "--env", envName, "--file", dotenvPath], {
+      cwd: root,
+      encoding: "utf-8"
+    });
+
+    // Secret should be encrypted via age (default provider)
+    const plaintext = await decryptFile(join(secretsDir, "db_password.age"));
+    expect(plaintext).toBe("imported-secret");
+
+    // Config should be stored as plaintext in env yaml
+    const envContent = await readFile(join(root, ".keyshelf", `${envName}.yaml`), "utf-8");
+    expect(envContent).toContain("imported-host");
+  });
+
+  it("stores secrets via explicit --provider", async () => {
+    const dotenvPath = join(root, ".env");
+    await writeFile(dotenvPath, "DB_PASSWORD=explicit-provider-secret\n");
+
+    execFileSync(
+      TSX,
+      [CLI, "import", "--env", envName, "--file", dotenvPath, "--provider", "age"],
+      {
+        cwd: root,
+        encoding: "utf-8"
+      }
+    );
+
+    const plaintext = await decryptFile(join(secretsDir, "db_password.age"));
+    expect(plaintext).toBe("explicit-provider-secret");
+  });
+});

--- a/test/e2e/set.test.ts
+++ b/test/e2e/set.test.ts
@@ -73,6 +73,27 @@ describe("keyshelf set (age)", () => {
     const plaintext = await decryptFile(join(secretsDir, "db_password.age"));
     expect(plaintext).toBe("updated-age-value");
   });
+
+  it("uses default provider for secret keys when --provider is omitted", async () => {
+    execFileSync(
+      TSX,
+      [CLI, "set", "--env", envName, "--value", "default-provider-value", "db/password"],
+      { cwd: root, encoding: "utf-8" }
+    );
+
+    const plaintext = await decryptFile(join(secretsDir, "db_password.age"));
+    expect(plaintext).toBe("default-provider-value");
+  });
+
+  it("stores config keys as plaintext even when default provider is configured", async () => {
+    execFileSync(TSX, [CLI, "set", "--env", envName, "--value", "new-host", "db/host"], {
+      cwd: root,
+      encoding: "utf-8"
+    });
+
+    const content = await readFile(join(root, ".keyshelf", `${envName}.yaml`), "utf-8");
+    expect(content).toContain("new-host");
+  });
 });
 
 describe.skipIf(!GCP_PROJECT)("keyshelf set (gcp)", { timeout: 30_000 }, () => {


### PR DESCRIPTION
## Summary
- `keyshelf set --env <env> <key>` and `keyshelf import --env <env>` now automatically use the configured `default-provider` for keys marked as `!secret` in the schema, without requiring an explicit `--provider` flag
- Non-secret (config) keys continue to be stored as plaintext even when a default provider is configured
- Provider config resolution now uses `loadConfig()` which correctly merges global and env-level provider settings

## Test plan
- [x] Added e2e test: `set` uses default provider for secret keys when `--provider` is omitted
- [x] Added e2e test: `set` stores config keys as plaintext even when default provider is configured
- [x] Added e2e test: `import` uses default provider for secret keys when `--provider` is omitted
- [x] Added e2e test: `import` stores secrets via explicit `--provider`
- [x] All 161 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)