### PR TITLE
feat: add opt-in encrypted secret cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,34 @@ default-provider:
 
 Secrets are created automatically on first `keyshelf set`. Requires GCP credentials configured in the environment (e.g. `GOOGLE_APPLICATION_CREDENTIALS` or `gcloud auth`).
 
+## Cache
+
+Keyshelf can cache resolved secrets locally to avoid repeated requests to providers. Cached values are encrypted with [age](https://age-encryption.org/) using an auto-generated identity stored in `.keyshelf/cache/identity.txt`.
+
+Enable caching by adding a `cache:` block to an environment file:
+
+```yaml
+# .keyshelf/dev.yaml
+cache:
+  ttl: 3600 # seconds
+
+default-provider:
+  name: gcp
+  project: my-gcp-project
+```
+
+| Option | Description                                                                              |
+| ------ | ---------------------------------------------------------------------------------------- |
+| `ttl`  | Time-to-live in seconds. Cached values older than this are re-fetched from the provider. |
+
+Cache files are stored in `.keyshelf/cache/<env>/` as `.age` encrypted files. Only provider-resolved values are cached — plaintext overrides and schema defaults are not.
+
+The cache directory should be added to `.gitignore`:
+
+```
+.keyshelf/cache/
+```
+
 ## Schema reference
 
 ### `keyshelf.yaml`
@@ -245,6 +273,10 @@ keys:
 ### `.keyshelf/<env>.yaml`
 
 ```yaml
+# Optional: cache resolved secrets locally (encrypted with age)
+cache:
+  ttl: 3600
+
 # Default provider for all unbound secrets in this env
 default-provider:
   name: age
@@ -279,6 +311,7 @@ API_KEY=api/key
 | `.keyshelf/<env>.yaml` | Depends | Safe if it only has plaintext config. Avoid committing if it has sensitive overrides |
 | `.keyshelf/secrets/`   | No      | Contains encrypted `.age` files — add to `.gitignore`                                |
 | `keys/*.txt`           | No      | Age identity (private key) files — add to `.gitignore`                               |
+| `.keyshelf/cache/`     | No      | Encrypted cache files and identity — add to `.gitignore`                             |
 | `.env.keyshelf`        | Yes     | App-level key mappings, no secret values                                             |
 
 ## Programmatic API

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -1,0 +1,108 @@
+import { readFile, writeFile, mkdir, stat, rm, link } from "node:fs/promises";
+import { join, dirname } from "node:path";
+import { randomBytes } from "node:crypto";
+import { Encrypter, Decrypter, generateIdentity, identityToRecipient } from "age-encryption";
+
+export interface SecretCacheOptions {
+  /** Directory to store encrypted cache files */
+  cacheDir: string;
+  /** Time-to-live in seconds */
+  ttl: number;
+}
+
+function keyPathToFileName(keyPath: string): string {
+  return keyPath.replace(/\//g, "_");
+}
+
+function cacheFilePath(cacheDir: string, envName: string, keyPath: string): string {
+  return join(cacheDir, envName, `${keyPathToFileName(keyPath)}.age`);
+}
+
+function identityFilePath(cacheDir: string): string {
+  return join(cacheDir, "identity.txt");
+}
+
+async function ensureIdentity(cacheDir: string): Promise<string> {
+  const idPath = identityFilePath(cacheDir);
+
+  try {
+    const content = await readFile(idPath, "utf-8");
+    return content.trim();
+  } catch {
+    // File doesn't exist yet — generate and write atomically
+  }
+
+  await mkdir(dirname(idPath), { recursive: true });
+
+  const identity = await generateIdentity();
+  const tmpPath = idPath + "." + randomBytes(6).toString("hex");
+  await writeFile(tmpPath, identity + "\n", { mode: 0o600 });
+
+  try {
+    // link fails with EEXIST if another process created the file first
+    await link(tmpPath, idPath);
+  } catch {
+    // Another process won — use their identity
+    await rm(tmpPath, { force: true });
+    const content = await readFile(idPath, "utf-8");
+    return content.trim();
+  }
+
+  await rm(tmpPath, { force: true });
+  return identity;
+}
+
+export class SecretCache {
+  private identity: string | undefined;
+
+  constructor(private readonly options: SecretCacheOptions) {}
+
+  async get(envName: string, keyPath: string): Promise<string | undefined> {
+    const filePath = cacheFilePath(this.options.cacheDir, envName, keyPath);
+
+    let fileStat;
+    try {
+      fileStat = await stat(filePath);
+    } catch {
+      return undefined;
+    }
+
+    const ageSeconds = (Date.now() - fileStat.mtimeMs) / 1000;
+    if (ageSeconds > this.options.ttl) {
+      await rm(filePath, { force: true });
+      return undefined;
+    }
+
+    try {
+      const identity = await this.getIdentity();
+      const ciphertext = await readFile(filePath);
+      const decrypter = new Decrypter();
+      decrypter.addIdentity(identity);
+      return await decrypter.decrypt(ciphertext, "text");
+    } catch {
+      // Corrupt or unreadable cache entry — treat as miss
+      await rm(filePath, { force: true });
+      return undefined;
+    }
+  }
+
+  async set(envName: string, keyPath: string, value: string): Promise<void> {
+    const identity = await this.getIdentity();
+    const recipient = await identityToRecipient(identity);
+
+    const encrypter = new Encrypter();
+    encrypter.addRecipient(recipient);
+    const ciphertext = await encrypter.encrypt(value);
+
+    const filePath = cacheFilePath(this.options.cacheDir, envName, keyPath);
+    await mkdir(dirname(filePath), { recursive: true });
+    await writeFile(filePath, ciphertext);
+  }
+
+  private async getIdentity(): Promise<string> {
+    if (!this.identity) {
+      this.identity = await ensureIdentity(this.options.cacheDir);
+    }
+    return this.identity;
+  }
+}

--- a/src/cli/cache.ts
+++ b/src/cli/cache.ts
@@ -1,0 +1,9 @@
+import { join } from "node:path";
+import type { LoadedConfig } from "../config/loader.js";
+import { SecretCache } from "../cache/index.js";
+
+export function createCache(config: LoadedConfig): SecretCache | undefined {
+  const ttl = config.env.cache?.ttl;
+  if (!ttl) return undefined;
+  return new SecretCache({ cacheDir: join(config.rootDir, ".keyshelf", "cache"), ttl });
+}

--- a/src/cli/ls.ts
+++ b/src/cli/ls.ts
@@ -7,6 +7,7 @@ import { isTaggedValue, type TaggedValue } from "../config/yaml-tags.js";
 import type { EnvConfig } from "../config/environment.js";
 import { resolve } from "../resolver/index.js";
 import { createDefaultRegistry } from "../providers/setup.js";
+import { createCache } from "./cache.js";
 
 interface KeyRow {
   path: string;
@@ -98,12 +99,14 @@ async function printRevealed(appDir: string, envName: string, mapFile?: string):
 
   const config = await loadConfig(appDir, envName, { mappingFile: mapFile });
   const registry = createDefaultRegistry();
+  const cache = createCache(config);
 
   const resolved = await resolve({
     schema: config.schema,
     env: config.env,
     envName,
-    registry
+    registry,
+    cache
   });
 
   const resolvedMap = new Map(resolved.map((r) => [r.path, r.value]));

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -3,6 +3,7 @@ import spawn from "cross-spawn";
 import { loadConfig } from "../config/loader.js";
 import { resolve, validate } from "../resolver/index.js";
 import { createDefaultRegistry } from "../providers/setup.js";
+import { createCache } from "./cache.js";
 
 export const runCommand = new Command("run")
   .description("Resolve secrets and run a command with env vars injected")
@@ -14,12 +15,14 @@ export const runCommand = new Command("run")
     const appDir = process.cwd();
     const config = await loadConfig(appDir, opts.env, { mappingFile: opts.map });
     const registry = createDefaultRegistry();
+    const cache = createCache(config);
 
     const resolveOpts = {
       schema: config.schema,
       env: config.env,
       envName: opts.env,
-      registry
+      registry,
+      cache
     };
 
     const errors = await validate(resolveOpts);

--- a/src/config/environment.ts
+++ b/src/config/environment.ts
@@ -7,8 +7,13 @@ export interface ProviderConfig {
   options: Record<string, unknown>;
 }
 
+export interface CacheConfig {
+  ttl: number;
+}
+
 export interface EnvConfig {
   defaultProvider?: ProviderConfig;
+  cache?: CacheConfig;
   overrides: Record<string, string | TaggedValue>;
 }
 
@@ -20,6 +25,7 @@ export function parseEnvironment(content: string): EnvConfig {
 
   const doc = raw as Record<string, unknown>;
   const defaultProvider = parseProviderBlock(doc["default-provider"]);
+  const cache = parseCacheBlock(doc.cache);
 
   const keysBlock = doc.keys;
   if (keysBlock != null && typeof keysBlock !== "object") {
@@ -36,7 +42,7 @@ export function parseEnvironment(content: string): EnvConfig {
     }
   }
 
-  return { defaultProvider, overrides };
+  return { defaultProvider, cache, overrides };
 }
 
 export function parseProviderBlock(raw: unknown): ProviderConfig | undefined {
@@ -54,4 +60,17 @@ export function parseProviderBlock(raw: unknown): ProviderConfig | undefined {
   }
 
   return { name, options };
+}
+
+export function parseCacheBlock(raw: unknown): CacheConfig | undefined {
+  if (!raw || typeof raw !== "object") return undefined;
+
+  const block = raw as Record<string, unknown>;
+  const ttl = block.ttl;
+
+  if (typeof ttl !== "number" || ttl <= 0) {
+    throw new Error('Cache "ttl" must be a positive number (seconds)');
+  }
+
+  return { ttl };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,8 +7,10 @@ export {
 export {
   parseEnvironment,
   parseProviderBlock,
+  parseCacheBlock,
   type EnvConfig,
-  type ProviderConfig
+  type ProviderConfig,
+  type CacheConfig
 } from "./config/environment.js";
 export { parseAppMapping, type AppMapping } from "./config/app-mapping.js";
 export { loadConfig, findRootDir, type LoadedConfig } from "./config/loader.js";
@@ -23,6 +25,8 @@ export { PlaintextProvider } from "./providers/plaintext.js";
 export { AgeProvider, generateIdentity, identityToRecipient } from "./providers/age.js";
 export { GcpSmProvider, type GcpSmProviderOptions } from "./providers/gcp-sm.js";
 export { createDefaultRegistry } from "./providers/setup.js";
+
+export { SecretCache, type SecretCacheOptions } from "./cache/index.js";
 
 export { flattenKeys, setNestedValue } from "./utils/paths.js";
 

--- a/src/resolver/index.ts
+++ b/src/resolver/index.ts
@@ -2,6 +2,7 @@ import type { KeyDefinition } from "../config/schema.js";
 import type { EnvConfig } from "../config/environment.js";
 import { isTaggedValue, type TaggedValue } from "../config/yaml-tags.js";
 import type { ProviderRegistry } from "../providers/registry.js";
+import type { SecretCache } from "../cache/index.js";
 import type { ResolvedKey, ValidationError } from "./types.js";
 
 export interface ResolveOptions {
@@ -9,15 +10,16 @@ export interface ResolveOptions {
   env: EnvConfig;
   envName: string;
   registry: ProviderRegistry;
+  cache?: SecretCache;
 }
 
 export async function validate(options: ResolveOptions): Promise<ValidationError[]> {
-  const { schema, env, envName, registry } = options;
+  const { schema, env, envName, registry, cache } = options;
   const errors: ValidationError[] = [];
 
   for (const key of schema) {
     try {
-      await resolveKey(key, env, envName, registry);
+      await resolveKey(key, env, envName, registry, cache);
     } catch (err) {
       errors.push({
         path: key.path,
@@ -30,11 +32,11 @@ export async function validate(options: ResolveOptions): Promise<ValidationError
 }
 
 export async function resolve(options: ResolveOptions): Promise<ResolvedKey[]> {
-  const { schema, env, envName, registry } = options;
+  const { schema, env, envName, registry, cache } = options;
   const results: ResolvedKey[] = [];
 
   for (const key of schema) {
-    const value = await resolveKey(key, env, envName, registry);
+    const value = await resolveKey(key, env, envName, registry, cache);
     if (value !== undefined) {
       results.push({ path: key.path, value });
     }
@@ -47,7 +49,8 @@ async function resolveKey(
   key: KeyDefinition,
   env: EnvConfig,
   envName: string,
-  registry: ProviderRegistry
+  registry: ProviderRegistry,
+  cache?: SecretCache
 ): Promise<string | undefined> {
   const override = env.overrides[key.path];
 
@@ -59,7 +62,9 @@ async function resolveKey(
   // 2. Env file explicit override (provider-tagged)
   if (override !== undefined && isTaggedValue(override)) {
     try {
-      return await resolveViaProvider(key.path, override, env, envName, registry);
+      return await resolveWithCache(key.path, envName, cache, () =>
+        resolveViaProvider(key.path, override, env, envName, registry)
+      );
     } catch (err) {
       if (key.optional) return undefined;
       throw err;
@@ -75,7 +80,7 @@ async function resolveKey(
       config: { ...env.defaultProvider.options }
     };
     try {
-      return await provider.resolve(ctx);
+      return await resolveWithCache(key.path, envName, cache, () => provider.resolve(ctx));
     } catch (err) {
       if (key.optional) return undefined;
       throw err;
@@ -93,6 +98,28 @@ async function resolveKey(
   }
 
   throw new Error(`No value for required key "${key.path}"`);
+}
+
+async function resolveWithCache(
+  keyPath: string,
+  envName: string,
+  cache: SecretCache | undefined,
+  fetchFn: () => Promise<string>
+): Promise<string> {
+  if (cache) {
+    const cached = await cache.get(envName, keyPath);
+    if (cached !== undefined) {
+      return cached;
+    }
+  }
+
+  const value = await fetchFn();
+
+  if (cache) {
+    await cache.set(envName, keyPath, value);
+  }
+
+  return value;
 }
 
 async function resolveViaProvider(

--- a/test/e2e/helpers/age.ts
+++ b/test/e2e/helpers/age.ts
@@ -2,7 +2,11 @@ import { writeFile, mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { generateIdentity } from "../../../src/providers/age.js";
 
-export async function writeAgeFixture(root: string, envName: string) {
+export interface AgeFixtureOptions {
+  cacheTtl?: number;
+}
+
+export async function writeAgeFixture(root: string, envName: string, options?: AgeFixtureOptions) {
   const identityFile = join(root, "key.txt");
   const secretsDir = join(root, ".keyshelf", "secrets");
 
@@ -14,19 +18,19 @@ export async function writeAgeFixture(root: string, envName: string) {
     ["keys:", "  db:", "    host: localhost", '    password: !secret ""'].join("\n")
   );
 
+  const envLines = [
+    ...(options?.cacheTtl ? ["cache:", `  ttl: ${options.cacheTtl}`] : []),
+    "default-provider:",
+    "  name: age",
+    `  identityFile: ${identityFile}`,
+    `  secretsDir: ${secretsDir}`,
+    "keys:",
+    "  db:",
+    "    host: prod-db"
+  ];
+
   await mkdir(join(root, ".keyshelf"), { recursive: true });
-  await writeFile(
-    join(root, ".keyshelf", `${envName}.yaml`),
-    [
-      "default-provider:",
-      "  name: age",
-      `  identityFile: ${identityFile}`,
-      `  secretsDir: ${secretsDir}`,
-      "keys:",
-      "  db:",
-      "    host: prod-db"
-    ].join("\n")
-  );
+  await writeFile(join(root, ".keyshelf", `${envName}.yaml`), envLines.join("\n"));
 
   await writeFile(
     join(root, ".env.keyshelf"),

--- a/test/e2e/ls.test.ts
+++ b/test/e2e/ls.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeAll } from "vitest";
-import { mkdtemp, writeFile, mkdir } from "node:fs/promises";
+import { mkdtemp, writeFile, mkdir, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { existsSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { writeAgeFixture } from "./helpers/age.js";
 
@@ -143,5 +144,54 @@ describe("keyshelf ls (age)", () => {
     const lines = result.trim().split("\n");
     expect(lines[0]).toMatch(/db\/host\s+config\s+prod-db/);
     expect(lines[1]).toMatch(/db\/password\s+secret\s+age-secret-value/);
+  });
+});
+
+describe("keyshelf ls --reveal (cache)", () => {
+  let root: string;
+  const envName = "cache-test";
+
+  beforeAll(async () => {
+    root = await mkdtemp(join(tmpdir(), "keyshelf-e2e-cache-ls-"));
+    await writeAgeFixture(root, envName, { cacheTtl: 3600 });
+
+    execFileSync(
+      TSX,
+      [
+        CLI,
+        "set",
+        "--env",
+        envName,
+        "--provider",
+        "age",
+        "--value",
+        "cached-reveal-secret",
+        "db/password"
+      ],
+      { cwd: root, encoding: "utf-8" }
+    );
+  });
+
+  it("populates cache on --reveal and serves from it afterwards", async () => {
+    // first reveal populates cache
+    execFileSync(TSX, [CLI, "ls", "--env", envName, "--reveal"], {
+      cwd: root,
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"]
+    });
+
+    expect(existsSync(join(root, ".keyshelf", "cache", envName, "db_password.age"))).toBe(true);
+
+    // delete the secret source
+    await rm(join(root, ".keyshelf", "secrets"), { recursive: true, force: true });
+
+    // second reveal should still work from cache
+    const result = execFileSync(TSX, [CLI, "ls", "--env", envName, "--reveal"], {
+      cwd: root,
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"]
+    });
+    const lines = result.trim().split("\n");
+    expect(lines[1]).toMatch(/db\/password\s+secret\s+cached-reveal-secret/);
   });
 });

--- a/test/e2e/run.test.ts
+++ b/test/e2e/run.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
-import { mkdtemp, writeFile, mkdir } from "node:fs/promises";
+import { mkdtemp, writeFile, mkdir, rm, readdir } from "node:fs/promises";
+import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { execFileSync } from "node:child_process";
@@ -324,5 +325,82 @@ describe.skipIf(!GCP_PROJECT)("keyshelf run (gcp)", { timeout: 30_000 }, () => {
       { cwd: root, encoding: "utf-8" }
     );
     expect(result.trim()).toBe("updated-secret");
+  });
+});
+
+describe("keyshelf run (cache)", () => {
+  let root: string;
+  const envName = "cache-test";
+
+  beforeAll(async () => {
+    root = await mkdtemp(join(tmpdir(), "keyshelf-e2e-cache-run-"));
+    await writeAgeFixture(root, envName, { cacheTtl: 3600 });
+
+    execFileSync(
+      TSX,
+      [
+        CLI,
+        "set",
+        "--env",
+        envName,
+        "--provider",
+        "age",
+        "--value",
+        "cached-secret",
+        "db/password"
+      ],
+      { cwd: root, encoding: "utf-8" }
+    );
+  });
+
+  it("creates encrypted cache files on first run", () => {
+    const result = execFileSync(
+      TSX,
+      [CLI, "run", "--env", envName, "--", "node", "-e", "console.log(process.env.DB_PASSWORD)"],
+      { cwd: root, encoding: "utf-8" }
+    );
+    expect(result.trim()).toBe("cached-secret");
+
+    const cacheDir = join(root, ".keyshelf", "cache");
+    expect(existsSync(join(cacheDir, "identity.txt"))).toBe(true);
+    expect(existsSync(join(cacheDir, envName, "db_password.age"))).toBe(true);
+  });
+
+  it("serves from cache after deleting the original secret file", async () => {
+    // first run to populate cache
+    execFileSync(TSX, [CLI, "run", "--env", envName, "--", "node", "-e", "console.log('warm')"], {
+      cwd: root,
+      encoding: "utf-8"
+    });
+
+    // delete the actual age secret source
+    await rm(join(root, ".keyshelf", "secrets"), { recursive: true, force: true });
+
+    // should still resolve from cache
+    const result = execFileSync(
+      TSX,
+      [CLI, "run", "--env", envName, "--", "node", "-e", "console.log(process.env.DB_PASSWORD)"],
+      { cwd: root, encoding: "utf-8" }
+    );
+    expect(result.trim()).toBe("cached-secret");
+  });
+
+  it("does not create cache directory when cache is not configured", async () => {
+    const noCacheRoot = await mkdtemp(join(tmpdir(), "keyshelf-e2e-nocache-run-"));
+    await writeAgeFixture(noCacheRoot, "dev");
+
+    execFileSync(
+      TSX,
+      [CLI, "set", "--env", "dev", "--provider", "age", "--value", "val", "db/password"],
+      { cwd: noCacheRoot, encoding: "utf-8" }
+    );
+
+    execFileSync(TSX, [CLI, "run", "--env", "dev", "--", "node", "-e", "console.log('ok')"], {
+      cwd: noCacheRoot,
+      encoding: "utf-8"
+    });
+
+    const entries = await readdir(join(noCacheRoot, ".keyshelf"));
+    expect(entries).not.toContain("cache");
   });
 });

--- a/test/unit/cache/index.test.ts
+++ b/test/unit/cache/index.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdtemp, readdir, stat, utimes, mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { SecretCache } from "../../../src/cache/index.js";
+
+describe("SecretCache", () => {
+  let cacheDir: string;
+
+  beforeEach(async () => {
+    cacheDir = await mkdtemp(join(tmpdir(), "keyshelf-cache-test-"));
+  });
+
+  it("returns undefined on cache miss", async () => {
+    const cache = new SecretCache({ cacheDir, ttl: 3600 });
+    const result = await cache.get("dev", "db/password");
+    expect(result).toBeUndefined();
+  });
+
+  it("encrypts, stores, and retrieves a value", async () => {
+    const cache = new SecretCache({ cacheDir, ttl: 3600 });
+    await cache.set("dev", "db/password", "my-secret");
+    const result = await cache.get("dev", "db/password");
+    expect(result).toBe("my-secret");
+  });
+
+  it("stores values in separate env directories", async () => {
+    const cache = new SecretCache({ cacheDir, ttl: 3600 });
+    await cache.set("dev", "db/password", "dev-secret");
+    await cache.set("staging", "db/password", "staging-secret");
+
+    expect(await cache.get("dev", "db/password")).toBe("dev-secret");
+    expect(await cache.get("staging", "db/password")).toBe("staging-secret");
+  });
+
+  it("auto-generates identity file on first use", async () => {
+    const cache = new SecretCache({ cacheDir, ttl: 3600 });
+    await cache.set("dev", "key", "value");
+
+    const identityPath = join(cacheDir, "identity.txt");
+    const identityStat = await stat(identityPath);
+    expect(identityStat.isFile()).toBe(true);
+    // Check file permissions (owner-only read/write)
+    expect(identityStat.mode & 0o777).toBe(0o600);
+  });
+
+  it("reuses existing identity across instances", async () => {
+    const cache1 = new SecretCache({ cacheDir, ttl: 3600 });
+    await cache1.set("dev", "key", "value");
+
+    const cache2 = new SecretCache({ cacheDir, ttl: 3600 });
+    const result = await cache2.get("dev", "key");
+    expect(result).toBe("value");
+  });
+
+  it("returns undefined for expired entries", async () => {
+    const cache = new SecretCache({ cacheDir, ttl: 60 });
+    await cache.set("dev", "key", "value");
+
+    // Backdate the file's mtime by 120 seconds to simulate expiry
+    const filePath = join(cacheDir, "dev", "key.age");
+    const past = new Date(Date.now() - 120_000);
+    await utimes(filePath, past, past);
+
+    const result = await cache.get("dev", "key");
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined for corrupt cache entries", async () => {
+    const cache = new SecretCache({ cacheDir, ttl: 3600 });
+    // Write a valid entry first to generate the identity
+    await cache.set("dev", "good", "value");
+
+    // Write garbage to a cache file
+    const corruptPath = join(cacheDir, "dev", "bad.age");
+    await writeFile(corruptPath, "not-valid-age-ciphertext");
+
+    const result = await cache.get("dev", "bad");
+    expect(result).toBeUndefined();
+  });
+
+  it("creates .age files on disk", async () => {
+    const cache = new SecretCache({ cacheDir, ttl: 3600 });
+    await cache.set("dev", "db/password", "secret");
+
+    const files = await readdir(join(cacheDir, "dev"));
+    expect(files).toContain("db_password.age");
+  });
+});

--- a/test/unit/config/environment.test.ts
+++ b/test/unit/config/environment.test.ts
@@ -94,4 +94,26 @@ describe("parseEnvironment", () => {
     });
     expect(env.overrides).toEqual({});
   });
+
+  it("parses cache block with ttl", () => {
+    const content = "cache:\n  ttl: 3600";
+    const env = parseEnvironment(content);
+    expect(env.cache).toEqual({ ttl: 3600 });
+  });
+
+  it("returns undefined cache when no cache block", () => {
+    const content = "keys:\n  db/host: localhost";
+    const env = parseEnvironment(content);
+    expect(env.cache).toBeUndefined();
+  });
+
+  it("throws for invalid cache ttl", () => {
+    const content = "cache:\n  ttl: -1";
+    expect(() => parseEnvironment(content)).toThrow('Cache "ttl" must be a positive number');
+  });
+
+  it("throws for non-numeric cache ttl", () => {
+    const content = "cache:\n  ttl: fast";
+    expect(() => parseEnvironment(content)).toThrow('Cache "ttl" must be a positive number');
+  });
 });

--- a/test/unit/resolver/index.test.ts
+++ b/test/unit/resolver/index.test.ts
@@ -4,6 +4,7 @@ import { ProviderRegistry } from "../../../src/providers/registry.js";
 import type { Provider } from "../../../src/providers/types.js";
 import type { KeyDefinition } from "../../../src/config/schema.js";
 import type { EnvConfig } from "../../../src/config/environment.js";
+import type { SecretCache } from "../../../src/cache/index.js";
 
 function mockProvider(name: string, resolveValue = "provider-value"): Provider {
   return {
@@ -338,6 +339,93 @@ describe("resolve", () => {
       registry: makeRegistry(gcp)
     });
     expect(result).toEqual([{ path: "app/name", value: "from-provider" }]);
+  });
+});
+
+describe("resolve with cache", () => {
+  function mockCache(): SecretCache {
+    return {
+      get: vi.fn().mockResolvedValue(undefined),
+      set: vi.fn().mockResolvedValue(undefined)
+    } as unknown as SecretCache;
+  }
+
+  it("populates cache on provider resolve", async () => {
+    const gcp = mockProvider("gcp", "secret-val");
+    const cache = mockCache();
+    const env: EnvConfig = {
+      defaultProvider: { name: "gcp", options: { project: "p" } },
+      overrides: {}
+    };
+    await resolve({
+      envName: "test",
+      schema: [secretKey("db/password")],
+      env,
+      registry: makeRegistry(gcp),
+      cache
+    });
+    expect(cache.set).toHaveBeenCalledWith("test", "db/password", "secret-val");
+  });
+
+  it("returns cached value without calling provider", async () => {
+    const gcp = mockProvider("gcp", "fresh-val");
+    const cache = mockCache();
+    (cache.get as ReturnType<typeof vi.fn>).mockResolvedValue("cached-val");
+    const env: EnvConfig = {
+      defaultProvider: { name: "gcp", options: { project: "p" } },
+      overrides: {}
+    };
+    const result = await resolve({
+      envName: "test",
+      schema: [secretKey("db/password")],
+      env,
+      registry: makeRegistry(gcp),
+      cache
+    });
+    expect(result).toEqual([{ path: "db/password", value: "cached-val" }]);
+    expect(gcp.resolve).not.toHaveBeenCalled();
+  });
+
+  it("does not cache plaintext overrides", async () => {
+    const cache = mockCache();
+    const env: EnvConfig = { overrides: { "db/host": "localhost" } };
+    await resolve({
+      envName: "test",
+      schema: [configKey("db/host", "default")],
+      env,
+      registry: makeRegistry(),
+      cache
+    });
+    expect(cache.set).not.toHaveBeenCalled();
+  });
+
+  it("does not cache schema defaults", async () => {
+    const cache = mockCache();
+    const env: EnvConfig = { overrides: {} };
+    await resolve({
+      envName: "test",
+      schema: [configKey("db/host", "default")],
+      env,
+      registry: makeRegistry(),
+      cache
+    });
+    expect(cache.set).not.toHaveBeenCalled();
+  });
+
+  it("caches provider-tagged overrides", async () => {
+    const gcp = mockProvider("gcp", "tagged-secret");
+    const cache = mockCache();
+    const env: EnvConfig = {
+      overrides: { "db/password": { tag: "gcp", config: { name: "x" } } }
+    };
+    await resolve({
+      envName: "test",
+      schema: [secretKey("db/password")],
+      env,
+      registry: makeRegistry(gcp),
+      cache
+    });
+    expect(cache.set).toHaveBeenCalledWith("test", "db/password", "tagged-secret");
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds an age-encrypted file cache for resolved secrets, opt-in via `cache: { ttl }` in environment config
- Cached values stored in `.keyshelf/cache/<env>/` with auto-generated identity (mode 0600)
- TTL checked via file mtime — no decryption needed to check expiry
- Only provider-resolved values are cached (plaintext overrides and schema defaults bypass cache)
- Graceful degradation: corrupt cache entries are treated as misses
- Race-safe identity generation via atomic `link()`

## Test plan
- [x] Unit tests for `SecretCache` (encrypt/decrypt roundtrip, TTL expiry, corrupt entries, identity reuse)
- [x] Unit tests for `parseCacheBlock` (valid TTL, missing block, invalid values)
- [x] Unit tests for resolver cache integration (cache hit skips provider, cache miss populates, plaintext/defaults not cached)
- [x] E2E tests in `run.test.ts` (cache file creation, serve from cache after source deletion, no cache when unconfigured)
- [x] E2E tests in `ls.test.ts` (`--reveal` populates and serves from cache)
- [x] All existing tests pass (including GCP e2e against `staging-480220`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)