### PR TITLE
fix: show actionable error for GCP auth failures

### DIFF
--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -3,6 +3,7 @@ import spawn from "cross-spawn";
 import { loadConfig } from "../config/loader.js";
 import { resolve, validate } from "../resolver/index.js";
 import { createDefaultRegistry } from "../providers/setup.js";
+import { GcpAuthError } from "../providers/gcp-sm.js";
 
 export const runCommand = new Command("run")
   .description("Resolve secrets and run a command with env vars injected")
@@ -24,9 +25,22 @@ export const runCommand = new Command("run")
 
     const errors = await validate(resolveOpts);
     if (errors.length > 0) {
-      console.error("Validation errors:");
-      for (const err of errors) {
-        console.error(`  - ${err.path}: ${err.message}`);
+      const authErrors = errors.filter((e) => e.error instanceof GcpAuthError);
+      const otherErrors = errors.filter((e) => !(e.error instanceof GcpAuthError));
+
+      if (authErrors.length > 0) {
+        console.error(
+          "GCP authentication failed. Your credentials may be expired or revoked.\n" +
+            "Run the following command to re-authenticate:\n\n" +
+            "  gcloud auth application-default login\n"
+        );
+      }
+
+      if (otherErrors.length > 0) {
+        console.error("Validation errors:");
+        for (const err of otherErrors) {
+          console.error(`  - ${err.path}: ${err.message}`);
+        }
       }
       process.exit(1);
     }

--- a/src/providers/gcp-sm.ts
+++ b/src/providers/gcp-sm.ts
@@ -5,6 +5,34 @@ export interface GcpSmProviderOptions {
   project: string;
 }
 
+export class GcpAuthError extends Error {
+  constructor(cause?: Error) {
+    super(
+      "GCP authentication failed. Run `gcloud auth application-default login` to re-authenticate."
+    );
+    this.name = "GcpAuthError";
+    this.cause = cause;
+  }
+}
+
+const AUTH_ERROR_PATTERNS = [
+  "invalid_grant",
+  "invalid_rapt",
+  "reauth related error",
+  "token has been expired or revoked",
+  "Could not load the default credentials",
+  "Could not automatically determine credentials"
+];
+
+function isAuthError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  const msg = err.message;
+  const code = (err as { code?: number }).code;
+  // gRPC UNAUTHENTICATED = 16
+  if (code === 16) return true;
+  return AUTH_ERROR_PATTERNS.some((pattern) => msg.includes(pattern));
+}
+
 function toSecretId(envName: string, keyPath: string): string {
   return `keyshelf__${envName}__${keyPath.replace(/\//g, "__")}`;
 }
@@ -32,9 +60,15 @@ export class GcpSmProvider implements Provider {
     const opts = this.resolveOptions(ctx);
     const secretId = toSecretId(ctx.envName, ctx.keyPath);
 
-    const [version] = await this.client.accessSecretVersion({
-      name: `projects/${opts.project}/secrets/${secretId}/versions/latest`
-    });
+    let version;
+    try {
+      [version] = await this.client.accessSecretVersion({
+        name: `projects/${opts.project}/secrets/${secretId}/versions/latest`
+      });
+    } catch (err) {
+      if (isAuthError(err)) throw new GcpAuthError(err as Error);
+      throw err;
+    }
 
     const payload = version.payload?.data;
     if (!payload) {
@@ -53,7 +87,8 @@ export class GcpSmProvider implements Provider {
         name: `projects/${opts.project}/secrets/${secretId}`
       });
       return true;
-    } catch {
+    } catch (err) {
+      if (isAuthError(err)) throw new GcpAuthError(err as Error);
       return false;
     }
   }
@@ -71,6 +106,7 @@ export class GcpSmProvider implements Provider {
         secret: { replication: { automatic: {} } }
       });
     } catch (err: unknown) {
+      if (isAuthError(err)) throw new GcpAuthError(err as Error);
       const code = (err as { code?: number }).code;
       if (code !== 6) {
         // 6 = ALREADY_EXISTS
@@ -79,9 +115,14 @@ export class GcpSmProvider implements Provider {
     }
 
     // Add new version
-    await this.client.addSecretVersion({
-      parent: `${parent}/secrets/${secretId}`,
-      payload: { data: Buffer.from(value, "utf-8") }
-    });
+    try {
+      await this.client.addSecretVersion({
+        parent: `${parent}/secrets/${secretId}`,
+        payload: { data: Buffer.from(value, "utf-8") }
+      });
+    } catch (err) {
+      if (isAuthError(err)) throw new GcpAuthError(err as Error);
+      throw err;
+    }
   }
 }

--- a/src/resolver/index.ts
+++ b/src/resolver/index.ts
@@ -21,7 +21,8 @@ export async function validate(options: ResolveOptions): Promise<ValidationError
     } catch (err) {
       errors.push({
         path: key.path,
-        message: err instanceof Error ? err.message : String(err)
+        message: err instanceof Error ? err.message : String(err),
+        error: err instanceof Error ? err : undefined
       });
     }
   }

--- a/src/resolver/types.ts
+++ b/src/resolver/types.ts
@@ -6,4 +6,5 @@ export interface ResolvedKey {
 export interface ValidationError {
   path: string;
   message: string;
+  error?: Error;
 }

--- a/test/unit/providers/gcp-sm.test.ts
+++ b/test/unit/providers/gcp-sm.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { SecretManagerServiceClient } from "@google-cloud/secret-manager";
-import { GcpSmProvider } from "../../../src/providers/gcp-sm.js";
+import { GcpSmProvider, GcpAuthError } from "../../../src/providers/gcp-sm.js";
 
 function mockClient() {
   return {
@@ -132,6 +132,73 @@ describe("GcpSmProvider", () => {
       client.createSecret.mockRejectedValue(permDenied);
 
       await expect(provider.set(ctx("db/password"), "val")).rejects.toThrow("PERMISSION_DENIED");
+    });
+  });
+
+  describe("auth error detection", () => {
+    it("throws GcpAuthError on invalid_grant in resolve", async () => {
+      const authErr = new Error(
+        '400 undefined: Getting metadata from plugin failed with error: {"error":"invalid_grant","error_description":"reauth related error (invalid_rapt)"}'
+      );
+      client.accessSecretVersion.mockRejectedValue(authErr);
+
+      await expect(provider.resolve(ctx("db/password"))).rejects.toThrow(GcpAuthError);
+      await expect(provider.resolve(ctx("db/password"))).rejects.toThrow(
+        "gcloud auth application-default login"
+      );
+    });
+
+    it("throws GcpAuthError on UNAUTHENTICATED gRPC code in resolve", async () => {
+      const authErr = Object.assign(new Error("UNAUTHENTICATED"), { code: 16 });
+      client.accessSecretVersion.mockRejectedValue(authErr);
+
+      await expect(provider.resolve(ctx("db/password"))).rejects.toThrow(GcpAuthError);
+    });
+
+    it("throws GcpAuthError on expired token in resolve", async () => {
+      const authErr = new Error("token has been expired or revoked");
+      client.accessSecretVersion.mockRejectedValue(authErr);
+
+      await expect(provider.resolve(ctx("db/password"))).rejects.toThrow(GcpAuthError);
+    });
+
+    it("throws GcpAuthError on auth error in validate", async () => {
+      const authErr = new Error(
+        '{"error":"invalid_grant","error_description":"reauth related error (invalid_rapt)"}'
+      );
+      client.getSecret.mockRejectedValue(authErr);
+
+      await expect(provider.validate(ctx("db/password"))).rejects.toThrow(GcpAuthError);
+    });
+
+    it("throws GcpAuthError on auth error in set (createSecret)", async () => {
+      const authErr = new Error("invalid_grant");
+      client.createSecret.mockRejectedValue(authErr);
+
+      await expect(provider.set(ctx("db/password"), "val")).rejects.toThrow(GcpAuthError);
+    });
+
+    it("throws GcpAuthError on auth error in set (addSecretVersion)", async () => {
+      client.createSecret.mockResolvedValue([{}]);
+      const authErr = new Error("token has been expired or revoked");
+      client.addSecretVersion.mockRejectedValue(authErr);
+
+      await expect(provider.set(ctx("db/password"), "val")).rejects.toThrow(GcpAuthError);
+    });
+
+    it("throws GcpAuthError when default credentials not found", async () => {
+      const authErr = new Error("Could not load the default credentials");
+      client.accessSecretVersion.mockRejectedValue(authErr);
+
+      await expect(provider.resolve(ctx("db/password"))).rejects.toThrow(GcpAuthError);
+    });
+
+    it("does not throw GcpAuthError for non-auth errors", async () => {
+      const notFound = new Error("NOT_FOUND: Secret not found");
+      client.accessSecretVersion.mockRejectedValue(notFound);
+
+      await expect(provider.resolve(ctx("db/password"))).rejects.toThrow("NOT_FOUND");
+      await expect(provider.resolve(ctx("db/password"))).rejects.not.toThrow(GcpAuthError);
     });
   });
 });

--- a/test/unit/resolver/index.test.ts
+++ b/test/unit/resolver/index.test.ts
@@ -364,14 +364,16 @@ describe("validate", () => {
       registry: makeRegistry()
     });
     expect(errors).toHaveLength(2);
-    expect(errors[0]).toEqual({
+    expect(errors[0]).toMatchObject({
       path: "db/password",
       message: 'No value for required key "db/password"'
     });
-    expect(errors[1]).toEqual({
+    expect(errors[0].error).toBeInstanceOf(Error);
+    expect(errors[1]).toMatchObject({
       path: "api/key",
       message: 'No value for required key "api/key"'
     });
+    expect(errors[1].error).toBeInstanceOf(Error);
   });
 
   it("skips optional secrets without error", async () => {
@@ -383,5 +385,23 @@ describe("validate", () => {
       registry: makeRegistry()
     });
     expect(errors).toEqual([]);
+  });
+
+  it("preserves original error object in validation errors", async () => {
+    const originalError = new Error("something went wrong");
+    const gcp = mockProvider("gcp");
+    (gcp.resolve as ReturnType<typeof vi.fn>).mockRejectedValue(originalError);
+    const env: EnvConfig = {
+      defaultProvider: { name: "gcp", options: { project: "my-proj" } },
+      overrides: {}
+    };
+    const errors = await validate({
+      envName: "test",
+      schema: [secretKey("db/password")],
+      env,
+      registry: makeRegistry(gcp)
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0].error).toBe(originalError);
   });
 });


### PR DESCRIPTION
## Summary
- Detects GCP authentication errors (`invalid_grant`, `invalid_rapt`, expired tokens, missing ADC) in the GCP Secret Manager provider and wraps them in a `GcpAuthError`
- Shows a single, actionable error message instead of repeating the same cryptic error for every secret key:
  ```
  GCP authentication failed. Your credentials may be expired or revoked.
  Run the following command to re-authenticate:

    gcloud auth application-default login
  ```
- Non-auth validation errors are still listed individually

## Test plan
- [x] Unit tests for auth error detection across `resolve`, `validate`, and `set` methods
- [x] Unit test verifying non-auth errors are not misidentified
- [x] Unit test verifying original error is preserved in `ValidationError`
- [x] All 127 unit tests passing
- [x] TypeScript type check passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)