### PR TITLE
feat: add sops provider

### DIFF
--- a/src/config/yaml-tags.ts
+++ b/src/config/yaml-tags.ts
@@ -32,7 +32,7 @@ function createBareTagType(tagName: string): yaml.Type {
   });
 }
 
-const TAG_NAMES = ["secret", "gcp", "aws", "age"] as const;
+const TAG_NAMES = ["secret", "gcp", "aws", "age", "sops"] as const;
 
 const mappingTypes = TAG_NAMES.map((name) => createTagType(name));
 const bareTypes = TAG_NAMES.map((name) => createBareTagType(name));

--- a/src/providers/setup.ts
+++ b/src/providers/setup.ts
@@ -2,11 +2,13 @@ import { ProviderRegistry } from "./registry.js";
 import { PlaintextProvider } from "./plaintext.js";
 import { AgeProvider } from "./age.js";
 import { GcpSmProvider } from "./gcp-sm.js";
+import { SopsProvider } from "./sops.js";
 
 export function createDefaultRegistry(): ProviderRegistry {
   const registry = new ProviderRegistry();
   registry.register(new PlaintextProvider());
   registry.register(new AgeProvider());
   registry.register(new GcpSmProvider());
+  registry.register(new SopsProvider());
   return registry;
 }

--- a/src/providers/sops.ts
+++ b/src/providers/sops.ts
@@ -1,0 +1,184 @@
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { randomBytes, createCipheriv, createDecipheriv, createHmac } from "node:crypto";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { Encrypter, Decrypter, identityToRecipient } from "age-encryption";
+import type { Provider, ProviderContext } from "./types.js";
+
+export interface SopsProviderOptions {
+  identityFile: string;
+  secretsFile: string;
+}
+
+interface EncryptedEntry {
+  data: string;
+  iv: string;
+  tag: string;
+}
+
+interface SecretsFile {
+  entries: Record<string, EncryptedEntry>;
+  sops: {
+    dataKey: string;
+    mac: string;
+  };
+}
+
+function expandTilde(filePath: string): string {
+  if (filePath.startsWith("~/") || filePath === "~") {
+    return join(homedir(), filePath.slice(1));
+  }
+  return filePath;
+}
+
+async function readIdentity(identityFile: string): Promise<string> {
+  const content = await readFile(identityFile, "utf-8");
+  return content.trim();
+}
+
+function generateDataKey(): Buffer {
+  return randomBytes(32);
+}
+
+async function encryptDataKey(dataKey: Buffer, recipient: string): Promise<string> {
+  const encrypter = new Encrypter();
+  encrypter.addRecipient(recipient);
+  const ciphertext = await encrypter.encrypt(dataKey);
+  // encrypt(Buffer) returns Uint8Array — encode as base64 for JSON storage
+  if (typeof ciphertext === "string") return ciphertext;
+  return Buffer.from(ciphertext).toString("base64");
+}
+
+async function decryptDataKey(encrypted: string, identity: string): Promise<Buffer> {
+  const decrypter = new Decrypter();
+  decrypter.addIdentity(identity);
+  const ciphertext = Buffer.from(encrypted, "base64");
+  const plain = await decrypter.decrypt(ciphertext, "uint8array");
+  return Buffer.from(plain);
+}
+
+function encryptValue(dataKey: Buffer, plaintext: string): EncryptedEntry {
+  const iv = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", dataKey, iv);
+  const encrypted = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  return {
+    data: encrypted.toString("base64"),
+    iv: iv.toString("base64"),
+    tag: cipher.getAuthTag().toString("base64")
+  };
+}
+
+function decryptValue(dataKey: Buffer, entry: EncryptedEntry): string {
+  const decipher = createDecipheriv("aes-256-gcm", dataKey, Buffer.from(entry.iv, "base64"));
+  decipher.setAuthTag(Buffer.from(entry.tag, "base64"));
+  return decipher.update(entry.data, "base64", "utf8") + decipher.final("utf8");
+}
+
+function computeMac(dataKey: Buffer, entries: Record<string, EncryptedEntry>): string {
+  const hmac = createHmac("sha256", dataKey);
+  for (const key of Object.keys(entries).sort()) {
+    const entry = entries[key];
+    hmac.update(key);
+    hmac.update(entry.data);
+    hmac.update(entry.iv);
+    hmac.update(entry.tag);
+  }
+  return hmac.digest("base64");
+}
+
+function verifyMac(dataKey: Buffer, file: SecretsFile): void {
+  const expected = computeMac(dataKey, file.entries);
+  if (expected !== file.sops.mac) {
+    throw new Error("sops: MAC verification failed — secrets file may have been tampered with");
+  }
+}
+
+async function readSecretsFile(path: string): Promise<SecretsFile> {
+  const content = await readFile(path, "utf-8");
+  return JSON.parse(content) as SecretsFile;
+}
+
+async function writeSecretsFile(path: string, file: SecretsFile): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, JSON.stringify(file, null, 2) + "\n");
+}
+
+export class SopsProvider implements Provider {
+  name = "sops";
+
+  private resolveOptions(ctx: ProviderContext): SopsProviderOptions {
+    const identityFile = ctx.config.identityFile;
+    const secretsFile = ctx.config.secretsFile;
+
+    if (typeof identityFile !== "string") {
+      throw new Error(`sops provider requires "identityFile" config for "${ctx.keyPath}"`);
+    }
+    if (typeof secretsFile !== "string") {
+      throw new Error(`sops provider requires "secretsFile" config for "${ctx.keyPath}"`);
+    }
+
+    return {
+      identityFile: expandTilde(identityFile),
+      secretsFile: expandTilde(secretsFile)
+    };
+  }
+
+  async resolve(ctx: ProviderContext): Promise<string> {
+    const opts = this.resolveOptions(ctx);
+    const file = await readSecretsFile(opts.secretsFile);
+    const identity = await readIdentity(opts.identityFile);
+    const dataKey = await decryptDataKey(file.sops.dataKey, identity);
+
+    verifyMac(dataKey, file);
+
+    const entry = file.entries[ctx.keyPath];
+    if (!entry) {
+      throw new Error(`sops: secret "${ctx.keyPath}" not found in ${opts.secretsFile}`);
+    }
+
+    return decryptValue(dataKey, entry);
+  }
+
+  async validate(ctx: ProviderContext): Promise<boolean> {
+    try {
+      const opts = this.resolveOptions(ctx);
+      const file = await readSecretsFile(opts.secretsFile);
+      return ctx.keyPath in file.entries;
+    } catch {
+      return false;
+    }
+  }
+
+  async set(ctx: ProviderContext, value: string): Promise<void> {
+    const opts = this.resolveOptions(ctx);
+    const identity = await readIdentity(opts.identityFile);
+    const recipient = await identityToRecipient(identity);
+
+    let file: SecretsFile;
+    let dataKey: Buffer;
+
+    try {
+      file = await readSecretsFile(opts.secretsFile);
+      dataKey = await decryptDataKey(file.sops.dataKey, identity);
+      verifyMac(dataKey, file);
+    } catch (err) {
+      const isNewFile =
+        err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT";
+      if (!isNewFile) throw err;
+
+      dataKey = generateDataKey();
+      file = {
+        entries: {},
+        sops: {
+          dataKey: await encryptDataKey(dataKey, recipient),
+          mac: ""
+        }
+      };
+    }
+
+    file.entries[ctx.keyPath] = encryptValue(dataKey, value);
+    file.sops.mac = computeMac(dataKey, file.entries);
+
+    await writeSecretsFile(opts.secretsFile, file);
+  }
+}

--- a/test/e2e/helpers/sops.ts
+++ b/test/e2e/helpers/sops.ts
@@ -1,0 +1,35 @@
+import { writeFile, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { generateIdentity } from "../../../src/providers/age.js";
+
+export async function writeSopsFixture(root: string, envName: string) {
+  const identityFile = join(root, "key.txt");
+  const secretsFile = join(root, ".keyshelf", "secrets.json");
+
+  const identity = await generateIdentity();
+  await writeFile(identityFile, identity);
+
+  await writeFile(
+    join(root, "keyshelf.yaml"),
+    ["keys:", "  db:", "    host: localhost", '    password: !secret ""'].join("\n")
+  );
+
+  await mkdir(join(root, ".keyshelf"), { recursive: true });
+  await writeFile(
+    join(root, ".keyshelf", `${envName}.yaml`),
+    [
+      "default-provider:",
+      "  name: sops",
+      `  identityFile: ${identityFile}`,
+      `  secretsFile: ${secretsFile}`,
+      "keys:",
+      "  db:",
+      "    host: prod-db"
+    ].join("\n")
+  );
+
+  await writeFile(
+    join(root, ".env.keyshelf"),
+    ["DB_HOST=db/host", "DB_PASSWORD=db/password"].join("\n")
+  );
+}

--- a/test/e2e/import.test.ts
+++ b/test/e2e/import.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { execFileSync } from "node:child_process";
 import { Decrypter } from "age-encryption";
 import { writeAgeFixture } from "./helpers/age.js";
+import { writeSopsFixture } from "./helpers/sops.js";
 
 const CLI = join(import.meta.dirname, "..", "..", "bin", "keyshelf.ts");
 const TSX = join(import.meta.dirname, "..", "..", "node_modules", ".bin", "tsx");
@@ -63,5 +64,55 @@ describe("keyshelf import (age)", () => {
 
     const plaintext = await decryptFile(join(secretsDir, "db_password.age"));
     expect(plaintext).toBe("explicit-provider-secret");
+  });
+});
+
+describe("keyshelf import (sops)", () => {
+  let root: string;
+  const envName = "sops-test";
+
+  beforeAll(async () => {
+    root = await mkdtemp(join(tmpdir(), "keyshelf-e2e-sops-import-"));
+    await writeSopsFixture(root, envName);
+  });
+
+  it("uses default provider for secret keys when --provider is omitted", async () => {
+    const dotenvPath = join(root, ".env");
+    await writeFile(dotenvPath, "DB_HOST=imported-host\nDB_PASSWORD=imported-secret\n");
+
+    execFileSync(TSX, [CLI, "import", "--env", envName, "--file", dotenvPath], {
+      cwd: root,
+      encoding: "utf-8"
+    });
+
+    // Secret should be encrypted via sops (default provider) — verify via run
+    const result = execFileSync(
+      TSX,
+      [CLI, "run", "--env", envName, "--", "node", "-e", "console.log(process.env.DB_PASSWORD)"],
+      { cwd: root, encoding: "utf-8" }
+    );
+    expect(result.trim()).toBe("imported-secret");
+
+    // Config should be stored as plaintext in env yaml
+    const envContent = await readFile(join(root, ".keyshelf", `${envName}.yaml`), "utf-8");
+    expect(envContent).toContain("imported-host");
+  });
+
+  it("stores secrets via explicit --provider", async () => {
+    const dotenvPath = join(root, ".env");
+    await writeFile(dotenvPath, "DB_PASSWORD=explicit-sops-secret\n");
+
+    execFileSync(
+      TSX,
+      [CLI, "import", "--env", envName, "--file", dotenvPath, "--provider", "sops"],
+      { cwd: root, encoding: "utf-8" }
+    );
+
+    const result = execFileSync(
+      TSX,
+      [CLI, "run", "--env", envName, "--", "node", "-e", "console.log(process.env.DB_PASSWORD)"],
+      { cwd: root, encoding: "utf-8" }
+    );
+    expect(result.trim()).toBe("explicit-sops-secret");
   });
 });

--- a/test/e2e/ls.test.ts
+++ b/test/e2e/ls.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { execFileSync } from "node:child_process";
 import { writeAgeFixture } from "./helpers/age.js";
+import { writeSopsFixture } from "./helpers/sops.js";
 
 const CLI = join(import.meta.dirname, "..", "..", "bin", "keyshelf.ts");
 const TSX = join(import.meta.dirname, "..", "..", "node_modules", ".bin", "tsx");
@@ -143,5 +144,52 @@ describe("keyshelf ls (age)", () => {
     const lines = result.trim().split("\n");
     expect(lines[0]).toMatch(/db\/host\s+config\s+prod-db/);
     expect(lines[1]).toMatch(/db\/password\s+secret\s+age-secret-value/);
+  });
+});
+
+describe("keyshelf ls (sops)", () => {
+  let root: string;
+  const envName = "sops-test";
+
+  beforeAll(async () => {
+    root = await mkdtemp(join(tmpdir(), "keyshelf-e2e-sops-ls-"));
+    await writeSopsFixture(root, envName);
+
+    execFileSync(
+      TSX,
+      [
+        CLI,
+        "set",
+        "--env",
+        envName,
+        "--provider",
+        "sops",
+        "--value",
+        "sops-secret-value",
+        "db/password"
+      ],
+      { cwd: root, encoding: "utf-8" }
+    );
+  });
+
+  it("shows provider source for sops secrets", () => {
+    const result = execFileSync(TSX, [CLI, "ls", "--env", envName], {
+      cwd: root,
+      encoding: "utf-8"
+    });
+    const lines = result.trim().split("\n");
+    expect(lines[0]).toMatch(/db\/host\s+config\s+override: prod-db/);
+    expect(lines[1]).toMatch(/db\/password\s+secret\s+provider: sops/);
+  });
+
+  it("--reveal resolves and shows actual values", () => {
+    const result = execFileSync(TSX, [CLI, "ls", "--env", envName, "--reveal"], {
+      cwd: root,
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"]
+    });
+    const lines = result.trim().split("\n");
+    expect(lines[0]).toMatch(/db\/host\s+config\s+prod-db/);
+    expect(lines[1]).toMatch(/db\/password\s+secret\s+sops-secret-value/);
   });
 });

--- a/test/e2e/run.test.ts
+++ b/test/e2e/run.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { execFileSync } from "node:child_process";
 import { GCP_PROJECT, createGcpClient, writeGcpFixture, deleteSecrets } from "./helpers/gcp.js";
 import { writeAgeFixture } from "./helpers/age.js";
+import { writeSopsFixture } from "./helpers/sops.js";
 
 const CLI = join(import.meta.dirname, "..", "..", "bin", "keyshelf.ts");
 const TSX = join(import.meta.dirname, "..", "..", "node_modules", ".bin", "tsx");
@@ -244,6 +245,79 @@ describe("keyshelf run (age)", () => {
       { cwd: root, encoding: "utf-8" }
     );
     expect(result.trim()).toBe("updated-age-secret");
+  });
+});
+
+describe("keyshelf run (sops)", () => {
+  let root: string;
+  const envName = "sops-test";
+
+  beforeAll(async () => {
+    root = await mkdtemp(join(tmpdir(), "keyshelf-e2e-sops-run-"));
+    await writeSopsFixture(root, envName);
+
+    execFileSync(
+      TSX,
+      [
+        CLI,
+        "set",
+        "--env",
+        envName,
+        "--provider",
+        "sops",
+        "--value",
+        "sops-secret-value",
+        "db/password"
+      ],
+      { cwd: root, encoding: "utf-8" }
+    );
+  });
+
+  it("resolves sops-encrypted secret and injects env vars", () => {
+    const result = execFileSync(
+      TSX,
+      [
+        CLI,
+        "run",
+        "--env",
+        envName,
+        "--",
+        "node",
+        "-e",
+        "console.log(JSON.stringify({host: process.env.DB_HOST, password: process.env.DB_PASSWORD}))"
+      ],
+      { cwd: root, encoding: "utf-8" }
+    );
+    const parsed = JSON.parse(result.trim());
+    expect(parsed).toEqual({
+      host: "prod-db",
+      password: "sops-secret-value"
+    });
+  });
+
+  it("picks up overwritten sops secret value", () => {
+    execFileSync(
+      TSX,
+      [
+        CLI,
+        "set",
+        "--env",
+        envName,
+        "--provider",
+        "sops",
+        "--value",
+        "updated-sops-secret",
+        "db/password"
+      ],
+      { cwd: root, encoding: "utf-8" }
+    );
+
+    const result = execFileSync(
+      TSX,
+      [CLI, "run", "--env", envName, "--", "node", "-e", "console.log(process.env.DB_PASSWORD)"],
+      { cwd: root, encoding: "utf-8" }
+    );
+    expect(result.trim()).toBe("updated-sops-secret");
   });
 });
 

--- a/test/e2e/set.test.ts
+++ b/test/e2e/set.test.ts
@@ -7,6 +7,7 @@ import { SecretManagerServiceClient } from "@google-cloud/secret-manager";
 import { Decrypter } from "age-encryption";
 import { GCP_PROJECT, createGcpClient, writeGcpFixture, deleteSecrets } from "./helpers/gcp.js";
 import { writeAgeFixture } from "./helpers/age.js";
+import { writeSopsFixture } from "./helpers/sops.js";
 
 const CLI = join(import.meta.dirname, "..", "..", "bin", "keyshelf.ts");
 const TSX = join(import.meta.dirname, "..", "..", "node_modules", ".bin", "tsx");
@@ -83,6 +84,93 @@ describe("keyshelf set (age)", () => {
 
     const plaintext = await decryptFile(join(secretsDir, "db_password.age"));
     expect(plaintext).toBe("default-provider-value");
+  });
+
+  it("stores config keys as plaintext even when default provider is configured", async () => {
+    execFileSync(TSX, [CLI, "set", "--env", envName, "--value", "new-host", "db/host"], {
+      cwd: root,
+      encoding: "utf-8"
+    });
+
+    const content = await readFile(join(root, ".keyshelf", `${envName}.yaml`), "utf-8");
+    expect(content).toContain("new-host");
+  });
+});
+
+describe("keyshelf set (sops)", () => {
+  let root: string;
+  let secretsFile: string;
+  const envName = "sops-test";
+
+  beforeAll(async () => {
+    root = await mkdtemp(join(tmpdir(), "keyshelf-e2e-sops-set-"));
+    await writeSopsFixture(root, envName);
+    secretsFile = join(root, ".keyshelf", "secrets.json");
+  });
+
+  it("creates an encrypted secret in the secrets file", async () => {
+    execFileSync(
+      TSX,
+      [
+        CLI,
+        "set",
+        "--env",
+        envName,
+        "--provider",
+        "sops",
+        "--value",
+        "sops-secret-value",
+        "db/password"
+      ],
+      { cwd: root, encoding: "utf-8" }
+    );
+
+    const content = JSON.parse(await readFile(secretsFile, "utf-8"));
+    expect(content.entries["db/password"]).toBeDefined();
+    expect(content.entries["db/password"].data).toBeDefined();
+    expect(content.sops.dataKey).toBeDefined();
+    expect(content.sops.mac).toBeDefined();
+  });
+
+  it("overwrites an existing sops secret", async () => {
+    execFileSync(
+      TSX,
+      [
+        CLI,
+        "set",
+        "--env",
+        envName,
+        "--provider",
+        "sops",
+        "--value",
+        "updated-sops-value",
+        "db/password"
+      ],
+      { cwd: root, encoding: "utf-8" }
+    );
+
+    // Verify via resolve (run command)
+    const result = execFileSync(
+      TSX,
+      [CLI, "run", "--env", envName, "--", "node", "-e", "console.log(process.env.DB_PASSWORD)"],
+      { cwd: root, encoding: "utf-8" }
+    );
+    expect(result.trim()).toBe("updated-sops-value");
+  });
+
+  it("uses default provider for secret keys when --provider is omitted", async () => {
+    execFileSync(
+      TSX,
+      [CLI, "set", "--env", envName, "--value", "default-sops-value", "db/password"],
+      { cwd: root, encoding: "utf-8" }
+    );
+
+    const result = execFileSync(
+      TSX,
+      [CLI, "run", "--env", envName, "--", "node", "-e", "console.log(process.env.DB_PASSWORD)"],
+      { cwd: root, encoding: "utf-8" }
+    );
+    expect(result.trim()).toBe("default-sops-value");
   });
 
   it("stores config keys as plaintext even when default provider is configured", async () => {

--- a/test/unit/providers/sops.test.ts
+++ b/test/unit/providers/sops.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdtemp, writeFile, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { homedir, tmpdir } from "node:os";
+import { SopsProvider } from "../../../src/providers/sops.js";
+import { generateIdentity } from "../../../src/providers/age.js";
+
+describe("SopsProvider", () => {
+  let tmpDir: string;
+  let identityFile: string;
+  let secretsFile: string;
+  let provider: SopsProvider;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "keyshelf-sops-"));
+    identityFile = join(tmpDir, "key.txt");
+    secretsFile = join(tmpDir, "secrets.json");
+
+    const identity = await generateIdentity();
+    await writeFile(identityFile, identity);
+
+    provider = new SopsProvider();
+  });
+
+  function ctx(keyPath: string) {
+    return { keyPath, envName: "test", config: { identityFile, secretsFile } };
+  }
+
+  it("roundtrips set + resolve", async () => {
+    await provider.set(ctx("db/password"), "supersecret");
+    const result = await provider.resolve(ctx("db/password"));
+    expect(result).toBe("supersecret");
+  });
+
+  it("roundtrips multiple keys", async () => {
+    await provider.set(ctx("db/password"), "dbpass");
+    await provider.set(ctx("api/key"), "apikey123");
+
+    expect(await provider.resolve(ctx("db/password"))).toBe("dbpass");
+    expect(await provider.resolve(ctx("api/key"))).toBe("apikey123");
+  });
+
+  it("stores all secrets in a single file", async () => {
+    await provider.set(ctx("db/password"), "dbpass");
+    await provider.set(ctx("api/key"), "apikey123");
+
+    const content = JSON.parse(await readFile(secretsFile, "utf-8"));
+    expect(Object.keys(content.entries)).toEqual(
+      expect.arrayContaining(["db/password", "api/key"])
+    );
+  });
+
+  it("overwrites existing secret", async () => {
+    await provider.set(ctx("db/password"), "old");
+    await provider.set(ctx("db/password"), "new");
+    expect(await provider.resolve(ctx("db/password"))).toBe("new");
+  });
+
+  it("validate returns true for existing secret", async () => {
+    await provider.set(ctx("db/password"), "value");
+    expect(await provider.validate(ctx("db/password"))).toBe(true);
+  });
+
+  it("validate returns false for missing secret", async () => {
+    expect(await provider.validate(ctx("missing/key"))).toBe(false);
+  });
+
+  it("validate returns false for missing file", async () => {
+    const missingCtx = {
+      keyPath: "k",
+      envName: "test",
+      config: { identityFile, secretsFile: join(tmpDir, "nope.json") }
+    };
+    expect(await provider.validate(missingCtx)).toBe(false);
+  });
+
+  it("resolve throws for missing secret", async () => {
+    await provider.set(ctx("other"), "val");
+    await expect(provider.resolve(ctx("missing/key"))).rejects.toThrow(
+      'secret "missing/key" not found'
+    );
+  });
+
+  it("resolve throws for missing file", async () => {
+    await expect(provider.resolve(ctx("missing/key"))).rejects.toThrow();
+  });
+
+  it("throws when identityFile is missing from config", async () => {
+    await expect(
+      provider.resolve({
+        keyPath: "k",
+        envName: "test",
+        config: { secretsFile }
+      })
+    ).rejects.toThrow("identityFile");
+  });
+
+  it("throws when secretsFile is missing from config", async () => {
+    await expect(
+      provider.resolve({
+        keyPath: "k",
+        envName: "test",
+        config: { identityFile }
+      })
+    ).rejects.toThrow("secretsFile");
+  });
+
+  it("handles empty string values", async () => {
+    await provider.set(ctx("empty"), "");
+    expect(await provider.resolve(ctx("empty"))).toBe("");
+  });
+
+  it("handles special characters", async () => {
+    const special = 'p@$$w0rd!#%^&*()_+{}|:"<>?`~';
+    await provider.set(ctx("special"), special);
+    expect(await provider.resolve(ctx("special"))).toBe(special);
+  });
+
+  it("detects tampering via MAC", async () => {
+    await provider.set(ctx("db/password"), "secret");
+
+    const content = JSON.parse(await readFile(secretsFile, "utf-8"));
+    content.entries["db/password"].data = "dGFtcGVyZWQ="; // "tampered" in base64
+    await writeFile(secretsFile, JSON.stringify(content));
+
+    await expect(provider.resolve(ctx("db/password"))).rejects.toThrow("MAC verification failed");
+  });
+
+  it("detects key injection via MAC", async () => {
+    await provider.set(ctx("db/password"), "secret");
+
+    const content = JSON.parse(await readFile(secretsFile, "utf-8"));
+    content.entries["injected/key"] = {
+      data: "ZmFrZQ==",
+      iv: "AAAAAAAAAAAAAAAA",
+      tag: "AAAAAAAAAAAAAAAAAAAAAA=="
+    };
+    await writeFile(secretsFile, JSON.stringify(content));
+
+    await expect(provider.resolve(ctx("db/password"))).rejects.toThrow("MAC verification failed");
+  });
+
+  it("expands ~ in identityFile and secretsFile", async () => {
+    const home = homedir();
+    const relIdentity = identityFile.replace(home, "~");
+    const relSecrets = secretsFile.replace(home, "~");
+
+    if (!identityFile.startsWith(home)) return;
+
+    const tildeCtx = {
+      keyPath: "tilde/test",
+      envName: "test",
+      config: { identityFile: relIdentity, secretsFile: relSecrets }
+    };
+
+    await provider.set(tildeCtx, "tilde-value");
+    expect(await provider.resolve(tildeCtx)).toBe("tilde-value");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a new `sops` provider that stores all secrets in a single JSON file using a SOPS-like format
- Uses a two-tier encryption scheme: an age-wrapped AES-256 data key for per-value AES-GCM encryption
- Includes HMAC-SHA256 MAC over all entries for tamper detection
- No new dependencies — uses `node:crypto` for AES-GCM/HMAC alongside existing `age-encryption`

### Config example
```yaml
default-provider:
  name: sops
  identityFile: ./keys/dev.txt
  secretsFile: ./.keyshelf/secrets.json
```

### File format
```json
{
  "entries": {
    "db/password": { "data": "...", "iv": "...", "tag": "..." }
  },
  "sops": {
    "dataKey": "<base64 age-encrypted AES-256 key>",
    "mac": "<HMAC-SHA256>"
  }
}
```

## Test plan

- [x] Unit tests (16 tests): roundtrips, multi-key, overwrites, validation, missing keys/files, config errors, empty strings, special chars, tilde expansion, MAC tampering detection
- [x] E2E tests (10 tests): `set`, `run`, `ls`, `import` commands all tested with sops provider
- [x] Full test suite passes (197 passed, 4 skipped GCP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)