### PR TITLE
fix: resolve provider config paths relative to project root

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ default-provider:
 | `identityFile` | Path to the age identity (private key) file       |
 | `secretsDir`   | Directory where `.age` encrypted files are stored |
 
+Relative paths are resolved from the project root (the directory containing `keyshelf.yaml`), so `./keys/production.txt` always refers to the same file regardless of where you run the command. Absolute paths and `~`-prefixed paths are used as-is.
+
 Generate a new identity:
 
 ```javascript
@@ -228,6 +230,8 @@ default-provider:
 | -------------- | -------------------------------------------------------- |
 | `identityFile` | Path to the age identity (private key) file              |
 | `secretsFile`  | Path to the JSON file where encrypted secrets are stored |
+
+Relative paths are resolved from the project root (the directory containing `keyshelf.yaml`). Absolute paths and `~`-prefixed paths are used as-is.
 
 The secrets file is created automatically on first `keyshelf set`. It contains all encrypted entries, the age-encrypted data key, and an HMAC for tamper detection. Unlike the `age` provider (one file per secret), `sops` keeps everything in a single file, which can be easier to manage and commit.
 
@@ -313,6 +317,7 @@ const errors = await validate({
   schema: config.schema,
   env: config.env,
   envName: "production",
+  rootDir: config.rootDir,
   registry
 });
 if (errors.length > 0) {
@@ -324,6 +329,7 @@ const resolved = await resolve({
   schema: config.schema,
   env: config.env,
   envName: "production",
+  rootDir: config.rootDir,
   registry
 });
 // [{ path: 'db/host', value: 'prod-db.example.com' }, ...]

--- a/src/cli/import.ts
+++ b/src/cli/import.ts
@@ -91,7 +91,7 @@ export const importCommand = new Command("import")
         if (config?.env.defaultProvider && config.env.defaultProvider.name === providerName) {
           Object.assign(providerConfig, config.env.defaultProvider.options);
         }
-        await provider.set({ keyPath, envName: opts.env, config: providerConfig }, value);
+        await provider.set({ keyPath, envName: opts.env, rootDir, config: providerConfig }, value);
         console.log(`  secret: ${envVar} -> ${keyPath} (via ${providerName})`);
       } else {
         setNestedValue(envDoc, keyPath, value);

--- a/src/cli/ls.ts
+++ b/src/cli/ls.ts
@@ -103,6 +103,7 @@ async function printRevealed(appDir: string, envName: string, mapFile?: string):
     schema: config.schema,
     env: config.env,
     envName,
+    rootDir: config.rootDir,
     registry
   });
 

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -20,6 +20,7 @@ export const runCommand = new Command("run")
       schema: config.schema,
       env: config.env,
       envName: opts.env,
+      rootDir: config.rootDir,
       registry
     };
 

--- a/src/cli/set.ts
+++ b/src/cli/set.ts
@@ -71,7 +71,7 @@ export const setCommand = new Command("set")
         Object.assign(providerConfig, config.env.defaultProvider.options);
       }
 
-      await provider.set({ keyPath, envName: opts.env, config: providerConfig }, value);
+      await provider.set({ keyPath, envName: opts.env, rootDir, config: providerConfig }, value);
       console.log(`Stored "${keyPath}" via ${providerName} provider for ${opts.env}`);
       return;
     }

--- a/src/providers/age.ts
+++ b/src/providers/age.ts
@@ -1,6 +1,6 @@
 import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { homedir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve, isAbsolute } from "node:path";
 import { Encrypter, Decrypter, generateIdentity, identityToRecipient } from "age-encryption";
 import type { Provider, ProviderContext } from "./types.js";
 
@@ -17,11 +17,14 @@ function secretFilePath(secretsDir: string, keyPath: string): string {
   return join(secretsDir, `${keyPathToFileName(keyPath)}.age`);
 }
 
-function expandTilde(filePath: string): string {
+function resolvePath(filePath: string, rootDir: string): string {
   if (filePath.startsWith("~/") || filePath === "~") {
     return join(homedir(), filePath.slice(1));
   }
-  return filePath;
+  if (isAbsolute(filePath)) {
+    return filePath;
+  }
+  return resolve(rootDir, filePath);
 }
 
 async function readIdentity(identityFile: string): Promise<string> {
@@ -43,7 +46,10 @@ export class AgeProvider implements Provider {
       throw new Error(`age provider requires "secretsDir" config for "${ctx.keyPath}"`);
     }
 
-    return { identityFile: expandTilde(identityFile), secretsDir: expandTilde(secretsDir) };
+    return {
+      identityFile: resolvePath(identityFile, ctx.rootDir),
+      secretsDir: resolvePath(secretsDir, ctx.rootDir)
+    };
   }
 
   async resolve(ctx: ProviderContext): Promise<string> {

--- a/src/providers/sops.ts
+++ b/src/providers/sops.ts
@@ -1,7 +1,7 @@
 import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { randomBytes, createCipheriv, createDecipheriv, createHmac } from "node:crypto";
 import { homedir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve, isAbsolute } from "node:path";
 import { Encrypter, Decrypter, identityToRecipient } from "age-encryption";
 import type { Provider, ProviderContext } from "./types.js";
 
@@ -24,11 +24,14 @@ interface SecretsFile {
   };
 }
 
-function expandTilde(filePath: string): string {
+function resolvePath(filePath: string, rootDir: string): string {
   if (filePath.startsWith("~/") || filePath === "~") {
     return join(homedir(), filePath.slice(1));
   }
-  return filePath;
+  if (isAbsolute(filePath)) {
+    return filePath;
+  }
+  return resolve(rootDir, filePath);
 }
 
 async function readIdentity(identityFile: string): Promise<string> {
@@ -118,8 +121,8 @@ export class SopsProvider implements Provider {
     }
 
     return {
-      identityFile: expandTilde(identityFile),
-      secretsFile: expandTilde(secretsFile)
+      identityFile: resolvePath(identityFile, ctx.rootDir),
+      secretsFile: resolvePath(secretsFile, ctx.rootDir)
     };
   }
 

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -1,6 +1,7 @@
 export interface ProviderContext {
   keyPath: string;
   envName: string;
+  rootDir: string;
   config: Record<string, unknown>;
 }
 

--- a/src/resolver/index.ts
+++ b/src/resolver/index.ts
@@ -8,14 +8,15 @@ export interface ResolveOptions {
   schema: KeyDefinition[];
   env: EnvConfig;
   envName: string;
+  rootDir: string;
   registry: ProviderRegistry;
 }
 
 export async function validate(options: ResolveOptions): Promise<ValidationError[]> {
-  const { schema, env, envName, registry } = options;
+  const { schema, env, envName, rootDir, registry } = options;
 
   const results = await Promise.allSettled(
-    schema.map((key) => resolveKey(key, env, envName, registry))
+    schema.map((key) => resolveKey(key, env, envName, rootDir, registry))
   );
 
   const errors: ValidationError[] = [];
@@ -35,11 +36,11 @@ export async function validate(options: ResolveOptions): Promise<ValidationError
 }
 
 export async function resolve(options: ResolveOptions): Promise<ResolvedKey[]> {
-  const { schema, env, envName, registry } = options;
+  const { schema, env, envName, rootDir, registry } = options;
 
   const entries = await Promise.all(
     schema.map(async (key) => {
-      const value = await resolveKey(key, env, envName, registry);
+      const value = await resolveKey(key, env, envName, rootDir, registry);
       return value !== undefined ? { path: key.path, value } : null;
     })
   );
@@ -51,6 +52,7 @@ async function resolveKey(
   key: KeyDefinition,
   env: EnvConfig,
   envName: string,
+  rootDir: string,
   registry: ProviderRegistry
 ): Promise<string | undefined> {
   const override = env.overrides[key.path];
@@ -63,7 +65,7 @@ async function resolveKey(
   // 2. Env file explicit override (provider-tagged)
   if (override !== undefined && isTaggedValue(override)) {
     try {
-      return await resolveViaProvider(key.path, override, env, envName, registry);
+      return await resolveViaProvider(key.path, override, env, envName, rootDir, registry);
     } catch (err) {
       if (key.optional) return undefined;
       throw err;
@@ -76,6 +78,7 @@ async function resolveKey(
     const ctx = {
       keyPath: key.path,
       envName,
+      rootDir,
       config: { ...env.defaultProvider.options }
     };
     try {
@@ -104,6 +107,7 @@ async function resolveViaProvider(
   tagged: TaggedValue,
   env: EnvConfig,
   envName: string,
+  rootDir: string,
   registry: ProviderRegistry
 ): Promise<string> {
   const provider = registry.get(tagged.tag);
@@ -112,6 +116,7 @@ async function resolveViaProvider(
   const ctx = {
     keyPath,
     envName,
+    rootDir,
     config: { ...baseConfig, ...tagged.config }
   };
   return provider.resolve(ctx);

--- a/test/integration/resolver.test.ts
+++ b/test/integration/resolver.test.ts
@@ -32,7 +32,7 @@ describe("full resolution flow", () => {
     const registry = new ProviderRegistry();
     registry.register(new PlaintextProvider());
 
-    const result = await resolve({ schema, env, envName: "test", registry });
+    const result = await resolve({ schema, env, envName: "test", rootDir: tmpDir, registry });
     expect(result).toEqual([
       { path: "db/host", value: "prod-db.example.com" },
       { path: "db/port", value: "5432" }
@@ -64,12 +64,13 @@ describe("full resolution flow", () => {
       {
         keyPath: "db/password",
         envName: "test",
+        rootDir: tmpDir,
         config: { identityFile, secretsDir }
       },
       "supersecret"
     );
 
-    const result = await resolve({ schema, env, envName: "test", registry });
+    const result = await resolve({ schema, env, envName: "test", rootDir: tmpDir, registry });
     expect(result).toEqual([
       { path: "db/host", value: "prod-db" },
       { path: "db/password", value: "supersecret" }
@@ -90,7 +91,7 @@ describe("full resolution flow", () => {
     const env = parseEnvironment("");
     const registry = new ProviderRegistry();
 
-    const errors = await validate({ schema, env, envName: "test", registry });
+    const errors = await validate({ schema, env, envName: "test", rootDir: tmpDir, registry });
     expect(errors).toHaveLength(2);
     expect(errors.map((e) => e.path)).toEqual(["db/password", "api/key"]);
   });
@@ -132,6 +133,7 @@ describe("full resolution flow", () => {
         schema,
         env,
         envName: "prod",
+        rootDir: tmpDir,
         registry
       });
 
@@ -162,6 +164,7 @@ describe("full resolution flow", () => {
         schema,
         env,
         envName: "staging",
+        rootDir: tmpDir,
         registry
       });
 
@@ -195,6 +198,7 @@ describe("full resolution flow", () => {
         schema,
         env,
         envName: "dev",
+        rootDir: tmpDir,
         registry
       });
 

--- a/test/unit/providers/age.test.ts
+++ b/test/unit/providers/age.test.ts
@@ -22,7 +22,7 @@ describe("AgeProvider", () => {
   });
 
   function ctx(keyPath: string) {
-    return { keyPath, envName: "test", config: { identityFile, secretsDir } };
+    return { keyPath, envName: "test", rootDir: tmpDir, config: { identityFile, secretsDir } };
   }
 
   it("roundtrips set + resolve", async () => {
@@ -63,6 +63,7 @@ describe("AgeProvider", () => {
       provider.resolve({
         keyPath: "k",
         envName: "test",
+        rootDir: tmpDir,
         config: { secretsDir }
       })
     ).rejects.toThrow("identityFile");
@@ -73,6 +74,7 @@ describe("AgeProvider", () => {
       provider.resolve({
         keyPath: "k",
         envName: "test",
+        rootDir: tmpDir,
         config: { identityFile }
       })
     ).rejects.toThrow("secretsDir");
@@ -100,6 +102,7 @@ describe("AgeProvider", () => {
     const tildeCtx = {
       keyPath: "tilde/test",
       envName: "test",
+      rootDir: tmpDir,
       config: { identityFile: relIdentity, secretsDir: relSecrets }
     };
 

--- a/test/unit/providers/gcp-sm.test.ts
+++ b/test/unit/providers/gcp-sm.test.ts
@@ -21,7 +21,7 @@ describe("GcpSmProvider", () => {
   });
 
   function ctx(keyPath: string, envName = "prod") {
-    return { keyPath, envName, config: { project: "my-proj" } };
+    return { keyPath, envName, rootDir: "/tmp", config: { project: "my-proj" } };
   }
 
   describe("secret ID derivation", () => {
@@ -70,9 +70,9 @@ describe("GcpSmProvider", () => {
     });
 
     it("throws when project is missing", async () => {
-      await expect(provider.resolve({ keyPath: "k", envName: "dev", config: {} })).rejects.toThrow(
-        'gcp provider requires "project"'
-      );
+      await expect(
+        provider.resolve({ keyPath: "k", envName: "dev", rootDir: "/tmp", config: {} })
+      ).rejects.toThrow('gcp provider requires "project"');
     });
   });
 

--- a/test/unit/providers/plaintext.test.ts
+++ b/test/unit/providers/plaintext.test.ts
@@ -8,26 +8,38 @@ describe("PlaintextProvider", () => {
     const result = await provider.resolve({
       envName: "test",
       keyPath: "db/host",
+      rootDir: "/tmp",
       config: { value: "localhost" }
     });
     expect(result).toBe("localhost");
   });
 
   it("throws when value is not a string", async () => {
-    await expect(provider.resolve({ keyPath: "db/host", config: {} })).rejects.toThrow(
-      "Plaintext provider requires a string value"
-    );
+    await expect(
+      provider.resolve({ keyPath: "db/host", envName: "test", rootDir: "/tmp", config: {} })
+    ).rejects.toThrow("Plaintext provider requires a string value");
   });
 
   it("validates string values", async () => {
-    expect(await provider.validate({ keyPath: "k", config: { value: "v" } })).toBe(true);
+    expect(
+      await provider.validate({
+        keyPath: "k",
+        envName: "test",
+        rootDir: "/tmp",
+        config: { value: "v" }
+      })
+    ).toBe(true);
   });
 
   it("rejects non-string values", async () => {
-    expect(await provider.validate({ keyPath: "k", config: {} })).toBe(false);
+    expect(
+      await provider.validate({ keyPath: "k", envName: "test", rootDir: "/tmp", config: {} })
+    ).toBe(false);
   });
 
   it("set is a no-op", async () => {
-    await expect(provider.set({ keyPath: "k", config: {} }, "v")).resolves.toBeUndefined();
+    await expect(
+      provider.set({ keyPath: "k", envName: "test", rootDir: "/tmp", config: {} }, "v")
+    ).resolves.toBeUndefined();
   });
 });

--- a/test/unit/providers/sops.test.ts
+++ b/test/unit/providers/sops.test.ts
@@ -23,7 +23,7 @@ describe("SopsProvider", () => {
   });
 
   function ctx(keyPath: string) {
-    return { keyPath, envName: "test", config: { identityFile, secretsFile } };
+    return { keyPath, envName: "test", rootDir: tmpDir, config: { identityFile, secretsFile } };
   }
 
   it("roundtrips set + resolve", async () => {
@@ -69,6 +69,7 @@ describe("SopsProvider", () => {
     const missingCtx = {
       keyPath: "k",
       envName: "test",
+      rootDir: tmpDir,
       config: { identityFile, secretsFile: join(tmpDir, "nope.json") }
     };
     expect(await provider.validate(missingCtx)).toBe(false);
@@ -90,6 +91,7 @@ describe("SopsProvider", () => {
       provider.resolve({
         keyPath: "k",
         envName: "test",
+        rootDir: tmpDir,
         config: { secretsFile }
       })
     ).rejects.toThrow("identityFile");
@@ -100,6 +102,7 @@ describe("SopsProvider", () => {
       provider.resolve({
         keyPath: "k",
         envName: "test",
+        rootDir: tmpDir,
         config: { identityFile }
       })
     ).rejects.toThrow("secretsFile");
@@ -150,6 +153,7 @@ describe("SopsProvider", () => {
     const tildeCtx = {
       keyPath: "tilde/test",
       envName: "test",
+      rootDir: tmpDir,
       config: { identityFile: relIdentity, secretsFile: relSecrets }
     };
 

--- a/test/unit/resolver/index.test.ts
+++ b/test/unit/resolver/index.test.ts
@@ -40,6 +40,7 @@ describe("resolve", () => {
     };
     const result = await resolve({
       envName: "test",
+      rootDir: "/tmp",
       schema: [configKey("db/host", "localhost")],
       env,
       registry: makeRegistry()
@@ -51,6 +52,7 @@ describe("resolve", () => {
     const env: EnvConfig = { overrides: {} };
     const result = await resolve({
       envName: "test",
+      rootDir: "/tmp",
       schema: [configKey("db/host", "localhost")],
       env,
       registry: makeRegistry()
@@ -67,6 +69,7 @@ describe("resolve", () => {
     };
     const result = await resolve({
       envName: "test",
+      rootDir: "/tmp",
       schema: [secretKey("db/password")],
       env,
       registry: makeRegistry(gcp)
@@ -74,6 +77,7 @@ describe("resolve", () => {
     expect(result).toEqual([{ path: "db/password", value: "gcp-secret" }]);
     expect(gcp.resolve).toHaveBeenCalledWith({
       envName: "test",
+      rootDir: "/tmp",
       keyPath: "db/password",
       config: { name: "db-pass" }
     });
@@ -89,12 +93,14 @@ describe("resolve", () => {
     };
     await resolve({
       envName: "test",
+      rootDir: "/tmp",
       schema: [secretKey("db/password")],
       env,
       registry: makeRegistry(gcp)
     });
     expect(gcp.resolve).toHaveBeenCalledWith({
       envName: "test",
+      rootDir: "/tmp",
       keyPath: "db/password",
       config: { project: "my-proj", name: "custom" }
     });
@@ -113,12 +119,14 @@ describe("resolve", () => {
     };
     await resolve({
       envName: "test",
+      rootDir: "/tmp",
       schema: [secretKey("db/password")],
       env,
       registry: makeRegistry(gcp)
     });
     expect(gcp.resolve).toHaveBeenCalledWith({
       envName: "test",
+      rootDir: "/tmp",
       keyPath: "db/password",
       config: { project: "override" }
     });
@@ -132,6 +140,7 @@ describe("resolve", () => {
     };
     const result = await resolve({
       envName: "test",
+      rootDir: "/tmp",
       schema: [secretKey("db/password")],
       env,
       registry: makeRegistry(gcp)
@@ -139,6 +148,7 @@ describe("resolve", () => {
     expect(result).toEqual([{ path: "db/password", value: "default-secret" }]);
     expect(gcp.resolve).toHaveBeenCalledWith({
       envName: "test",
+      rootDir: "/tmp",
       keyPath: "db/password",
       config: { project: "my-proj" }
     });
@@ -149,6 +159,7 @@ describe("resolve", () => {
     await expect(
       resolve({
         envName: "test",
+        rootDir: "/tmp",
         schema: [secretKey("db/password")],
         env,
         registry: makeRegistry()
@@ -160,6 +171,7 @@ describe("resolve", () => {
     const env: EnvConfig = { overrides: {} };
     const result = await resolve({
       envName: "test",
+      rootDir: "/tmp",
       schema: [secretKey("db/password", true)],
       env,
       registry: makeRegistry()
@@ -172,6 +184,7 @@ describe("resolve", () => {
     await expect(
       resolve({
         envName: "test",
+        rootDir: "/tmp",
         schema: [configKey("db/host")],
         env,
         registry: makeRegistry()
@@ -187,6 +200,7 @@ describe("resolve", () => {
     };
     const result = await resolve({
       envName: "test",
+      rootDir: "/tmp",
       schema: [
         configKey("db/host", "localhost"),
         secretKey("db/password"),
@@ -208,6 +222,7 @@ describe("resolve", () => {
     };
     const result = await resolve({
       envName: "test",
+      rootDir: "/tmp",
       schema: [configKey("db/port", "5432")],
       env,
       registry: makeRegistry()
@@ -220,6 +235,7 @@ describe("resolve", () => {
     await expect(
       resolve({
         envName: "test",
+        rootDir: "/tmp",
         schema: [
           {
             path: "key",
@@ -244,12 +260,14 @@ describe("resolve", () => {
     };
     await resolve({
       envName: "test",
+      rootDir: "/tmp",
       schema: [secretKey("key")],
       env,
       registry: makeRegistry(aws)
     });
     expect(aws.resolve).toHaveBeenCalledWith({
       envName: "test",
+      rootDir: "/tmp",
       keyPath: "key",
       config: { region: "us-east-1" }
     });
@@ -261,6 +279,7 @@ describe("resolve", () => {
     };
     const result = await resolve({
       envName: "test",
+      rootDir: "/tmp",
       schema: [secretKey("db/password", true)],
       env,
       registry: makeRegistry()
@@ -279,6 +298,7 @@ describe("resolve", () => {
     };
     const result = await resolve({
       envName: "test",
+      rootDir: "/tmp",
       schema: [secretKey("pulumi/config-passphrase", true)],
       env,
       registry: makeRegistry(gcp)
@@ -298,6 +318,7 @@ describe("resolve", () => {
     await expect(
       resolve({
         envName: "test",
+        rootDir: "/tmp",
         schema: [secretKey("db/password")],
         env,
         registry: makeRegistry(gcp)
@@ -317,6 +338,7 @@ describe("resolve", () => {
     };
     const result = await resolve({
       envName: "test",
+      rootDir: "/tmp",
       schema: [secretKey("db/password", true)],
       env,
       registry: makeRegistry(gcp)
@@ -333,6 +355,7 @@ describe("resolve", () => {
     };
     const result = await resolve({
       envName: "test",
+      rootDir: "/tmp",
       schema: [configKey("app/name", "default-app")],
       env,
       registry: makeRegistry(gcp)
@@ -348,6 +371,7 @@ describe("validate", () => {
     };
     const errors = await validate({
       envName: "test",
+      rootDir: "/tmp",
       schema: [configKey("db/host", "default")],
       env,
       registry: makeRegistry()
@@ -359,6 +383,7 @@ describe("validate", () => {
     const env: EnvConfig = { overrides: {} };
     const errors = await validate({
       envName: "test",
+      rootDir: "/tmp",
       schema: [secretKey("db/password"), secretKey("api/key"), configKey("db/host", "localhost")],
       env,
       registry: makeRegistry()
@@ -380,6 +405,7 @@ describe("validate", () => {
     const env: EnvConfig = { overrides: {} };
     const errors = await validate({
       envName: "test",
+      rootDir: "/tmp",
       schema: [secretKey("optional/key", true)],
       env,
       registry: makeRegistry()
@@ -397,6 +423,7 @@ describe("validate", () => {
     };
     const errors = await validate({
       envName: "test",
+      rootDir: "/tmp",
       schema: [secretKey("db/password")],
       env,
       registry: makeRegistry(gcp)


### PR DESCRIPTION
## Summary
- Provider configuration paths (`identityFile`, `secretsFile`, `secretsDir`) were resolved relative to the current working directory, causing failures when running keyshelf from a subdirectory
- Added `rootDir` to `ProviderContext` and `ResolveOptions`, and updated `age` and `sops` providers to resolve relative paths against the project root (where `keyshelf.yaml` is located)
- Absolute paths and `~`-prefixed paths continue to work as before
- Updated README with path resolution documentation and programmatic API example

## Test plan
- [x] All 165 unit and integration tests pass
- [x] All 32 e2e tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)