### PR TITLE
feat: support template syntax in app mapping files

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,14 @@ DB_PORT=db/port
 DB_PASSWORD=db/password
 API_KEY=api/key
 API_URL=api/url
+
+# Template syntax — combine multiple keys into one env var
+DB_URL=postgres://${db/host}:${db/port}/mydb
 ```
 
 Each app declares exactly which keys it consumes and what env var names to use. The `.env.keyshelf` file is required — it controls which keys are injected into your app.
+
+Values can be either a direct key path (`db/host`) or a template with `${key/path}` references that get interpolated at resolve time. Templates can mix literal text with any number of key references.
 
 ### 4. Run your app
 
@@ -292,7 +297,15 @@ DB_HOST=db/host
 DB_PORT=db/port
 DB_PASSWORD=db/password
 API_KEY=api/key
+
+# Template syntax — interpolate multiple keys into one value
+DB_URL=postgres://${db/host}:${db/port}/mydb
+CLIENT_IDS=${google/web-client-id},${google/ios-client-id}
 ```
+
+Each line is either a **direct mapping** (`ENV_VAR=key/path`) or a **template** (`ENV_VAR=...${key/path}...`). Templates replace each `${key/path}` with its resolved value, allowing you to compose connection strings, comma-separated lists, or any other derived value.
+
+> **Note:** Template mappings are skipped during `keyshelf import` because a composite value cannot be decomposed back into individual keys.
 
 ## What to commit
 

--- a/src/cli/import.ts
+++ b/src/cli/import.ts
@@ -3,7 +3,7 @@ import { readFile, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import yaml from "js-yaml";
 import { findRootDir, loadConfig } from "../config/loader.js";
-import { parseAppMapping } from "../config/app-mapping.js";
+import { parseAppMapping, isTemplateMapping } from "../config/app-mapping.js";
 import { createDefaultRegistry } from "../providers/setup.js";
 import { KEYSHELF_SCHEMA } from "../config/yaml-tags.js";
 import { setNestedValue } from "../utils/paths.js";
@@ -50,8 +50,12 @@ export const importCommand = new Command("import")
     }
     const appMapping = parseAppMapping(mappingContent);
 
-    // Build reverse map: ENV_VAR -> key/path
-    const reverseMap = new Map(appMapping.map((m) => [m.envVar, m.keyPath]));
+    // Build reverse map: ENV_VAR -> key/path (skip template mappings)
+    const reverseMap = new Map(
+      appMapping
+        .filter((m) => !isTemplateMapping(m))
+        .map((m) => [m.envVar, (m as { keyPath: string }).keyPath])
+    );
 
     // Parse .env file
     const envFileContent = await readFile(opts.file, "utf-8");

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -4,6 +4,7 @@ import { loadConfig } from "../config/loader.js";
 import { resolve, validate } from "../resolver/index.js";
 import { createDefaultRegistry } from "../providers/setup.js";
 import { GcpAuthError } from "../providers/gcp-sm.js";
+import { isTemplateMapping, resolveTemplate } from "../config/app-mapping.js";
 
 export const runCommand = new Command("run")
   .description("Resolve secrets and run a command with env vars injected")
@@ -52,13 +53,23 @@ export const runCommand = new Command("run")
     const resolvedMap = new Map(resolved.map((r) => [r.path, r.value]));
 
     for (const mapping of config.appMapping) {
-      const value = resolvedMap.get(mapping.keyPath);
-      if (value !== undefined) {
+      if (isTemplateMapping(mapping)) {
+        const { value, missing } = resolveTemplate(mapping.template, resolvedMap);
+        for (const m of missing) {
+          console.error(
+            `warning: ${mapping.envVar} references "${m}" which is not defined in schema`
+          );
+        }
         envVars[mapping.envVar] = value;
       } else {
-        console.error(
-          `warning: ${mapping.envVar} maps to "${mapping.keyPath}" which is not defined in schema`
-        );
+        const value = resolvedMap.get(mapping.keyPath);
+        if (value !== undefined) {
+          envVars[mapping.envVar] = value;
+        } else {
+          console.error(
+            `warning: ${mapping.envVar} maps to "${mapping.keyPath}" which is not defined in schema`
+          );
+        }
       }
     }
 

--- a/src/config/app-mapping.ts
+++ b/src/config/app-mapping.ts
@@ -1,6 +1,37 @@
-export interface AppMapping {
+export interface DirectMapping {
   envVar: string;
   keyPath: string;
+}
+
+export interface TemplateMapping {
+  envVar: string;
+  template: string;
+  keyPaths: string[];
+}
+
+export type AppMapping = DirectMapping | TemplateMapping;
+
+const TEMPLATE_RE = /\$\{([^}]+)\}/g;
+
+export function isTemplateMapping(m: AppMapping): m is TemplateMapping {
+  return "template" in m;
+}
+
+export function resolveTemplate(
+  template: string,
+  resolvedMap: Map<string, string>
+): { value: string; missing: string[] } {
+  const missing: string[] = [];
+  const value = template.replace(TEMPLATE_RE, (_, keyPath: string) => {
+    const trimmed = keyPath.trim();
+    const resolved = resolvedMap.get(trimmed);
+    if (resolved === undefined) {
+      missing.push(trimmed);
+      return "";
+    }
+    return resolved;
+  });
+  return { value, missing };
 }
 
 export function parseAppMapping(content: string): AppMapping[] {
@@ -14,10 +45,16 @@ export function parseAppMapping(content: string): AppMapping[] {
     if (eqIndex === -1) continue;
 
     const envVar = line.slice(0, eqIndex).trim();
-    const keyPath = line.slice(eqIndex + 1).trim();
+    const value = line.slice(eqIndex + 1).trim();
 
-    if (envVar && keyPath) {
-      mappings.push({ envVar, keyPath });
+    if (!envVar || !value) continue;
+
+    if (TEMPLATE_RE.test(value)) {
+      TEMPLATE_RE.lastIndex = 0;
+      const keyPaths = [...value.matchAll(TEMPLATE_RE)].map((m) => m[1].trim());
+      mappings.push({ envVar, template: value, keyPaths });
+    } else {
+      mappings.push({ envVar, keyPath: value });
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,14 @@ export {
   type EnvConfig,
   type ProviderConfig
 } from "./config/environment.js";
-export { parseAppMapping, type AppMapping } from "./config/app-mapping.js";
+export {
+  parseAppMapping,
+  isTemplateMapping,
+  resolveTemplate,
+  type AppMapping,
+  type DirectMapping,
+  type TemplateMapping
+} from "./config/app-mapping.js";
 export { loadConfig, findRootDir, type LoadedConfig } from "./config/loader.js";
 export { KEYSHELF_SCHEMA, isTaggedValue, type TaggedValue } from "./config/yaml-tags.js";
 

--- a/test/e2e/run.test.ts
+++ b/test/e2e/run.test.ts
@@ -173,6 +173,41 @@ describe("keyshelf run", () => {
     );
     expect(result.trim()).toBe("dev-db");
   });
+
+  it("resolves template mappings with ${} syntax", async () => {
+    await writeFile(join(root, ".env.keyshelf"), "DB_URL=postgres://${db/host}:${db/port}/mydb\n");
+
+    const result = execFileSync(
+      TSX,
+      [CLI, "run", "--env", "dev", "--", "node", "-e", "console.log(process.env.DB_URL)"],
+      { cwd: root, encoding: "utf-8" }
+    );
+    expect(result.trim()).toBe("postgres://dev-db:5432/mydb");
+  });
+
+  it("mixes direct and template mappings", async () => {
+    await writeFile(
+      join(root, ".env.keyshelf"),
+      ["DB_HOST=db/host", "DB_URL=postgres://${db/host}:${db/port}/mydb"].join("\n")
+    );
+
+    const result = execFileSync(
+      TSX,
+      [
+        CLI,
+        "run",
+        "--env",
+        "dev",
+        "--",
+        "node",
+        "-e",
+        "console.log(JSON.stringify({host: process.env.DB_HOST, url: process.env.DB_URL}))"
+      ],
+      { cwd: root, encoding: "utf-8" }
+    );
+    const parsed = JSON.parse(result.trim());
+    expect(parsed).toEqual({ host: "dev-db", url: "postgres://dev-db:5432/mydb" });
+  });
 });
 
 describe("keyshelf run (age)", () => {

--- a/test/unit/config/app-mapping.test.ts
+++ b/test/unit/config/app-mapping.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseAppMapping } from "../../../src/config/app-mapping.js";
+import { parseAppMapping, resolveTemplate } from "../../../src/config/app-mapping.js";
 
 describe("parseAppMapping", () => {
   it("parses simple mappings", () => {
@@ -47,5 +47,76 @@ describe("parseAppMapping", () => {
 
   it("returns empty array for empty input", () => {
     expect(parseAppMapping("")).toEqual([]);
+  });
+
+  it("parses template mappings with ${} syntax", () => {
+    const content = "CLIENT_IDS=${google/web-client-id},${google/ios-client-id}";
+    expect(parseAppMapping(content)).toEqual([
+      {
+        envVar: "CLIENT_IDS",
+        template: "${google/web-client-id},${google/ios-client-id}",
+        keyPaths: ["google/web-client-id", "google/ios-client-id"]
+      }
+    ]);
+  });
+
+  it("parses single template reference", () => {
+    const content = "DB_URL=postgres://${db/host}:${db/port}/mydb";
+    expect(parseAppMapping(content)).toEqual([
+      {
+        envVar: "DB_URL",
+        template: "postgres://${db/host}:${db/port}/mydb",
+        keyPaths: ["db/host", "db/port"]
+      }
+    ]);
+  });
+
+  it("mixes direct and template mappings", () => {
+    const content = "DB_HOST=db/host\nDB_URL=postgres://${db/host}:${db/port}/mydb";
+    const result = parseAppMapping(content);
+    expect(result).toEqual([
+      { envVar: "DB_HOST", keyPath: "db/host" },
+      {
+        envVar: "DB_URL",
+        template: "postgres://${db/host}:${db/port}/mydb",
+        keyPaths: ["db/host", "db/port"]
+      }
+    ]);
+  });
+
+  it("trims whitespace inside template references", () => {
+    const content = "VAR=${ db/host }";
+    expect(parseAppMapping(content)).toEqual([
+      { envVar: "VAR", template: "${ db/host }", keyPaths: ["db/host"] }
+    ]);
+  });
+});
+
+describe("resolveTemplate", () => {
+  it("resolves all references in a template", () => {
+    const map = new Map([
+      ["db/host", "localhost"],
+      ["db/port", "5432"]
+    ]);
+    const { value, missing } = resolveTemplate("postgres://${db/host}:${db/port}/mydb", map);
+    expect(value).toBe("postgres://localhost:5432/mydb");
+    expect(missing).toEqual([]);
+  });
+
+  it("reports missing keys and substitutes empty string", () => {
+    const map = new Map([["db/host", "localhost"]]);
+    const { value, missing } = resolveTemplate("${db/host}:${db/port}", map);
+    expect(value).toBe("localhost:");
+    expect(missing).toEqual(["db/port"]);
+  });
+
+  it("handles template with no literal text", () => {
+    const map = new Map([
+      ["a", "1"],
+      ["b", "2"]
+    ]);
+    const { value, missing } = resolveTemplate("${a}${b}", map);
+    expect(value).toBe("12");
+    expect(missing).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- Adds `${key/path}` interpolation syntax to `.env.keyshelf` mapping files, allowing multiple keys to be concatenated into a single env var
- Fully backward compatible: plain `KEY=key/path` mappings work as before; only values containing `${...}` are treated as templates
- Template mappings are skipped during `keyshelf import` (can't decompose a composite value back into individual secrets)

## Test plan
- [x] Unit tests for template parsing and `resolveTemplate` helper
- [x] E2e tests for `keyshelf run` with template and mixed mappings
- [x] All 151 existing unit tests pass
- [x] All existing e2e tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)