### PR TITLE
chore(action): pin keyshelf to ^4.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5276,7 +5276,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "keyshelf": "*"
+        "keyshelf": "^4.4.0"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",
@@ -5289,7 +5289,7 @@
     },
     "packages/cli": {
       "name": "keyshelf",
-      "version": "4.3.0",
+      "version": "4.4.0",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/secret-manager": "^6.1.1",

--- a/packages/action/package.json
+++ b/packages/action/package.json
@@ -19,7 +19,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "keyshelf": "*"
+    "keyshelf": "^4.4.0"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",


### PR DESCRIPTION
## Summary

- Pin `@keyshelf/action`'s `keyshelf` dependency from `*` → `^4.4.0`. `4.4.0` is the first published version with `ls --reveal --format json`, which the action's `emit-env.mjs` depends on.
- Without this, an external consumer's `npm install` inside the action's directory pulls whatever's currently latest on npm — fine today, but it would silently regress if a future incompatible major were published.

## Test plan

- [x] `npm install` resolves keyshelf to a `4.4.x` (verified locally)
- [x] `npm run lint`, `format:check`, `typecheck`, `build`, `test` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)