### PR TITLE
docs(action): use real component tag in README usage example

### DIFF
--- a/packages/action/README.md
+++ b/packages/action/README.md
@@ -5,7 +5,7 @@ GitHub Action that resolves [keyshelf](https://github.com/pantoninho/keyshelf)-m
 ## Usage
 
 ```yaml
-- uses: pantoninho/keyshelf/packages/action@v1
+- uses: pantoninho/keyshelf/packages/action@keyshelf-action-v0.2.0
   with:
     env: staging
     identity: ${{ secrets.KEYSHELF_STAGING_IDENTITY }}


### PR DESCRIPTION
## Summary
- README's usage example referenced `@v1`, but no floating major-version tag exists — release-please tags the action as `keyshelf-action-v<x.y.z>` (component-prefixed via `include-component-in-tag`)
- Updated the snippet to `@keyshelf-action-v0.2.0` so users get a working ref

## Ordering note
Merge **after** #67 lands, since that's what creates the `keyshelf-action-v0.2.0` tag this README now points to.

## Test plan
- [ ] Visual check of `packages/action/README.md` snippet

🤖 Generated with [Claude Code](https://claude.com/claude-code)