### PR TITLE
fix(action): always install action deps (closes #70)

### DIFF
--- a/packages/action/action.yml
+++ b/packages/action/action.yml
@@ -39,12 +39,7 @@ runs:
     - name: Install action dependencies
       shell: bash
       working-directory: ${{ github.action_path }}
-      run: |
-        if node -e "require.resolve('keyshelf/bin')" 2>/dev/null; then
-          echo "keyshelf already resolvable from $(pwd); skipping install"
-        else
-          npm install --omit=dev --no-audit --no-fund --silent
-        fi
+      run: npm install --omit=dev --no-audit --no-fund --silent
 
     - name: Write identity
       if: inputs.identity != ''


### PR DESCRIPTION
## Summary
- Drop the `require.resolve('keyshelf/bin')` skip-install branch in the bootstrap step. The check ran from `${{ github.action_path }}`, but Node module resolution could still find a consumer's `keyshelf` install up the directory tree, causing the install to be skipped while `write-identity.mjs` (resolving from `_actions/...`) had no `node_modules` to import from.
- Always run `npm install --omit=dev` in the action's directory. ~3-5s cost per run, but correctness over micro-optimization.

Fixes #70.

## Test plan
- [ ] Consumer repo with `keyshelf` installed at root invokes the action — `write-identity.mjs` resolves `keyshelf` successfully.
- [ ] Consumer repo without `keyshelf` installed still works (regression check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)