### PR TITLE
chore(release-please): use a single combined release PR

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
   "include-component-in-tag": true,
-  "separate-pull-requests": true,
+  "separate-pull-requests": false,
   "packages": {
     "packages/cli": {
       "package-name": "keyshelf"


### PR DESCRIPTION
## Summary
- Flip `separate-pull-requests` to `false` in `release-please-config.json` so CLI + action releases ship in one combined PR.
- Two release PRs both edit `.release-please-manifest.json`, so whichever merges second conflicts every time (e.g. #76 had to be manually rebased after #75 merged). Bundling them removes that recurring toil.
- The action depends on the CLI via npm, so coupling the releases also matches reality — the action shouldn't tag a new version against an unreleased CLI.

## Test plan
- [ ] Merge #76 first (action 0.3.0) so we land on a clean manifest.
- [ ] After this PR merges, on the next conventional commit to either package, confirm release-please opens **one** combined release PR rather than two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)