### PR TITLE
feat(v5): phase 0

### DIFF
--- a/docs/v5/spec.md
+++ b/docs/v5/spec.md
@@ -1,0 +1,367 @@
+# Keyshelf v5 — API Spec
+
+Status: **locked** (Phase 0). Implementation phases reference this document as
+the source of truth.
+
+---
+
+## Configuration entry point
+
+A keyshelf project has exactly one `keyshelf.config.ts` at the repo root. It
+must default-export the result of `defineConfig({ ... })`.
+
+```ts
+import { defineConfig } from "keyshelf/config";
+
+export default defineConfig({
+  envs: ["dev", "staging", "production"],
+  groups: ["app", "ci"],
+  keys: {
+    /* ... */
+  }
+});
+```
+
+The `.env.keyshelf` file (app-name → key-path mapping) is unchanged from v4.
+
+---
+
+## `defineConfig` input
+
+```ts
+defineConfig({
+  envs:   string[];          // required, non-empty, unique
+  groups?: string[];          // optional, unique; if omitted, no group filtering
+  keys:   KeyTree;           // required, non-empty
+})
+```
+
+- `envs` enumerates every environment name the config recognises. Any
+  `values` map elsewhere in the config may only use names from this list. There
+  is no implicit / dynamic env support in v5.
+- `groups` enumerates every group name. Any `group:` field in a key record
+  must reference a name from this list. If `groups` is omitted, every key is
+  effectively groupless and `--group` filtering is rejected at runtime.
+- `keys` is a `KeyTree` (see below).
+
+`defineConfig` returns an opaque `KeyshelfConfig` value (a branded structure
+the loader recognises). The return type carries inferred env names, group
+names, and the flattened key-path union, used to type-check `values` keys and
+template references.
+
+---
+
+## `KeyTree` shape
+
+A `KeyTree` is an object literal whose entries are one of:
+
+| Form                                        | Interpretation                                  |
+| ------------------------------------------- | ----------------------------------------------- |
+| Bare scalar (`string \| number \| boolean`) | Sugar for `config({ value: <scalar> })`         |
+| `config({ ... })`                           | Explicit config record (a leaf)                 |
+| `secret({ ... })`                           | Explicit secret record (a leaf)                 |
+| Object literal `{ ... }`                    | **Namespace** — recurse into a nested `KeyTree` |
+
+Disambiguation rule: **factory calls are leaves; bare object literals are
+namespaces.** This is enforced at the type level via the `__kind` discriminant
+on factory return values, and at runtime by the validator.
+
+Keys are addressed by `/`-separated paths derived from nesting:
+`db: { password: secret({...}) }` flattens to `db/password`.
+
+### String paths as escape hatch
+
+A property name may itself be a `/`-separated path. This is the only way to
+declare a leaf at a path that would otherwise have to be a namespace:
+
+```ts
+keys: {
+  'db/password': secret({ /* ... */ }),  // path: db/password
+  db: {
+    host: 'localhost',                    // path: db/host
+  },
+}
+```
+
+Validation rejects any pair of declarations that flatten to the same path.
+
+---
+
+## `config(...)`
+
+```ts
+config({
+  group?: string;                                    // must be in groups[]
+  optional?: boolean;                                // default false
+  description?: string;                              // free-form
+  value?: ConfigScalar | TemplateString;             // envless binding
+  default?: ConfigScalar | TemplateString;           // alias for `value`
+  values?: Partial<Record<EnvName, ConfigScalar | TemplateString>>;
+})
+```
+
+- `ConfigScalar` is `string | number | boolean`.
+- `TemplateString` is a string containing `${path/to/key}` references; see
+  _Template interpolation_ below.
+- `value` and `default` are aliases. **Setting both is a validation error.**
+  The two names exist purely for legibility:
+  - `value:` reads naturally for envless records (`token: config({ value: '...' })`)
+  - `default:` reads naturally when paired with `values:` (the env-specific
+    overrides are exceptions to the default).
+- `values` keys are the env names where this record has an override. They are
+  not required to cover every env in `envs`; missing envs fall back to
+  `value` / `default`.
+
+### Bare scalar sugar
+
+```ts
+log: {
+  level: "info";
+}
+// equivalent to
+log: {
+  level: config({ value: "info" });
+}
+```
+
+Bare scalars cannot carry `group`, `optional`, or `values` — use the explicit
+factory if any of those apply.
+
+---
+
+## `secret(...)`
+
+```ts
+secret({
+  group?: string;                                    // must be in groups[]
+  optional?: boolean;                                // default false
+  description?: string;
+  value?: ProviderRef;                               // envless binding
+  default?: ProviderRef;                             // alias for `value`
+  values?: Partial<Record<EnvName, ProviderRef>>;
+})
+```
+
+Same `value` / `default` / `values` semantics as `config`, with the
+following differences:
+
+- All bindings (`value`, `default`, each entry in `values`) **must** be a
+  `ProviderRef` — the result of a provider factory call. Plaintext secrets are
+  not supported.
+- A `secret` must have _some_ binding that can resolve in the active env.
+  Concretely: at least one of `value`/`default`, or a matching entry in
+  `values`. The validator enforces that `secret(...)` declarations are not
+  empty; the resolver enforces presence per active env.
+- `optional: true` skips the key (returns `undefined`) when no binding applies
+  for the active env, or when the bound provider raises a not-found error.
+  Provider-side errors that are _not_ not-found (auth, network, etc.) still
+  propagate even for optional secrets.
+
+---
+
+## Provider factories
+
+Provider factories are imported from `keyshelf/config` and return a
+`ProviderRef` carrying a `__kind: 'provider:<name>'` discriminant.
+
+### `age(options)`
+
+```ts
+age({
+  identityFile?: string;   // path, used for decryption
+  recipient?: string;      // age public key, used for `keyshelf set` encryption
+})
+```
+
+At least one of `identityFile` or `recipient` is required (validator). The
+encrypted payload itself is stored alongside the config in the provider's
+own conventions, not inline.
+
+### `gcp(options)`
+
+```ts
+gcp({
+  project: string;
+  secret?: string;         // explicit Secret Manager name; defaults to a
+                           // path-derived convention
+  version?: string;        // defaults to 'latest'
+})
+```
+
+### `sops(options)`
+
+```ts
+sops({
+  file: string;            // path, relative to repo root
+  path?: string;           // dot/jsonpath into the decrypted document
+})
+```
+
+Phase 4 ports these providers to the new `ProviderContext`; option shapes
+above are pinned.
+
+---
+
+## Resolution order
+
+For each declared key, given an active `envName`:
+
+1. If `values[envName]` is set → use that binding.
+2. Else if `value` or `default` is set → use that binding.
+3. Else if the key is `optional` → skip (resolver returns `undefined`).
+4. Else → resolver raises a required-key error.
+
+For a binding that is a `ProviderRef`, the resolver invokes the provider with
+a `ProviderContext` (Phase 4 shape) and uses the returned string.
+
+For a binding that is a `ConfigScalar`, the value is used as-is (numbers and
+booleans are stringified at the env-mapping boundary, not in the config
+representation).
+
+For a binding that is a `TemplateString`, see below.
+
+---
+
+## Template interpolation
+
+A config binding may contain `${path/to/key}` references. The resolver
+substitutes each reference with the resolved value of the named key. Rules:
+
+- References resolve **after** group/filter selection has run. Behavior when
+  a referenced key is filtered out is defined under
+  _Decision: template references under group filtering_ below.
+- Cyclic references are a validation error.
+- Templates may reference both `config` and `secret` keys. Referencing a
+  secret key from a template-rendered output is allowed but should be used
+  carefully — if the template is written to `.env.keyshelf` output the secret
+  ends up in the rendered env var.
+- Escaping: `$${...}` produces a literal `${...}`.
+
+Templates are only valid inside `config(...)` bindings, not inside
+`secret(...)` bindings.
+
+---
+
+## Validation rules (for Phase 2)
+
+The Phase 2 validator must enforce, in addition to the type-level constraints:
+
+1. `value` and `default` mutually exclusive on any single record.
+2. Every key in any `values` map must be in the top-level `envs` list.
+3. Every `group` field must be in the top-level `groups` list (or the
+   declaration is rejected if `groups` is absent).
+4. `secret({...})` must have at least one binding (`value` / `default` /
+   non-empty `values`).
+5. Duplicate flattened paths are rejected (covers both string-path /
+   nested mixing and case-insensitive duplicates on case-insensitive file
+   systems — `db/Host` and `db/host` are duplicates).
+6. Path segments must match `/^[A-Za-z_][A-Za-z0-9_-]*$/`. The `/` separator
+   is reserved.
+7. Template references in `config` bindings must resolve to declared key
+   paths and must not form cycles.
+8. `.env.keyshelf` references must point to declared key paths
+   (loader-time validation against the flattened key set).
+
+---
+
+## Decisions (open questions from issue #78)
+
+### Decision: reserved namespace conflict edge case
+
+**Question.** What does this mean?
+
+```ts
+keys: {
+  foo: { value: 'bar' },
+}
+```
+
+— is `foo` a leaf record with field `value: 'bar'`, or a namespace with a
+sub-key `foo/value`?
+
+**Decision.** It is a **namespace**. Object literals are _always_ namespaces.
+A leaf record requires an explicit `config(...)` or `secret(...)` factory
+call. Therefore the example above declares a key at path `foo/value` whose
+default is the string `'bar'`.
+
+To declare a leaf at path `foo`, use:
+
+```ts
+keys: {
+  foo: 'bar',                   // bare scalar, sugar for config({ value: 'bar' })
+  // or
+  foo: config({ value: 'bar' }),
+}
+```
+
+To declare a leaf at path `foo` _and_ sub-keys under `foo/*`, use the
+string-path escape hatch for the leaf:
+
+```ts
+keys: {
+  foo: {
+    sub: 'x',                   // foo/sub
+  },
+  'foo/value': 'bar',           // foo/value (the leaf)
+}
+```
+
+**Why this rule.** It removes ambiguity entirely: a property's _shape_
+(literal object vs factory return) is the disambiguator, never the property's
+_name_. The validator can check the rule by inspecting `__kind` without
+reasoning about the schema of common namespace names.
+
+**How to apply.** Phase 2 validator surfaces a clear error message when a
+nested object accidentally contains keys that look like factory options
+(e.g. `{ value: ..., values: { ... } }`) — suggest the explicit factory.
+
+### Decision: `.env.keyshelf` template behavior under group filtering
+
+**Question.** When `--group app` is active and a `.env.keyshelf` template
+references a key that belongs to a different group (e.g. `${ci/token}`), what
+happens?
+
+Options considered:
+
+- **error** — fail the whole render
+- **skip** — omit the resulting env var entirely
+- **empty** — set the env var to an empty string
+
+**Decision.** **Skip the env var, with a stderr warning.** If any key
+referenced by an env-var template is filtered out (by `--group`, `--filter`,
+or because it is optional and unresolved), the entire env var is omitted from
+the rendered output, and a warning of the form
+
+```
+keyshelf: skipping ENV_VAR — referenced key 'ci/token' is filtered out
+```
+
+is written to stderr.
+
+**Why this rule.** Group filtering is a deliberate "I want a partial render"
+operation; refusing to render anything because an unrelated group's keys are
+absent defeats the point. Empty-string fallback is dangerous (silent bad
+input to consumer apps). Skip-with-warning preserves auditability without
+forcing the user to maintain group-segmented `.env.keyshelf` files. The
+stderr warning is the audit trail.
+
+**How to apply.** Phase 3 resolver returns a per-env-var status. Phase 5
+`run` and `ls` commands consume that status to decide whether to emit the
+var. Tests cover: (a) all keys filtered in → var renders; (b) any referenced
+key filtered out → var skipped + warning; (c) optional unresolved key →
+var skipped + warning. Same behavior for `--filter` and unset optional keys
+— the rule is "if any referenced key is unavailable in the active selection,
+skip the var."
+
+---
+
+## Out of scope (restated for clarity)
+
+- Dynamic / undeclared env names (no `--env preview-pr-123` until the user
+  declares it in `envs`).
+- TS-format `.env.keyshelf`. Stay with the v4 format.
+- Variation axes beyond env (region, tenant, …). The `values` naming was
+  chosen to leave the door open, but no implementation work happens in v5.
+- Plaintext secrets. `secret(...)` always requires a `ProviderRef`. If you
+  truly want a plaintext "secret-shaped" value, use `config(...)` and accept
+  that it will be treated as non-sensitive by the tooling.

--- a/docs/v5/spec.md
+++ b/docs/v5/spec.md
@@ -69,21 +69,28 @@ on factory return values, and at runtime by the validator.
 Keys are addressed by `/`-separated paths derived from nesting:
 `db: { password: secret({...}) }` flattens to `db/password`.
 
-### String paths as escape hatch
+### String paths
 
-A property name may itself be a `/`-separated path. This is the only way to
-declare a leaf at a path that would otherwise have to be a namespace:
+A property name may itself be a `/`-separated path. This is purely a
+flatten-the-nesting convenience for short configs:
 
 ```ts
 keys: {
-  'db/password': secret({ /* ... */ }),  // path: db/password
+  'db/host': 'localhost',
+  'db/port': 5432,
+}
+// equivalent to
+keys: {
   db: {
-    host: 'localhost',                    // path: db/host
+    host: 'localhost',
+    port: 5432,
   },
 }
 ```
 
 Validation rejects any pair of declarations that flatten to the same path.
+A path is either a leaf or a namespace, never both — declaring `foo: 'bar'`
+and `foo: { x: 'y' }` at the same level is a duplicate-path error.
 
 ---
 
@@ -294,17 +301,9 @@ keys: {
 }
 ```
 
-To declare a leaf at path `foo` _and_ sub-keys under `foo/*`, use the
-string-path escape hatch for the leaf:
-
-```ts
-keys: {
-  foo: {
-    sub: 'x',                   // foo/sub
-  },
-  'foo/value': 'bar',           // foo/value (the leaf)
-}
-```
+A path is either a leaf or a namespace, never both. Declaring `foo` as a
+scalar/factory at the same level as `foo: { ... }` is a duplicate-path
+error — there is no shape that supports both simultaneously, by design.
 
 **Why this rule.** It removes ambiguity entirely: a property's _shape_
 (literal object vs factory return) is the disambiguator, never the property's

--- a/docs/v5/spec.md
+++ b/docs/v5/spec.md
@@ -259,14 +259,17 @@ The Phase 2 validator must enforce, in addition to the type-level constraints:
    declaration is rejected if `groups` is absent).
 4. `secret({...})` must have at least one binding (`value` / `default` /
    non-empty `values`).
-5. Duplicate flattened paths are rejected (covers both string-path /
-   nested mixing and case-insensitive duplicates on case-insensitive file
-   systems — `db/Host` and `db/host` are duplicates).
-6. Path segments must match `/^[A-Za-z_][A-Za-z0-9_-]*$/`. The `/` separator
+5. Duplicate flattened paths are rejected (covers string-path / nested
+   mixing — e.g. `foo: { x: 'a' }` and `'foo/x': 'b'` declared at the same
+   level).
+6. A leaf path may not be a prefix of any other leaf path. Declaring `foo`
+   as a leaf and `'foo/x'` as another leaf in the same config is rejected:
+   any given path is either a leaf or a namespace prefix, never both.
+7. Path segments must match `/^[A-Za-z_][A-Za-z0-9_-]*$/`. The `/` separator
    is reserved.
-7. Template references in `config` bindings must resolve to declared key
+8. Template references in `config` bindings must resolve to declared key
    paths and must not form cycles.
-8. `.env.keyshelf` references must point to declared key paths
+9. `.env.keyshelf` references must point to declared key paths
    (loader-time validation against the flattened key set).
 
 ---
@@ -302,8 +305,9 @@ keys: {
 ```
 
 A path is either a leaf or a namespace, never both. Declaring `foo` as a
-scalar/factory at the same level as `foo: { ... }` is a duplicate-path
-error — there is no shape that supports both simultaneously, by design.
+leaf (scalar / factory) and `foo/x` as another leaf in the same config is
+rejected by validation rule 6 — there is no shape that supports both
+simultaneously, by design.
 
 **Why this rule.** It removes ambiguity entirely: a property's _shape_
 (literal object vs factory return) is the disambiguator, never the property's

--- a/examples/01-basic.config.ts
+++ b/examples/01-basic.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "keyshelf/config";
+
+export default defineConfig({
+  envs: ["dev"],
+
+  keys: {
+    log: {
+      level: "info",
+      format: "json"
+    },
+    server: {
+      host: "localhost",
+      port: 3000,
+      debug: true
+    }
+  }
+});

--- a/examples/02-env-and-group.config.ts
+++ b/examples/02-env-and-group.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig, config, secret, age, gcp } from "keyshelf/config";
+
+export default defineConfig({
+  envs: ["dev", "staging", "production"],
+  groups: ["app"],
+
+  keys: {
+    log: {
+      level: config({
+        group: "app",
+        default: "info",
+        values: {
+          production: "warn"
+        }
+      })
+    },
+    db: {
+      host: config({
+        group: "app",
+        default: "localhost",
+        values: {
+          staging: "staging-db.internal",
+          production: "prod-db.internal"
+        }
+      }),
+      password: secret({
+        group: "app",
+        default: age({ identityFile: "./keys/dev.txt" }),
+        values: {
+          production: gcp({ project: "myproj" })
+        }
+      })
+    }
+  }
+});

--- a/examples/03-envless-shared-secret.config.ts
+++ b/examples/03-envless-shared-secret.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig, config, secret, age } from "keyshelf/config";
+
+export default defineConfig({
+  envs: ["dev", "production"],
+  groups: ["app", "ci"],
+
+  keys: {
+    github: {
+      token: secret({
+        group: "ci",
+        value: age({ identityFile: "./keys/ci.txt" })
+      })
+    },
+
+    npm: {
+      registry: config({
+        value: "https://registry.npmjs.org/"
+      })
+    },
+
+    app: {
+      name: config({
+        group: "app",
+        value: "keyshelf"
+      })
+    }
+  }
+});

--- a/examples/04-optional-secrets.config.ts
+++ b/examples/04-optional-secrets.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig, secret, age, gcp } from "keyshelf/config";
+
+export default defineConfig({
+  envs: ["dev", "production"],
+  groups: ["app"],
+
+  keys: {
+    sentry: {
+      dsn: secret({
+        group: "app",
+        optional: true,
+        values: {
+          production: gcp({ project: "myproj" })
+        }
+      })
+    },
+
+    pulumi: {
+      "config-passphrase": secret({
+        group: "app",
+        optional: true,
+        default: age({ identityFile: "./keys/dev.txt" }),
+        values: {
+          production: gcp({ project: "myproj", secret: "pulumi-passphrase" })
+        }
+      })
+    }
+  }
+});

--- a/examples/05-nested-namespaces.config.ts
+++ b/examples/05-nested-namespaces.config.ts
@@ -1,0 +1,43 @@
+import { defineConfig, config, secret, age } from "keyshelf/config";
+
+export default defineConfig({
+  envs: ["dev", "production"],
+
+  keys: {
+    services: {
+      auth: {
+        api: {
+          url: "http://localhost:4000",
+          key: secret({
+            value: age({ identityFile: "./keys/dev.txt" })
+          })
+        }
+      },
+      billing: {
+        api: {
+          url: "http://localhost:4001"
+        }
+      }
+    },
+
+    db: {
+      primary: {
+        host: "localhost",
+        port: 5432
+      },
+      replica: {
+        host: "localhost",
+        port: 5433
+      }
+    },
+
+    "feature-flags/launch-darkly/sdk-key": secret({
+      value: age({ identityFile: "./keys/dev.txt" })
+    }),
+    "feature-flags": {
+      "launch-darkly": {
+        environment: config({ value: "dev" })
+      }
+    }
+  }
+});

--- a/examples/05-nested-namespaces.config.ts
+++ b/examples/05-nested-namespaces.config.ts
@@ -34,10 +34,6 @@ export default defineConfig({
     "feature-flags/launch-darkly/sdk-key": secret({
       value: age({ identityFile: "./keys/dev.txt" })
     }),
-    "feature-flags": {
-      "launch-darkly": {
-        environment: config({ value: "dev" })
-      }
-    }
+    "feature-flags/launch-darkly/environment": config({ value: "dev" })
   }
 });

--- a/examples/06-template-config.config.ts
+++ b/examples/06-template-config.config.ts
@@ -1,0 +1,42 @@
+import { defineConfig, config, secret, age } from "keyshelf/config";
+
+export default defineConfig({
+  envs: ["dev", "production"],
+
+  keys: {
+    db: {
+      host: config({
+        default: "localhost",
+        values: {
+          production: "prod-db.internal"
+        }
+      }),
+      port: 5432,
+      user: "app",
+      password: secret({
+        value: age({ identityFile: "./keys/dev.txt" })
+      }),
+
+      url: config({
+        default: "postgres://${db/user}:${db/password}@${db/host}:${db/port}/mydb"
+      })
+    },
+
+    server: {
+      host: "localhost",
+      port: 8080,
+      "public-url": config({
+        default: "http://${server/host}:${server/port}",
+        values: {
+          production: "https://app.example.com"
+        }
+      })
+    },
+
+    docs: {
+      escaped: config({
+        value: "literal $${not/a/reference} dollar-brace"
+      })
+    }
+  }
+});

--- a/examples/07-full.config.ts
+++ b/examples/07-full.config.ts
@@ -1,0 +1,73 @@
+import { defineConfig, config, secret, age, gcp, sops } from "keyshelf/config";
+
+export default defineConfig({
+  envs: ["dev", "staging", "production"],
+  groups: ["app", "ci", "ops"],
+
+  keys: {
+    log: {
+      level: config({
+        group: "app",
+        default: "info",
+        values: { production: "warn" }
+      }),
+      format: "json"
+    },
+
+    db: {
+      host: config({
+        group: "app",
+        default: "localhost",
+        values: {
+          staging: "staging-db.internal",
+          production: "prod-db.internal"
+        }
+      }),
+      port: 5432,
+      user: config({ group: "app", value: "app" }),
+      password: secret({
+        group: "app",
+        default: age({ identityFile: "./keys/dev.txt" }),
+        values: {
+          staging: sops({ file: "./secrets/staging.yaml", path: "db.password" }),
+          production: gcp({ project: "myproj" })
+        }
+      }),
+      url: config({
+        group: "app",
+        default: "postgres://${db/user}:${db/password}@${db/host}:${db/port}/mydb"
+      })
+    },
+
+    sentry: {
+      dsn: secret({
+        group: "app",
+        optional: true,
+        values: {
+          production: gcp({ project: "myproj" })
+        }
+      })
+    },
+
+    github: {
+      token: secret({
+        group: "ci",
+        description: "Shared CI token, not env-scoped",
+        value: age({ identityFile: "./keys/ci.txt" })
+      })
+    },
+
+    grafana: {
+      api: {
+        url: config({
+          group: "ops",
+          default: "https://grafana.internal"
+        }),
+        token: secret({
+          group: "ops",
+          value: gcp({ project: "myproj", secret: "grafana-api-token" })
+        })
+      }
+    }
+  }
+});

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,16 @@
+# Keyshelf v5 examples
+
+These are reference configurations for Phase 0 spec lock. Each file exercises a
+specific shape from `docs/v5/spec.md`. They will compile once the Phase 2
+loader/types land; until then, treat them as the type-shape contract the
+implementation must satisfy.
+
+| File                                                                       | Shapes covered                                                  |
+| -------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| [01-basic.config.ts](./01-basic.config.ts)                                 | Bare scalars, groupless config, no envs in use                  |
+| [02-env-and-group.config.ts](./02-env-and-group.config.ts)                 | `values` map keyed by env, `group` field, mixed config + secret |
+| [03-envless-shared-secret.config.ts](./03-envless-shared-secret.config.ts) | Envless secret in a group; envless config without a group       |
+| [04-optional-secrets.config.ts](./04-optional-secrets.config.ts)           | `optional: true` with and without a binding fallback            |
+| [05-nested-namespaces.config.ts](./05-nested-namespaces.config.ts)         | Deep nesting + string-path escape hatch                         |
+| [06-template-config.config.ts](./06-template-config.config.ts)             | `${path/to/key}` interpolation in config values                 |
+| [07-full.config.ts](./07-full.config.ts)                                   | Canonical example mixing every shape                            |

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,6 +11,6 @@ implementation must satisfy.
 | [02-env-and-group.config.ts](./02-env-and-group.config.ts)                 | `values` map keyed by env, `group` field, mixed config + secret |
 | [03-envless-shared-secret.config.ts](./03-envless-shared-secret.config.ts) | Envless secret in a group; envless config without a group       |
 | [04-optional-secrets.config.ts](./04-optional-secrets.config.ts)           | `optional: true` with and without a binding fallback            |
-| [05-nested-namespaces.config.ts](./05-nested-namespaces.config.ts)         | Deep nesting + string-path escape hatch                         |
+| [05-nested-namespaces.config.ts](./05-nested-namespaces.config.ts)         | Deep nesting and `'a/b/c'` flattened-path notation              |
 | [06-template-config.config.ts](./06-template-config.config.ts)             | `${path/to/key}` interpolation in config values                 |
 | [07-full.config.ts](./07-full.config.ts)                                   | Canonical example mixing every shape                            |


### PR DESCRIPTION
## Summary

Phase 0 of v5 (issue #78): spec lock. No implementation, just pinned design.

- **`docs/v5/spec.md`** — full API surface for `defineConfig` / `config` / `secret` / `age` / `gcp` / `sops`, resolution order, template interpolation rules, validation rules (forwarded to Phase 2), and out-of-scope restated.
- **`examples/`** — seven `.config.ts` files exercising every shape called out in the issue: bare scalars, env+group, envless+group, envless+groupless, optional secrets, nested namespaces, template interpolation, and a full canonical example.

## Decisions

Both open questions from #78 are resolved in `docs/v5/spec.md`:

- **Namespace conflict (`foo: { value: 'bar' }`).** Object literals are *always* namespaces. A leaf at `foo` requires a bare scalar (`foo: 'bar'`) or an explicit factory (`foo: config({...})`). A path is either a leaf or a namespace, never both — there's no shape supporting `foo` as a leaf *and* `foo/*` as children at the same time, by design. Disambiguation is by the *shape* of the value (factory return vs literal object), never the property name. The `'a/b/c': value` notation is a flatten-the-nesting convenience, not an escape from a conflict.
- **`.env.keyshelf` template references under `--group` filtering.** Skip the env var, log a stderr warning. Same rule for `--filter` and for optional unresolved keys: if any referenced key is unavailable in the active selection, the var is omitted with an audit-trail warning. Empty-string fallback was rejected (silent bad input); whole-render error was rejected (defeats the purpose of partial render).

## Out of scope for this PR

No `keyshelf/config` package exists yet — the example files reference an import that lands in Phase 1/2. They are the type-shape contract Phase 2 must satisfy, not runnable code.

## Test plan

- [ ] Re-read `docs/v5/spec.md` end-to-end and confirm the API surface matches expectations
- [ ] Walk each `examples/*.config.ts` and confirm the spec covers it
- [ ] Re-check the two decisions against the open questions in #78