### PR TITLE
feat(v5): scaffold phase 1 entrypoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5288,7 +5288,7 @@
     },
     "packages/cli": {
       "name": "keyshelf",
-      "version": "4.4.0",
+      "version": "4.5.0",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/secret-manager": "^6.1.1",
@@ -5298,7 +5298,8 @@
         "js-yaml": "^4.1.1"
       },
       "bin": {
-        "keyshelf": "dist/bin/keyshelf.js"
+        "keyshelf": "dist/bin/keyshelf.js",
+        "keyshelf-next": "dist/bin/keyshelf-next.js"
       },
       "devDependencies": {
         "@types/cross-spawn": "^6.0.6",

--- a/packages/cli/bin/keyshelf-next.ts
+++ b/packages/cli/bin/keyshelf-next.ts
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+
+import { createV5Program } from "../src/v5/cli/index.js";
+
+const program = createV5Program();
+program.parseAsync(process.argv).catch((err) => {
+  console.error(`error: ${err.message}`);
+  process.exit(1);
+});

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -10,7 +10,8 @@
     "directory": "packages/cli"
   },
   "bin": {
-    "keyshelf": "./dist/bin/keyshelf.js"
+    "keyshelf": "./dist/bin/keyshelf.js",
+    "keyshelf-next": "./dist/bin/keyshelf-next.js"
   },
   "main": "./dist/src/index.js",
   "types": "./dist/index.d.ts",
@@ -20,6 +21,7 @@
       "import": "./dist/src/index.js"
     },
     "./bin": "./dist/bin/keyshelf.js",
+    "./bin-next": "./dist/bin/keyshelf-next.js",
     "./package.json": "./package.json"
   },
   "files": [
@@ -30,6 +32,7 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsx bin/keyshelf.ts",
+    "dev:next": "tsx bin/keyshelf-next.ts",
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit"

--- a/packages/cli/src/v5/cli/index.ts
+++ b/packages/cli/src/v5/cli/index.ts
@@ -1,0 +1,19 @@
+import { Command } from "commander";
+
+const V5_VERSION = "5.0.0-alpha.0";
+
+export function createV5Program(): Command {
+  const program = new Command("keyshelf-next")
+    .description("Keyshelf v5 development CLI")
+    .version(V5_VERSION);
+
+  program.addCommand(createStatusCommand());
+
+  return program;
+}
+
+function createStatusCommand(): Command {
+  return new Command("status").description("Show v5 implementation status").action(() => {
+    console.log("keyshelf v5 phase 1 scaffold is installed");
+  });
+}

--- a/packages/cli/src/v5/index.ts
+++ b/packages/cli/src/v5/index.ts
@@ -1,0 +1,1 @@
+export { createV5Program } from "./cli/index.js";

--- a/packages/cli/test/unit/v5/cli.test.ts
+++ b/packages/cli/test/unit/v5/cli.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from "vitest";
+import { createV5Program } from "../../../src/v5/index.js";
+
+describe("createV5Program", () => {
+  it("creates an isolated keyshelf-next program", () => {
+    const program = createV5Program();
+
+    expect(program.name()).toBe("keyshelf-next");
+    expect(program.commands.map((command) => command.name())).toEqual(["status"]);
+  });
+
+  it("reports phase 1 status", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await createV5Program().parseAsync(["node", "keyshelf-next", "status"]);
+
+    expect(log).toHaveBeenCalledWith("keyshelf v5 phase 1 scaffold is installed");
+    log.mockRestore();
+  });
+});

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/**/*.ts", "bin/keyshelf.ts"],
+  entry: ["src/**/*.ts", "bin/*.ts"],
   format: ["esm"],
   target: "node20",
   bundle: false,


### PR DESCRIPTION
## Summary
- add isolated v5 source scaffold under packages/cli/src/v5
- add keyshelf-next binary and dev script for phase 1 iteration
- update build/package metadata and add unit coverage for the v5 CLI scaffold

## Verification
- npm run typecheck -w packages/cli
- npm test -w packages/cli
- npm run build -w packages/cli
- node packages/cli/dist/bin/keyshelf-next.js status

Closes #78 phase 1.