### PR TITLE
feat: implement v5 phase 2 config loader

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3264,6 +3264,15 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
     "node_modules/joycon": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
@@ -5271,9 +5280,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/zod": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.1.tgz",
+      "integrity": "sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "packages/action": {
       "name": "@keyshelf/action",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.5.0",
@@ -5295,7 +5313,9 @@
         "age-encryption": "^0.3.0",
         "commander": "^14.0.3",
         "cross-spawn": "^7.0.6",
-        "js-yaml": "^4.1.1"
+        "jiti": "^2.6.1",
+        "js-yaml": "^4.1.1",
+        "zod": "^4.4.1"
       },
       "bin": {
         "keyshelf": "dist/bin/keyshelf.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,6 +22,10 @@
     },
     "./bin": "./dist/bin/keyshelf.js",
     "./bin-next": "./dist/bin/keyshelf-next.js",
+    "./config": {
+      "types": "./dist/v5/config/index.d.ts",
+      "import": "./dist/src/v5/config/index.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [
@@ -46,7 +50,9 @@
     "age-encryption": "^0.3.0",
     "commander": "^14.0.3",
     "cross-spawn": "^7.0.6",
-    "js-yaml": "^4.1.1"
+    "jiti": "^2.6.1",
+    "js-yaml": "^4.1.1",
+    "zod": "^4.4.1"
   },
   "devDependencies": {
     "@types/cross-spawn": "^6.0.6",

--- a/packages/cli/src/v5/cli/index.ts
+++ b/packages/cli/src/v5/cli/index.ts
@@ -14,6 +14,6 @@ export function createV5Program(): Command {
 
 function createStatusCommand(): Command {
   return new Command("status").description("Show v5 implementation status").action(() => {
-    console.log("keyshelf v5 phase 1 scaffold is installed");
+    console.log("keyshelf v5 phase 2 config loader is installed");
   });
 }

--- a/packages/cli/src/v5/config/factories.ts
+++ b/packages/cli/src/v5/config/factories.ts
@@ -1,7 +1,6 @@
 import type {
   AgeProviderOptions,
   BuiltinProviderRef,
-  ConfigRecord,
   ConfigRecordInput,
   DefineConfigInput,
   GcpProviderOptions,
@@ -9,7 +8,6 @@ import type {
   KeyshelfConfig,
   KeyTree,
   ProviderRef,
-  SecretRecord,
   SecretRecordInput,
   SopsProviderOptions
 } from "./types.js";

--- a/packages/cli/src/v5/config/factories.ts
+++ b/packages/cli/src/v5/config/factories.ts
@@ -1,0 +1,60 @@
+import type {
+  AgeProviderOptions,
+  BuiltinProviderRef,
+  ConfigRecord,
+  ConfigRecordInput,
+  DefineConfigInput,
+  GcpProviderOptions,
+  KeyPaths,
+  KeyshelfConfig,
+  KeyTree,
+  ProviderRef,
+  SecretRecord,
+  SecretRecordInput,
+  SopsProviderOptions
+} from "./types.js";
+
+export function defineConfig<
+  const EnvNames extends readonly [string, ...string[]],
+  const GroupNames extends readonly string[] = readonly [],
+  const Keys extends KeyTree<EnvNames[number], GroupNames[number]> = KeyTree<
+    EnvNames[number],
+    GroupNames[number]
+  >
+>(
+  input: DefineConfigInput<EnvNames, GroupNames, Keys>
+): KeyshelfConfig<EnvNames[number], GroupNames[number], KeyPaths<Keys>> {
+  return { __kind: "keyshelf:config", ...input };
+}
+
+export function config<const Input extends ConfigRecordInput>(
+  input: Input
+): Input & { __kind: "config" } {
+  return { __kind: "config", ...input };
+}
+
+export function secret<const Input extends SecretRecordInput>(
+  input: Input
+): Input & { __kind: "secret" } {
+  return { __kind: "secret", ...input };
+}
+
+export function age<const Options extends AgeProviderOptions>(
+  options: Options
+): ProviderRef<"age", Options> {
+  return { __kind: "provider:age", name: "age", options };
+}
+
+export function gcp<const Options extends GcpProviderOptions>(
+  options: Options
+): ProviderRef<"gcp", Options> {
+  return { __kind: "provider:gcp", name: "gcp", options };
+}
+
+export function sops<const Options extends SopsProviderOptions>(
+  options: Options
+): ProviderRef<"sops", Options> {
+  return { __kind: "provider:sops", name: "sops", options };
+}
+
+export type { BuiltinProviderRef };

--- a/packages/cli/src/v5/config/index.ts
+++ b/packages/cli/src/v5/config/index.ts
@@ -1,0 +1,33 @@
+export { defineConfig, config, secret, age, gcp, sops } from "./factories.js";
+export {
+  findV5RootDir,
+  loadV5Config,
+  type LoadedV5Config,
+  type LoadV5ConfigOptions
+} from "./loader.js";
+export {
+  isProviderRef,
+  keyshelfConfigSchema,
+  normalizeConfig,
+  providerRefSchema,
+  validateAppMappingReferences
+} from "./schema.js";
+export type {
+  AgeProviderOptions,
+  BuiltinProviderRef,
+  ConfigBinding,
+  ConfigRecord,
+  ConfigRecordInput,
+  ConfigScalar,
+  DefineConfigInput,
+  GcpProviderOptions,
+  KeyPaths,
+  KeyshelfConfig,
+  KeyTree,
+  NormalizedConfig,
+  NormalizedRecord,
+  ProviderRef,
+  SecretRecord,
+  SecretRecordInput,
+  SopsProviderOptions
+} from "./types.js";

--- a/packages/cli/src/v5/config/loader.ts
+++ b/packages/cli/src/v5/config/loader.ts
@@ -1,0 +1,94 @@
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { performance } from "node:perf_hooks";
+import { createJiti } from "jiti";
+import { parseAppMapping, type AppMapping } from "../../config/app-mapping.js";
+import { normalizeConfig, validateAppMappingReferences } from "./schema.js";
+import type { KeyshelfConfig, NormalizedConfig } from "./types.js";
+
+const CONFIG_FILE = "keyshelf.config.ts";
+const APP_MAPPING_FILE = ".env.keyshelf";
+
+export interface LoadedV5Config {
+  rootDir: string;
+  configPath: string;
+  config: NormalizedConfig;
+  appMapping: AppMapping[];
+  loadTimeMs: number;
+}
+
+export interface LoadV5ConfigOptions {
+  configPath?: string;
+  mappingFile?: string;
+}
+
+export function findV5RootDir(from: string): string {
+  let dir = resolve(from);
+
+  while (true) {
+    if (existsSync(join(dir, CONFIG_FILE))) {
+      return dir;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) {
+      throw new Error(`Could not find ${CONFIG_FILE} in ${from} or any parent directory`);
+    }
+    dir = parent;
+  }
+}
+
+export async function loadV5Config(
+  appDir: string,
+  options: LoadV5ConfigOptions = {}
+): Promise<LoadedV5Config> {
+  const explicitConfigPath = options.configPath === undefined ? undefined : resolve(options.configPath);
+  const rootDir = explicitConfigPath === undefined ? findV5RootDir(appDir) : dirname(explicitConfigPath);
+  const configPath = explicitConfigPath ?? join(rootDir, CONFIG_FILE);
+
+  const started = performance.now();
+  const rawConfig = await importConfig(configPath);
+  const config = normalizeConfig(rawConfig);
+  const loadTimeMs = performance.now() - started;
+
+  const mappingPath = options.mappingFile
+    ? resolve(options.mappingFile)
+    : join(resolve(appDir), APP_MAPPING_FILE);
+  const appMapping = await loadAppMapping(mappingPath, options.mappingFile !== undefined);
+  validateAppMappingReferences(appMapping, config.keys);
+
+  return {
+    rootDir,
+    configPath,
+    config,
+    appMapping,
+    loadTimeMs
+  };
+}
+
+async function importConfig(configPath: string): Promise<KeyshelfConfig> {
+  const configModulePath = fileURLToPath(new URL("./index.js", import.meta.url));
+  const jiti = createJiti(import.meta.url, {
+    alias: {
+      "keyshelf/config": configModulePath
+    }
+  });
+  return await jiti.import<KeyshelfConfig>(configPath, { default: true });
+}
+
+async function loadAppMapping(mappingPath: string, required: boolean): Promise<AppMapping[]> {
+  try {
+    return parseAppMapping(await readFile(mappingPath, "utf-8"));
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      if (required) {
+        throw new Error(`App mapping file not found: ${mappingPath}`, {
+          cause: err
+        });
+      }
+      return [];
+    }
+    throw err;
+  }
+}

--- a/packages/cli/src/v5/config/loader.ts
+++ b/packages/cli/src/v5/config/loader.ts
@@ -43,8 +43,10 @@ export async function loadV5Config(
   appDir: string,
   options: LoadV5ConfigOptions = {}
 ): Promise<LoadedV5Config> {
-  const explicitConfigPath = options.configPath === undefined ? undefined : resolve(options.configPath);
-  const rootDir = explicitConfigPath === undefined ? findV5RootDir(appDir) : dirname(explicitConfigPath);
+  const explicitConfigPath =
+    options.configPath === undefined ? undefined : resolve(options.configPath);
+  const rootDir =
+    explicitConfigPath === undefined ? findV5RootDir(appDir) : dirname(explicitConfigPath);
   const configPath = explicitConfigPath ?? join(rootDir, CONFIG_FILE);
 
   const started = performance.now();

--- a/packages/cli/src/v5/config/schema.ts
+++ b/packages/cli/src/v5/config/schema.ts
@@ -12,6 +12,7 @@ import type {
 
 const PATH_SEGMENT_RE = /^[A-Za-z_][A-Za-z0-9_-]*$/;
 const TEMPLATE_RE = /(?<!\$)\$\{([^}]+)\}/g;
+const CONFIG_SCALAR_TYPES = new Set(["string", "number", "boolean"]);
 
 const configScalarSchema = z.union([z.string(), z.number(), z.boolean()]);
 
@@ -473,7 +474,7 @@ function copyDefinedRecord<T>(
 }
 
 function isScalar(value: unknown): value is ConfigBinding {
-  return typeof value === "string" || typeof value === "number" || typeof value === "boolean";
+  return CONFIG_SCALAR_TYPES.has(typeof value);
 }
 
 function isNamespace(value: unknown): value is KeyNamespace {

--- a/packages/cli/src/v5/config/schema.ts
+++ b/packages/cli/src/v5/config/schema.ts
@@ -96,6 +96,12 @@ interface KeyNamespace {
 
 type KeyNode = ConfigBinding | ConfigRecord | SecretRecord | KeyNamespace;
 
+interface TemplateVisitState {
+  visiting: Set<string>;
+  visited: Set<string>;
+  stack: string[];
+}
+
 const keyNodeSchema: z.ZodType<KeyNode> = z.lazy(() =>
   z.union([
     configScalarSchema,
@@ -133,37 +139,11 @@ export function normalizeConfig(input: unknown): NormalizedConfig {
   const groups = [...(parsed.groups ?? [])];
   checkUnique("groups", groups, errors);
 
-  const envSet = new Set(parsed.envs);
-  const groupSet = new Set(groups);
   const flattened = flattenKeyTree(parsed.keys, errors);
   const paths = new Set(flattened.map((record) => record.path));
 
   validatePathConflicts(flattened, errors);
-
-  for (const record of flattened) {
-    if (record.value !== undefined && record.default !== undefined) {
-      errors.push(`${record.path}: value and default are mutually exclusive`);
-    }
-
-    if (record.group !== undefined && !groupSet.has(record.group)) {
-      const suffix = groups.length === 0 ? " because no groups are declared" : "";
-      errors.push(`${record.path}: group "${record.group}" is not declared${suffix}`);
-    }
-
-    for (const envName of Object.keys(record.values ?? {})) {
-      if (!envSet.has(envName)) {
-        errors.push(`${record.path}: values contains undeclared env "${envName}"`);
-      }
-    }
-
-    if (record.kind === "secret") {
-      const hasValues = record.values !== undefined && Object.keys(record.values).length > 0;
-      if (record.value === undefined && record.default === undefined && !hasValues) {
-        errors.push(`${record.path}: secret requires value, default, or at least one values entry`);
-      }
-    }
-  }
-
+  validateRecords(flattened, parsed.envs, groups, errors);
   validateTemplateReferences(flattened, paths, errors);
 
   if (errors.length > 0) {
@@ -200,6 +180,62 @@ export function validateAppMappingReferences(
   }
 }
 
+function validateRecords(
+  records: NormalizedRecord[],
+  envs: readonly string[],
+  groups: readonly string[],
+  errors: string[]
+): void {
+  const envSet = new Set(envs);
+  const groupSet = new Set(groups);
+
+  for (const record of records) {
+    validateRecordValue(record, errors);
+    validateRecordGroup(record, groups, groupSet, errors);
+    validateRecordValues(record, envSet, errors);
+    validateSecretValue(record, errors);
+  }
+}
+
+function validateRecordValue(record: NormalizedRecord, errors: string[]): void {
+  if (record.value !== undefined && record.default !== undefined) {
+    errors.push(`${record.path}: value and default are mutually exclusive`);
+  }
+}
+
+function validateRecordGroup(
+  record: NormalizedRecord,
+  groups: readonly string[],
+  groupSet: Set<string>,
+  errors: string[]
+): void {
+  if (record.group === undefined || groupSet.has(record.group)) return;
+
+  const suffix = groups.length === 0 ? " because no groups are declared" : "";
+  errors.push(`${record.path}: group "${record.group}" is not declared${suffix}`);
+}
+
+function validateRecordValues(
+  record: NormalizedRecord,
+  envSet: Set<string>,
+  errors: string[]
+): void {
+  for (const envName of Object.keys(record.values ?? {})) {
+    if (!envSet.has(envName)) {
+      errors.push(`${record.path}: values contains undeclared env "${envName}"`);
+    }
+  }
+}
+
+function validateSecretValue(record: NormalizedRecord, errors: string[]): void {
+  if (record.kind !== "secret") return;
+
+  const hasValues = record.values !== undefined && Object.keys(record.values).length > 0;
+  if (record.value === undefined && record.default === undefined && !hasValues) {
+    errors.push(`${record.path}: secret requires value, default, or at least one values entry`);
+  }
+}
+
 function flattenKeyTree(
   tree: KeyTree,
   errors: string[],
@@ -209,65 +245,79 @@ function flattenKeyTree(
   const seen = new Set<string>();
 
   for (const [rawKey, value] of Object.entries(tree)) {
-    const keyParts = rawKey.split("/");
-    const fullParts = [...prefix, ...keyParts];
+    const fullParts = [...prefix, ...rawKey.split("/")];
     const path = fullParts.join("/");
 
-    if (seen.has(path)) {
-      errors.push(`${path}: duplicate flattened path`);
-      continue;
-    }
-    seen.add(path);
+    if (hasSeenPath(path, seen, errors)) continue;
 
     validatePathParts(fullParts, errors);
-
-    if (isConfigRecord(value)) {
-      records.push({
-        path,
-        kind: "config",
-        group: value.group,
-        optional: value.optional ?? false,
-        description: value.description,
-        value: value.value,
-        default: value.default,
-        values: copyDefinedRecord(value.values)
-      });
-      continue;
-    }
-
-    if (isSecretRecord(value)) {
-      records.push({
-        path,
-        kind: "secret",
-        group: value.group,
-        optional: value.optional ?? false,
-        description: value.description,
-        value: value.value,
-        default: value.default,
-        values: copyDefinedRecord(value.values)
-      });
-      continue;
-    }
-
-    if (isScalar(value)) {
-      records.push({
-        path,
-        kind: "config",
-        optional: false,
-        value
-      });
-      continue;
-    }
-
-    if (value == null || typeof value !== "object" || Array.isArray(value)) {
-      errors.push(`${path}: expected scalar, config(...), secret(...), or namespace object`);
-      continue;
-    }
-
-    records.push(...flattenKeyTree(value as KeyTree, errors, fullParts));
+    records.push(...flattenKeyNode(value, path, fullParts, errors));
   }
 
   return records;
+}
+
+function hasSeenPath(path: string, seen: Set<string>, errors: string[]): boolean {
+  if (seen.has(path)) {
+    errors.push(`${path}: duplicate flattened path`);
+    return true;
+  }
+
+  seen.add(path);
+  return false;
+}
+
+function flattenKeyNode(
+  value: KeyNode,
+  path: string,
+  fullParts: string[],
+  errors: string[]
+): NormalizedRecord[] {
+  if (isConfigRecord(value)) return [normalizeConfigRecord(path, value)];
+  if (isSecretRecord(value)) return [normalizeSecretRecord(path, value)];
+  if (isScalar(value)) return [normalizeScalarRecord(path, value)];
+
+  if (!isNamespace(value)) {
+    errors.push(`${path}: expected scalar, config(...), secret(...), or namespace object`);
+    return [];
+  }
+
+  return flattenKeyTree(value as KeyTree, errors, fullParts);
+}
+
+function normalizeConfigRecord(path: string, value: ConfigRecord): NormalizedRecord {
+  return {
+    path,
+    kind: "config",
+    group: value.group,
+    optional: value.optional ?? false,
+    description: value.description,
+    value: value.value,
+    default: value.default,
+    values: copyDefinedRecord(value.values)
+  };
+}
+
+function normalizeSecretRecord(path: string, value: SecretRecord): NormalizedRecord {
+  return {
+    path,
+    kind: "secret",
+    group: value.group,
+    optional: value.optional ?? false,
+    description: value.description,
+    value: value.value,
+    default: value.default,
+    values: copyDefinedRecord(value.values)
+  };
+}
+
+function normalizeScalarRecord(path: string, value: ConfigBinding): NormalizedRecord {
+  return {
+    path,
+    kind: "config",
+    optional: false,
+    value
+  };
 }
 
 function validatePathParts(parts: string[], errors: string[]): void {
@@ -304,55 +354,87 @@ function validateTemplateReferences(
   paths: Set<string>,
   errors: string[]
 ): void {
+  const graph = buildTemplateGraph(records, paths, errors);
+  validateTemplateGraph(graph, errors);
+}
+
+function buildTemplateGraph(
+  records: NormalizedRecord[],
+  paths: Set<string>,
+  errors: string[]
+): Map<string, string[]> {
   const graph = new Map<string, string[]>();
 
   for (const record of records) {
     if (record.kind !== "config") continue;
-
-    const references = [
-      ...extractTemplateReferences(record.value),
-      ...extractTemplateReferences(record.default),
-      ...Object.values(record.values ?? {}).flatMap((value) => extractTemplateReferences(value))
-    ];
-
-    for (const reference of references) {
-      if (!paths.has(reference)) {
-        errors.push(`${record.path}: template references unknown key "${reference}"`);
-      }
-    }
-
-    graph.set(
-      record.path,
-      references.filter((reference) => paths.has(reference))
-    );
+    graph.set(record.path, validateTemplateRecord(record, paths, errors));
   }
 
-  const visiting = new Set<string>();
-  const visited = new Set<string>();
-  const stack: string[] = [];
+  return graph;
+}
 
-  const visit = (path: string): void => {
-    if (visited.has(path)) return;
-    if (visiting.has(path)) {
-      const cycleStart = stack.indexOf(path);
-      const cycle = [...stack.slice(cycleStart), path].join(" -> ");
-      errors.push(`template cycle detected: ${cycle}`);
-      return;
-    }
+function validateTemplateRecord(
+  record: Extract<NormalizedRecord, { kind: "config" }>,
+  paths: Set<string>,
+  errors: string[]
+): string[] {
+  const references = getTemplateReferences(record);
 
-    visiting.add(path);
-    stack.push(path);
-    for (const dependency of graph.get(path) ?? []) {
-      visit(dependency);
+  for (const reference of references) {
+    if (!paths.has(reference)) {
+      errors.push(`${record.path}: template references unknown key "${reference}"`);
     }
-    stack.pop();
-    visiting.delete(path);
-    visited.add(path);
+  }
+
+  return references.filter((reference) => paths.has(reference));
+}
+
+function getTemplateReferences(record: Extract<NormalizedRecord, { kind: "config" }>): string[] {
+  return [
+    ...extractTemplateReferences(record.value),
+    ...extractTemplateReferences(record.default),
+    ...Object.values(record.values ?? {}).flatMap((value) => extractTemplateReferences(value))
+  ];
+}
+
+function validateTemplateGraph(graph: Map<string, string[]>, errors: string[]): void {
+  const state: TemplateVisitState = {
+    visiting: new Set<string>(),
+    visited: new Set<string>(),
+    stack: []
   };
 
   for (const path of graph.keys()) {
-    visit(path);
+    visitTemplatePath(path, graph, state, errors);
   }
+}
+
+function visitTemplatePath(
+  path: string,
+  graph: Map<string, string[]>,
+  state: TemplateVisitState,
+  errors: string[]
+): void {
+  if (state.visited.has(path)) return;
+  if (state.visiting.has(path)) {
+    reportTemplateCycle(path, state.stack, errors);
+    return;
+  }
+
+  state.visiting.add(path);
+  state.stack.push(path);
+  for (const dependency of graph.get(path) ?? []) {
+    visitTemplatePath(dependency, graph, state, errors);
+  }
+  state.stack.pop();
+  state.visiting.delete(path);
+  state.visited.add(path);
+}
+
+function reportTemplateCycle(path: string, stack: string[], errors: string[]): void {
+  const cycleStart = stack.indexOf(path);
+  const cycle = [...stack.slice(cycleStart), path].join(" -> ");
+  errors.push(`template cycle detected: ${cycle}`);
 }
 
 function extractTemplateReferences(value: unknown): string[] {
@@ -392,6 +474,10 @@ function copyDefinedRecord<T>(
 
 function isScalar(value: unknown): value is ConfigBinding {
   return typeof value === "string" || typeof value === "number" || typeof value === "boolean";
+}
+
+function isNamespace(value: unknown): value is KeyNamespace {
+  return value != null && typeof value === "object" && !Array.isArray(value);
 }
 
 function isConfigRecord(value: unknown): value is ConfigRecord {

--- a/packages/cli/src/v5/config/schema.ts
+++ b/packages/cli/src/v5/config/schema.ts
@@ -279,11 +279,6 @@ function flattenKeyNode(
   const scalar = configScalarSchema.safeParse(value);
   if (scalar.success) return [normalizeScalarRecord(path, scalar.data)];
 
-  if (!isNamespace(value)) {
-    errors.push(`${path}: expected scalar, config(...), secret(...), or namespace object`);
-    return [];
-  }
-
   return flattenKeyTree(value as KeyTree, errors, fullParts);
 }
 
@@ -474,34 +469,23 @@ function copyDefinedRecord<T>(
   return copy;
 }
 
-function isNamespace(value: unknown): value is KeyNamespace {
-  return value != null && typeof value === "object" && !Array.isArray(value);
-}
-
 function isConfigRecord(value: unknown): value is ConfigRecord {
-  return (
-    value != null &&
-    typeof value === "object" &&
-    !Array.isArray(value) &&
-    (value as { __kind?: unknown }).__kind === "config"
-  );
+  return getKind(value) === "config";
 }
 
 function isSecretRecord(value: unknown): value is SecretRecord {
-  return (
-    value != null &&
-    typeof value === "object" &&
-    !Array.isArray(value) &&
-    (value as { __kind?: unknown }).__kind === "secret"
-  );
+  return getKind(value) === "secret";
 }
 
 export function isProviderRef(value: unknown): value is BuiltinProviderRef {
-  return (
-    value != null &&
-    typeof value === "object" &&
-    !Array.isArray(value) &&
-    typeof (value as { __kind?: unknown }).__kind === "string" &&
-    (value as { __kind: string }).__kind.startsWith("provider:")
-  );
+  const kind = getKind(value);
+  return typeof kind === "string" && kind.startsWith("provider:");
+}
+
+function getKind(value: unknown): unknown {
+  if (value == null) return undefined;
+  if (typeof value !== "object") return undefined;
+  if (Array.isArray(value)) return undefined;
+
+  return (value as { __kind?: unknown }).__kind;
 }

--- a/packages/cli/src/v5/config/schema.ts
+++ b/packages/cli/src/v5/config/schema.ts
@@ -1,0 +1,407 @@
+import { z } from "zod";
+import type {
+  BuiltinProviderRef,
+  ConfigBinding,
+  ConfigRecord,
+  KeyTree,
+  KeyshelfConfig,
+  NormalizedConfig,
+  NormalizedRecord,
+  SecretRecord
+} from "./types.js";
+
+const PATH_SEGMENT_RE = /^[A-Za-z_][A-Za-z0-9_-]*$/;
+const TEMPLATE_RE = /(?<!\$)\$\{([^}]+)\}/g;
+
+const configScalarSchema = z.union([z.string(), z.number(), z.boolean()]);
+
+const ageProviderSchema = z
+  .object({
+    __kind: z.literal("provider:age"),
+    name: z.literal("age"),
+    options: z
+      .object({
+        identityFile: z.string().optional(),
+        recipient: z.string().optional()
+      })
+      .strict()
+      .refine((options) => options.identityFile !== undefined || options.recipient !== undefined, {
+        message: "age provider requires identityFile or recipient"
+      })
+  })
+  .strict();
+
+const gcpProviderSchema = z
+  .object({
+    __kind: z.literal("provider:gcp"),
+    name: z.literal("gcp"),
+    options: z
+      .object({
+        project: z.string().min(1),
+        secret: z.string().optional(),
+        version: z.string().optional()
+      })
+      .strict()
+  })
+  .strict();
+
+const sopsProviderSchema = z
+  .object({
+    __kind: z.literal("provider:sops"),
+    name: z.literal("sops"),
+    options: z
+      .object({
+        file: z.string().min(1),
+        path: z.string().optional()
+      })
+      .strict()
+  })
+  .strict();
+
+const providerRefSchema = z.discriminatedUnion("__kind", [
+  ageProviderSchema,
+  gcpProviderSchema,
+  sopsProviderSchema
+]);
+
+const baseRecordSchema = {
+  group: z.string().optional(),
+  optional: z.boolean().optional(),
+  description: z.string().optional()
+};
+
+const configRecordSchema = z
+  .object({
+    __kind: z.literal("config"),
+    ...baseRecordSchema,
+    value: configScalarSchema.optional(),
+    default: configScalarSchema.optional(),
+    values: z.record(z.string(), configScalarSchema).optional()
+  })
+  .strict();
+
+const secretRecordSchema = z
+  .object({
+    __kind: z.literal("secret"),
+    ...baseRecordSchema,
+    value: providerRefSchema.optional(),
+    default: providerRefSchema.optional(),
+    values: z.record(z.string(), providerRefSchema).optional()
+  })
+  .strict();
+
+interface KeyNamespace {
+  [key: string]: KeyNode;
+}
+
+type KeyNode = ConfigBinding | ConfigRecord | SecretRecord | KeyNamespace;
+
+const keyNodeSchema: z.ZodType<KeyNode> = z.lazy(() =>
+  z.union([
+    configScalarSchema,
+    configRecordSchema,
+    secretRecordSchema,
+    z
+      .record(z.string(), keyNodeSchema)
+      .refine((value) => !Object.hasOwn(value, "__kind"), {
+        message: "factory objects with __kind must match their declared schema"
+      })
+  ])
+);
+
+const keyshelfConfigSchema = z
+  .object({
+    __kind: z.literal("keyshelf:config"),
+    envs: z.array(z.string().min(1)).nonempty(),
+    groups: z.array(z.string().min(1)).optional(),
+    keys: z.record(z.string(), keyNodeSchema)
+  })
+  .strict();
+
+export { keyshelfConfigSchema, providerRefSchema };
+
+export function normalizeConfig(input: unknown): NormalizedConfig {
+  const parsed = keyshelfConfigSchema.parse(input) as KeyshelfConfig;
+  const errors: string[] = [];
+
+  checkUnique("envs", parsed.envs, errors);
+  const groups = [...(parsed.groups ?? [])];
+  checkUnique("groups", groups, errors);
+
+  const envSet = new Set(parsed.envs);
+  const groupSet = new Set(groups);
+  const flattened = flattenKeyTree(parsed.keys, errors);
+  const paths = new Set(flattened.map((record) => record.path));
+
+  validatePathConflicts(flattened, errors);
+
+  for (const record of flattened) {
+    if (record.value !== undefined && record.default !== undefined) {
+      errors.push(`${record.path}: value and default are mutually exclusive`);
+    }
+
+    if (record.group !== undefined && !groupSet.has(record.group)) {
+      const suffix = groups.length === 0 ? " because no groups are declared" : "";
+      errors.push(`${record.path}: group "${record.group}" is not declared${suffix}`);
+    }
+
+    for (const envName of Object.keys(record.values ?? {})) {
+      if (!envSet.has(envName)) {
+        errors.push(`${record.path}: values contains undeclared env "${envName}"`);
+      }
+    }
+
+    if (record.kind === "secret") {
+      const hasValues = record.values !== undefined && Object.keys(record.values).length > 0;
+      if (record.value === undefined && record.default === undefined && !hasValues) {
+        errors.push(`${record.path}: secret requires value, default, or at least one values entry`);
+      }
+    }
+  }
+
+  validateTemplateReferences(flattened, paths, errors);
+
+  if (errors.length > 0) {
+    throw new Error(`Invalid keyshelf.config.ts:\n${errors.map((error) => `- ${error}`).join("\n")}`);
+  }
+
+  return {
+    envs: [...parsed.envs],
+    groups,
+    keys: flattened
+  };
+}
+
+export function validateAppMappingReferences(
+  mappings: Array<{ envVar: string; keyPath?: string; keyPaths?: string[] }>,
+  flattenedKeys: NormalizedRecord[]
+): void {
+  const paths = new Set(flattenedKeys.map((record) => record.path));
+  const errors: string[] = [];
+
+  for (const mapping of mappings) {
+    const references = mapping.keyPaths ?? (mapping.keyPath !== undefined ? [mapping.keyPath] : []);
+    for (const reference of references) {
+      if (!paths.has(reference)) {
+        errors.push(`${mapping.envVar}: references unknown key "${reference}"`);
+      }
+    }
+  }
+
+  if (errors.length > 0) {
+    throw new Error(`Invalid .env.keyshelf:\n${errors.map((error) => `- ${error}`).join("\n")}`);
+  }
+}
+
+function flattenKeyTree(tree: KeyTree, errors: string[], prefix: string[] = []): NormalizedRecord[] {
+  const records: NormalizedRecord[] = [];
+  const seen = new Set<string>();
+
+  for (const [rawKey, value] of Object.entries(tree)) {
+    const keyParts = rawKey.split("/");
+    const fullParts = [...prefix, ...keyParts];
+    const path = fullParts.join("/");
+
+    if (seen.has(path)) {
+      errors.push(`${path}: duplicate flattened path`);
+      continue;
+    }
+    seen.add(path);
+
+    validatePathParts(fullParts, errors);
+
+    if (isConfigRecord(value)) {
+      records.push({
+        path,
+        kind: "config",
+        group: value.group,
+        optional: value.optional ?? false,
+        description: value.description,
+        value: value.value,
+        default: value.default,
+        values: copyDefinedRecord(value.values)
+      });
+      continue;
+    }
+
+    if (isSecretRecord(value)) {
+      records.push({
+        path,
+        kind: "secret",
+        group: value.group,
+        optional: value.optional ?? false,
+        description: value.description,
+        value: value.value,
+        default: value.default,
+        values: copyDefinedRecord(value.values)
+      });
+      continue;
+    }
+
+    if (isScalar(value)) {
+      records.push({
+        path,
+        kind: "config",
+        optional: false,
+        value
+      });
+      continue;
+    }
+
+    if (value == null || typeof value !== "object" || Array.isArray(value)) {
+      errors.push(`${path}: expected scalar, config(...), secret(...), or namespace object`);
+      continue;
+    }
+
+    records.push(...flattenKeyTree(value as KeyTree, errors, fullParts));
+  }
+
+  return records;
+}
+
+function validatePathParts(parts: string[], errors: string[]): void {
+  for (const part of parts) {
+    if (!PATH_SEGMENT_RE.test(part)) {
+      errors.push(`${parts.join("/")}: invalid path segment "${part}"`);
+    }
+  }
+}
+
+function validatePathConflicts(records: NormalizedRecord[], errors: string[]): void {
+  const sorted = [...records].sort((a, b) => a.path.localeCompare(b.path));
+  const seen = new Set<string>();
+
+  for (const record of sorted) {
+    if (seen.has(record.path)) {
+      errors.push(`${record.path}: duplicate flattened path`);
+      continue;
+    }
+    seen.add(record.path);
+
+    const segments = record.path.split("/");
+    for (let index = 1; index < segments.length; index += 1) {
+      const prefix = segments.slice(0, index).join("/");
+      if (seen.has(prefix)) {
+        errors.push(`${record.path}: conflicts with leaf path "${prefix}"`);
+      }
+    }
+  }
+}
+
+function validateTemplateReferences(
+  records: NormalizedRecord[],
+  paths: Set<string>,
+  errors: string[]
+): void {
+  const graph = new Map<string, string[]>();
+
+  for (const record of records) {
+    if (record.kind !== "config") continue;
+
+    const references = [
+      ...extractTemplateReferences(record.value),
+      ...extractTemplateReferences(record.default),
+      ...Object.values(record.values ?? {}).flatMap((value) => extractTemplateReferences(value))
+    ];
+
+    for (const reference of references) {
+      if (!paths.has(reference)) {
+        errors.push(`${record.path}: template references unknown key "${reference}"`);
+      }
+    }
+
+    graph.set(record.path, references.filter((reference) => paths.has(reference)));
+  }
+
+  const visiting = new Set<string>();
+  const visited = new Set<string>();
+  const stack: string[] = [];
+
+  const visit = (path: string): void => {
+    if (visited.has(path)) return;
+    if (visiting.has(path)) {
+      const cycleStart = stack.indexOf(path);
+      const cycle = [...stack.slice(cycleStart), path].join(" -> ");
+      errors.push(`template cycle detected: ${cycle}`);
+      return;
+    }
+
+    visiting.add(path);
+    stack.push(path);
+    for (const dependency of graph.get(path) ?? []) {
+      visit(dependency);
+    }
+    stack.pop();
+    visiting.delete(path);
+    visited.add(path);
+  };
+
+  for (const path of graph.keys()) {
+    visit(path);
+  }
+}
+
+function extractTemplateReferences(value: unknown): string[] {
+  if (typeof value !== "string") return [];
+
+  const references: string[] = [];
+  TEMPLATE_RE.lastIndex = 0;
+  for (const match of value.matchAll(TEMPLATE_RE)) {
+    references.push(match[1].trim());
+  }
+  return references;
+}
+
+function checkUnique(label: string, values: readonly string[], errors: string[]): void {
+  const seen = new Set<string>();
+  for (const value of values) {
+    if (seen.has(value)) {
+      errors.push(`${label}: duplicate "${value}"`);
+    }
+    seen.add(value);
+  }
+}
+
+function copyDefinedRecord<T>(values: Partial<Record<string, T>> | undefined): Record<string, T> | undefined {
+  if (values === undefined) return undefined;
+
+  const copy: Record<string, T> = {};
+  for (const [key, value] of Object.entries(values)) {
+    if (value !== undefined) {
+      copy[key] = value;
+    }
+  }
+  return copy;
+}
+
+function isScalar(value: unknown): value is ConfigBinding {
+  return typeof value === "string" || typeof value === "number" || typeof value === "boolean";
+}
+
+function isConfigRecord(value: unknown): value is ConfigRecord {
+  return (
+    value != null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    (value as { __kind?: unknown }).__kind === "config"
+  );
+}
+
+function isSecretRecord(value: unknown): value is SecretRecord {
+  return (
+    value != null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    (value as { __kind?: unknown }).__kind === "secret"
+  );
+}
+
+export function isProviderRef(value: unknown): value is BuiltinProviderRef {
+  return (
+    value != null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    typeof (value as { __kind?: unknown }).__kind === "string" &&
+    (value as { __kind: string }).__kind.startsWith("provider:")
+  );
+}

--- a/packages/cli/src/v5/config/schema.ts
+++ b/packages/cli/src/v5/config/schema.ts
@@ -12,7 +12,6 @@ import type {
 
 const PATH_SEGMENT_RE = /^[A-Za-z_][A-Za-z0-9_-]*$/;
 const TEMPLATE_RE = /(?<!\$)\$\{([^}]+)\}/g;
-const CONFIG_SCALAR_TYPES = new Set(["string", "number", "boolean"]);
 
 const configScalarSchema = z.union([z.string(), z.number(), z.boolean()]);
 
@@ -276,7 +275,9 @@ function flattenKeyNode(
 ): NormalizedRecord[] {
   if (isConfigRecord(value)) return [normalizeConfigRecord(path, value)];
   if (isSecretRecord(value)) return [normalizeSecretRecord(path, value)];
-  if (isScalar(value)) return [normalizeScalarRecord(path, value)];
+
+  const scalar = configScalarSchema.safeParse(value);
+  if (scalar.success) return [normalizeScalarRecord(path, scalar.data)];
 
   if (!isNamespace(value)) {
     errors.push(`${path}: expected scalar, config(...), secret(...), or namespace object`);
@@ -471,10 +472,6 @@ function copyDefinedRecord<T>(
     }
   }
   return copy;
-}
-
-function isScalar(value: unknown): value is ConfigBinding {
-  return CONFIG_SCALAR_TYPES.has(typeof value);
 }
 
 function isNamespace(value: unknown): value is KeyNamespace {

--- a/packages/cli/src/v5/config/schema.ts
+++ b/packages/cli/src/v5/config/schema.ts
@@ -103,6 +103,9 @@ const keyNodeSchema: z.ZodType<KeyNode> = z.lazy(() =>
     secretRecordSchema,
     z
       .record(z.string(), keyNodeSchema)
+      .refine((value) => Object.keys(value).length > 0, {
+        message: "key namespaces must not be empty"
+      })
       .refine((value) => !Object.hasOwn(value, "__kind"), {
         message: "factory objects with __kind must match their declared schema"
       })
@@ -114,7 +117,9 @@ const keyshelfConfigSchema = z
     __kind: z.literal("keyshelf:config"),
     envs: z.array(z.string().min(1)).nonempty(),
     groups: z.array(z.string().min(1)).optional(),
-    keys: z.record(z.string(), keyNodeSchema)
+    keys: z.record(z.string(), keyNodeSchema).refine((value) => Object.keys(value).length > 0, {
+      message: "keys must contain at least one entry"
+    })
   })
   .strict();
 

--- a/packages/cli/src/v5/config/schema.ts
+++ b/packages/cli/src/v5/config/schema.ts
@@ -167,7 +167,9 @@ export function normalizeConfig(input: unknown): NormalizedConfig {
   validateTemplateReferences(flattened, paths, errors);
 
   if (errors.length > 0) {
-    throw new Error(`Invalid keyshelf.config.ts:\n${errors.map((error) => `- ${error}`).join("\n")}`);
+    throw new Error(
+      `Invalid keyshelf.config.ts:\n${errors.map((error) => `- ${error}`).join("\n")}`
+    );
   }
 
   return {
@@ -198,7 +200,11 @@ export function validateAppMappingReferences(
   }
 }
 
-function flattenKeyTree(tree: KeyTree, errors: string[], prefix: string[] = []): NormalizedRecord[] {
+function flattenKeyTree(
+  tree: KeyTree,
+  errors: string[],
+  prefix: string[] = []
+): NormalizedRecord[] {
   const records: NormalizedRecord[] = [];
   const seen = new Set<string>();
 
@@ -315,7 +321,10 @@ function validateTemplateReferences(
       }
     }
 
-    graph.set(record.path, references.filter((reference) => paths.has(reference)));
+    graph.set(
+      record.path,
+      references.filter((reference) => paths.has(reference))
+    );
   }
 
   const visiting = new Set<string>();
@@ -367,7 +376,9 @@ function checkUnique(label: string, values: readonly string[], errors: string[])
   }
 }
 
-function copyDefinedRecord<T>(values: Partial<Record<string, T>> | undefined): Record<string, T> | undefined {
+function copyDefinedRecord<T>(
+  values: Partial<Record<string, T>> | undefined
+): Record<string, T> | undefined {
   if (values === undefined) return undefined;
 
   const copy: Record<string, T> = {};

--- a/packages/cli/src/v5/config/types.ts
+++ b/packages/cli/src/v5/config/types.ts
@@ -34,15 +34,19 @@ export interface BaseRecord<GroupName extends string = string> {
   description?: string;
 }
 
-export interface ConfigRecordInput<EnvName extends string = string, GroupName extends string = string>
-  extends BaseRecord<GroupName> {
+export interface ConfigRecordInput<
+  EnvName extends string = string,
+  GroupName extends string = string
+> extends BaseRecord<GroupName> {
   value?: ConfigBinding;
   default?: ConfigBinding;
   values?: Partial<Record<EnvName, ConfigBinding>>;
 }
 
-export interface SecretRecordInput<EnvName extends string = string, GroupName extends string = string>
-  extends BaseRecord<GroupName> {
+export interface SecretRecordInput<
+  EnvName extends string = string,
+  GroupName extends string = string
+> extends BaseRecord<GroupName> {
   value?: BuiltinProviderRef;
   default?: BuiltinProviderRef;
   values?: Partial<Record<EnvName, BuiltinProviderRef>>;

--- a/packages/cli/src/v5/config/types.ts
+++ b/packages/cli/src/v5/config/types.ts
@@ -1,0 +1,151 @@
+export type ConfigScalar = string | number | boolean;
+export type ConfigBinding = ConfigScalar;
+
+export interface ProviderRef<Name extends string = string, Options = unknown> {
+  __kind: `provider:${Name}`;
+  name: Name;
+  options: Options;
+}
+
+export interface AgeProviderOptions {
+  identityFile?: string;
+  recipient?: string;
+}
+
+export interface GcpProviderOptions {
+  project: string;
+  secret?: string;
+  version?: string;
+}
+
+export interface SopsProviderOptions {
+  file: string;
+  path?: string;
+}
+
+export type BuiltinProviderRef =
+  | ProviderRef<"age", AgeProviderOptions>
+  | ProviderRef<"gcp", GcpProviderOptions>
+  | ProviderRef<"sops", SopsProviderOptions>;
+
+export interface BaseRecord<GroupName extends string = string> {
+  group?: GroupName;
+  optional?: boolean;
+  description?: string;
+}
+
+export interface ConfigRecordInput<EnvName extends string = string, GroupName extends string = string>
+  extends BaseRecord<GroupName> {
+  value?: ConfigBinding;
+  default?: ConfigBinding;
+  values?: Partial<Record<EnvName, ConfigBinding>>;
+}
+
+export interface SecretRecordInput<EnvName extends string = string, GroupName extends string = string>
+  extends BaseRecord<GroupName> {
+  value?: BuiltinProviderRef;
+  default?: BuiltinProviderRef;
+  values?: Partial<Record<EnvName, BuiltinProviderRef>>;
+}
+
+export type ConfigRecord<
+  EnvName extends string = string,
+  GroupName extends string = string
+> = ConfigRecordInput<EnvName, GroupName> & {
+  __kind: "config";
+};
+
+export type SecretRecord<
+  EnvName extends string = string,
+  GroupName extends string = string
+> = SecretRecordInput<EnvName, GroupName> & {
+  __kind: "secret";
+};
+
+export type KeyLeaf<EnvName extends string = string, GroupName extends string = string> =
+  | ConfigScalar
+  | ConfigRecord<EnvName, GroupName>
+  | SecretRecord<EnvName, GroupName>;
+
+export type KeyTree<EnvName extends string = string, GroupName extends string = string> = {
+  readonly [key: string]: KeyLeaf<EnvName, GroupName> | KeyTree<EnvName, GroupName>;
+};
+
+export interface DefineConfigInput<
+  EnvNames extends readonly [string, ...string[]] = readonly [string, ...string[]],
+  GroupNames extends readonly string[] = readonly string[],
+  Keys extends KeyTree<EnvNames[number], GroupNames[number]> = KeyTree<
+    EnvNames[number],
+    GroupNames[number]
+  >
+> {
+  envs: EnvNames;
+  groups?: GroupNames;
+  keys: Keys;
+}
+
+type JoinPath<Prefix extends string, Key extends string> = Prefix extends ""
+  ? Key
+  : `${Prefix}/${Key}`;
+
+type SplitPath<Path extends string> = Path extends `${infer Head}/${infer Rest}`
+  ? Head extends ""
+    ? never
+    : Rest extends ""
+      ? never
+      : Path
+  : Path;
+
+export type KeyPaths<Tree, Prefix extends string = ""> = Tree extends ConfigRecord | SecretRecord
+  ? Prefix
+  : Tree extends ConfigScalar
+    ? Prefix
+    : Tree extends object
+      ? {
+          [Key in keyof Tree & string]: Tree[Key] extends ConfigRecord | SecretRecord | ConfigScalar
+            ? JoinPath<Prefix, SplitPath<Key>>
+            : Tree[Key] extends object
+              ? KeyPaths<Tree[Key], JoinPath<Prefix, SplitPath<Key>>>
+              : never;
+        }[keyof Tree & string]
+      : never;
+
+export interface KeyshelfConfig<
+  EnvName extends string = string,
+  GroupName extends string = string,
+  Path extends string = string
+> {
+  __kind: "keyshelf:config";
+  envs: readonly EnvName[];
+  groups?: readonly GroupName[];
+  keys: KeyTree<EnvName, GroupName>;
+  __paths?: Path;
+}
+
+export type NormalizedRecord =
+  | {
+      path: string;
+      kind: "config";
+      group?: string;
+      optional: boolean;
+      description?: string;
+      value?: ConfigBinding;
+      default?: ConfigBinding;
+      values?: Record<string, ConfigBinding>;
+    }
+  | {
+      path: string;
+      kind: "secret";
+      group?: string;
+      optional: boolean;
+      description?: string;
+      value?: BuiltinProviderRef;
+      default?: BuiltinProviderRef;
+      values?: Record<string, BuiltinProviderRef>;
+    };
+
+export interface NormalizedConfig {
+  envs: string[];
+  groups: string[];
+  keys: NormalizedRecord[];
+}

--- a/packages/cli/src/v5/index.ts
+++ b/packages/cli/src/v5/index.ts
@@ -1,1 +1,2 @@
 export { createV5Program } from "./cli/index.js";
+export * from "./config/index.js";

--- a/packages/cli/test/integration/v5-loader.test.ts
+++ b/packages/cli/test/integration/v5-loader.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { findV5RootDir, loadV5Config } from "../../src/v5/config/index.js";
+
+async function createFixture() {
+  const root = await mkdtemp(join(tmpdir(), "keyshelf-v5-loader-"));
+  await writeFile(
+    join(root, "keyshelf.config.ts"),
+    [
+      'import { age, config, defineConfig, secret } from "keyshelf/config";',
+      "",
+      "export default defineConfig({",
+      '  envs: ["dev", "production"],',
+      '  groups: ["app", "ci"],',
+      "  keys: {",
+      '    log: { level: "info" },',
+      '    "db/host": config({ group: "app", default: "localhost", values: { production: "prod-db" } }),',
+      '    "github/token": secret({ group: "ci", value: age({ identityFile: "./ci.txt" }) })',
+      "  }",
+      "});"
+    ].join("\n")
+  );
+
+  const appDir = join(root, "apps", "api");
+  await mkdir(appDir, { recursive: true });
+  await writeFile(
+    join(appDir, ".env.keyshelf"),
+    ["DB_HOST=db/host", "LOG_LEVEL=log/level", "GITHUB_TOKEN=github/token"].join("\n")
+  );
+
+  return { root, appDir };
+}
+
+describe("v5 config loader", () => {
+  it("finds a v5 root from a nested app directory", async () => {
+    const { root, appDir } = await createFixture();
+
+    expect(findV5RootDir(appDir)).toBe(root);
+  });
+
+  it("loads TypeScript config through jiti and validates app mappings", async () => {
+    const { root, appDir } = await createFixture();
+
+    const loaded = await loadV5Config(appDir);
+
+    expect(loaded.rootDir).toBe(root);
+    expect(loaded.configPath).toBe(join(root, "keyshelf.config.ts"));
+    expect(loaded.config.envs).toEqual(["dev", "production"]);
+    expect(loaded.config.groups).toEqual(["app", "ci"]);
+    expect(loaded.config.keys.map((key) => key.path)).toEqual([
+      "log/level",
+      "db/host",
+      "github/token"
+    ]);
+    expect(loaded.appMapping).toEqual([
+      { envVar: "DB_HOST", keyPath: "db/host" },
+      { envVar: "LOG_LEVEL", keyPath: "log/level" },
+      { envVar: "GITHUB_TOKEN", keyPath: "github/token" }
+    ]);
+    expect(loaded.loadTimeMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("rejects unknown .env.keyshelf references at load time", async () => {
+    const { appDir } = await createFixture();
+    await writeFile(join(appDir, ".env.keyshelf"), "DB_PASSWORD=db/password\n");
+
+    await expect(loadV5Config(appDir)).rejects.toThrow(
+      'DB_PASSWORD: references unknown key "db/password"'
+    );
+  });
+
+  it("loads an explicit mapping file and rejects a missing explicit mapping file", async () => {
+    const { root, appDir } = await createFixture();
+    const mappingFile = join(root, "app.env.keyshelf");
+    await writeFile(mappingFile, "HOST=db/host\n");
+
+    await expect(loadV5Config(appDir, { mappingFile })).resolves.toMatchObject({
+      appMapping: [{ envVar: "HOST", keyPath: "db/host" }]
+    });
+
+    await expect(loadV5Config(appDir, { mappingFile: join(root, "missing") })).rejects.toThrow(
+      "App mapping file not found"
+    );
+  });
+});

--- a/packages/cli/test/unit/v5/cli.test.ts
+++ b/packages/cli/test/unit/v5/cli.test.ts
@@ -9,12 +9,12 @@ describe("createV5Program", () => {
     expect(program.commands.map((command) => command.name())).toEqual(["status"]);
   });
 
-  it("reports phase 1 status", async () => {
+  it("reports phase 2 status", async () => {
     const log = vi.spyOn(console, "log").mockImplementation(() => {});
 
     await createV5Program().parseAsync(["node", "keyshelf-next", "status"]);
 
-    expect(log).toHaveBeenCalledWith("keyshelf v5 phase 1 scaffold is installed");
+    expect(log).toHaveBeenCalledWith("keyshelf v5 phase 2 config loader is installed");
     log.mockRestore();
   });
 });

--- a/packages/cli/test/unit/v5/config.test.ts
+++ b/packages/cli/test/unit/v5/config.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from "vitest";
+import {
+  age,
+  config,
+  defineConfig,
+  gcp,
+  normalizeConfig,
+  secret,
+  validateAppMappingReferences
+} from "../../../src/v5/config/index.js";
+
+describe("v5 config factories and validation", () => {
+  it("normalizes nested namespaces, string paths, bare scalars, config, and secrets", () => {
+    const normalized = normalizeConfig(
+      defineConfig({
+        envs: ["dev", "production"],
+        groups: ["app", "ci"],
+        keys: {
+          log: {
+            level: "info"
+          },
+          "db/host": config({
+            group: "app",
+            default: "localhost",
+            values: { production: "db.example.com" }
+          }),
+          github: {
+            token: secret({
+              group: "ci",
+              value: age({ identityFile: "./ci.txt" })
+            })
+          }
+        }
+      })
+    );
+
+    expect(normalized.keys).toEqual([
+      { path: "log/level", kind: "config", optional: false, value: "info" },
+      {
+        path: "db/host",
+        kind: "config",
+        group: "app",
+        optional: false,
+        description: undefined,
+        value: undefined,
+        default: "localhost",
+        values: { production: "db.example.com" }
+      },
+      {
+        path: "github/token",
+        kind: "secret",
+        group: "ci",
+        optional: false,
+        description: undefined,
+        value: age({ identityFile: "./ci.txt" }),
+        default: undefined,
+        values: undefined
+      }
+    ]);
+  });
+
+  it("rejects value and default on the same record", () => {
+    expect(() =>
+      normalizeConfig(
+        defineConfig({
+          envs: ["dev"],
+          keys: {
+            host: config({ value: "localhost", default: "127.0.0.1" })
+          }
+        })
+      )
+    ).toThrow("value and default are mutually exclusive");
+  });
+
+  it("rejects undeclared env values and groups", () => {
+    expect(() =>
+      normalizeConfig(
+        defineConfig({
+          envs: ["dev"],
+          groups: ["app"],
+          keys: {
+            host: config({
+              group: "ci",
+              values: { production: "db.example.com" }
+            })
+          }
+        })
+      )
+    ).toThrow(/group "ci" is not declared[\s\S]*undeclared env "production"/);
+  });
+
+  it("rejects empty secrets", () => {
+    expect(() =>
+      normalizeConfig(
+        defineConfig({
+          envs: ["dev"],
+          keys: {
+            token: secret({})
+          }
+        })
+      )
+    ).toThrow("secret requires value, default, or at least one values entry");
+  });
+
+  it("rejects invalid provider options", () => {
+    expect(() =>
+      normalizeConfig(
+        defineConfig({
+          envs: ["dev"],
+          keys: {
+            token: secret({ value: age({}) })
+          }
+        })
+      )
+    ).toThrow("age provider requires identityFile or recipient");
+  });
+
+  it("rejects duplicate flattened paths", () => {
+    expect(() =>
+      normalizeConfig(
+        defineConfig({
+          envs: ["dev"],
+          keys: {
+            db: { host: "localhost" },
+            "db/host": "127.0.0.1"
+          }
+        })
+      )
+    ).toThrow("duplicate flattened path");
+  });
+
+  it("rejects leaf paths that are namespace prefixes", () => {
+    expect(() =>
+      normalizeConfig(
+        defineConfig({
+          envs: ["dev"],
+          keys: {
+            db: "localhost",
+            "db/host": "localhost"
+          }
+        })
+      )
+    ).toThrow('conflicts with leaf path "db"');
+  });
+
+  it("rejects invalid path segments", () => {
+    expect(() =>
+      normalizeConfig(
+        defineConfig({
+          envs: ["dev"],
+          keys: {
+            "db.host": "localhost"
+          }
+        })
+      )
+    ).toThrow('invalid path segment "db.host"');
+  });
+
+  it("validates template references and cycles", () => {
+    expect(() =>
+      normalizeConfig(
+        defineConfig({
+          envs: ["dev"],
+          keys: {
+            db: {
+              url: config({ value: "postgres://${db/missing}" })
+            }
+          }
+        })
+      )
+    ).toThrow('template references unknown key "db/missing"');
+
+    expect(() =>
+      normalizeConfig(
+        defineConfig({
+          envs: ["dev"],
+          keys: {
+            a: config({ value: "${b}" }),
+            b: config({ value: "${a}" })
+          }
+        })
+      )
+    ).toThrow("template cycle detected");
+  });
+
+  it("allows templates to reference secrets and ignores escaped template markers", () => {
+    const normalized = normalizeConfig(
+      defineConfig({
+        envs: ["dev"],
+        keys: {
+          token: secret({ value: gcp({ project: "my-project" }) }),
+          url: config({ value: "https://x.test?token=${token}&literal=$${missing}" })
+        }
+      })
+    );
+
+    expect(normalized.keys.map((key) => key.path)).toEqual(["token", "url"]);
+  });
+
+  it("validates app mapping references against flattened keys", () => {
+    const normalized = normalizeConfig(
+      defineConfig({
+        envs: ["dev"],
+        keys: {
+          db: { host: "localhost" }
+        }
+      })
+    );
+
+    expect(() =>
+      validateAppMappingReferences(
+        [{ envVar: "DB_URL", keyPaths: ["db/host", "db/password"] }],
+        normalized.keys
+      )
+    ).toThrow('DB_URL: references unknown key "db/password"');
+  });
+});

--- a/packages/cli/test/unit/v5/config.test.ts
+++ b/packages/cli/test/unit/v5/config.test.ts
@@ -102,6 +102,27 @@ describe("v5 config factories and validation", () => {
     ).toThrow("secret requires value, default, or at least one values entry");
   });
 
+  it("rejects empty key trees and namespaces", () => {
+    expect(() =>
+      normalizeConfig({
+        __kind: "keyshelf:config",
+        envs: ["dev"],
+        keys: {}
+      })
+    ).toThrow("keys must contain at least one entry");
+
+    expect(() =>
+      normalizeConfig(
+        defineConfig({
+          envs: ["dev"],
+          keys: {
+            db: {}
+          }
+        })
+      )
+    ).toThrow("key namespaces must not be empty");
+  });
+
   it("rejects invalid provider options", () => {
     expect(() =>
       normalizeConfig(

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -14,6 +14,7 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
+    "types": ["node"],
     "ignoreDeprecations": "6.0"
   },
   "include": ["src", "bin"],

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -7,5 +7,5 @@ export default defineConfig({
   bundle: false,
   clean: true,
   sourcemap: true,
-  dts: { entry: "src/index.ts" }
+  dts: { entry: ["src/index.ts", "src/v5/config/index.ts"] }
 });


### PR DESCRIPTION
## Summary
- add the v5 keyshelf/config factory API and public package export
- add jiti-based TypeScript config loading plus zod validation/normalization
- validate flattened paths, env/group references, provider refs, config templates, and .env.keyshelf references
- add focused v5 unit and integration coverage

## Verification
- npm run typecheck -w packages/cli
- npm test -w packages/cli
- npm run build -w packages/cli
- ./node_modules/.bin/tsc --module Node16 --moduleResolution Node16 --target ES2022 --noEmit --types node --skipLibCheck examples/*.config.ts
- jiti load bench on examples/07-full.config.ts: 11 keys in 8.9ms