### PR TITLE
refactor(v5): type validateAppMappingReferences with AppMapping union

### DIFF
--- a/packages/cli/src/v5/config/schema.ts
+++ b/packages/cli/src/v5/config/schema.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { isTemplateMapping, type AppMapping } from "../../config/app-mapping.js";
 import type {
   BuiltinProviderRef,
   ConfigBinding,
@@ -160,14 +161,14 @@ export function normalizeConfig(input: unknown): NormalizedConfig {
 }
 
 export function validateAppMappingReferences(
-  mappings: Array<{ envVar: string; keyPath?: string; keyPaths?: string[] }>,
+  mappings: AppMapping[],
   flattenedKeys: NormalizedRecord[]
 ): void {
   const paths = new Set(flattenedKeys.map((record) => record.path));
   const errors: string[] = [];
 
   for (const mapping of mappings) {
-    const references = mapping.keyPaths ?? (mapping.keyPath !== undefined ? [mapping.keyPath] : []);
+    const references = isTemplateMapping(mapping) ? mapping.keyPaths : [mapping.keyPath];
     for (const reference of references) {
       if (!paths.has(reference)) {
         errors.push(`${mapping.envVar}: references unknown key "${reference}"`);

--- a/packages/cli/test/unit/v5/config.test.ts
+++ b/packages/cli/test/unit/v5/config.test.ts
@@ -230,9 +230,22 @@ describe("v5 config factories and validation", () => {
 
     expect(() =>
       validateAppMappingReferences(
-        [{ envVar: "DB_URL", keyPaths: ["db/host", "db/password"] }],
+        [
+          {
+            envVar: "DB_URL",
+            template: "postgres://${db/host}/${db/password}",
+            keyPaths: ["db/host", "db/password"]
+          }
+        ],
         normalized.keys
       )
     ).toThrow('DB_URL: references unknown key "db/password"');
+
+    expect(() =>
+      validateAppMappingReferences(
+        [{ envVar: "DB_PASSWORD", keyPath: "db/password" }],
+        normalized.keys
+      )
+    ).toThrow('DB_PASSWORD: references unknown key "db/password"');
   });
 });


### PR DESCRIPTION
## Summary

`validateAppMappingReferences` in the v5 schema took a duck-typed shape (`Array<{ envVar; keyPath?; keyPaths? }>`) instead of the real `AppMapping` union that the loader already produces. That hid the fact that `keyPath` and `keyPaths` are mutually exclusive (one per discriminated branch) and would silently accept structurally compatible garbage from anywhere.

This PR:
- imports `AppMapping` and `isTemplateMapping` from `src/config/app-mapping.ts` and uses them in the v5 validator
- switches the per-mapping reference extraction from a `??` fallback to a real type guard
- updates the unit test to pass a proper `TemplateMapping` (with `template`) and adds a `DirectMapping` case so both branches are exercised

Addresses item 2 from the PR review on #82 (#79 / #80 / #82 follow-up).

## Test plan
- [x] \`npm run typecheck -w packages/cli\`
- [x] \`npm test -w packages/cli\` — 232 passing, 4 skipped (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)