### PR TITLE
refactor(v5): collapse value/default alias at normalize time

### DIFF
--- a/packages/cli/src/v5/config/schema.ts
+++ b/packages/cli/src/v5/config/schema.ts
@@ -190,16 +190,9 @@ function validateRecords(
   const groupSet = new Set(groups);
 
   for (const record of records) {
-    validateRecordValue(record, errors);
     validateRecordGroup(record, groups, groupSet, errors);
     validateRecordValues(record, envSet, errors);
     validateSecretValue(record, errors);
-  }
-}
-
-function validateRecordValue(record: NormalizedRecord, errors: string[]): void {
-  if (record.value !== undefined && record.default !== undefined) {
-    errors.push(`${record.path}: value and default are mutually exclusive`);
   }
 }
 
@@ -231,7 +224,7 @@ function validateSecretValue(record: NormalizedRecord, errors: string[]): void {
   if (record.kind !== "secret") return;
 
   const hasValues = record.values !== undefined && Object.keys(record.values).length > 0;
-  if (record.value === undefined && record.default === undefined && !hasValues) {
+  if (record.value === undefined && !hasValues) {
     errors.push(`${record.path}: secret requires value, default, or at least one values entry`);
   }
 }
@@ -273,8 +266,8 @@ function flattenKeyNode(
   fullParts: string[],
   errors: string[]
 ): NormalizedRecord[] {
-  if (isConfigRecord(value)) return [normalizeConfigRecord(path, value)];
-  if (isSecretRecord(value)) return [normalizeSecretRecord(path, value)];
+  if (isConfigRecord(value)) return [normalizeConfigRecord(path, value, errors)];
+  if (isSecretRecord(value)) return [normalizeSecretRecord(path, value, errors)];
 
   const scalar = configScalarSchema.safeParse(value);
   if (scalar.success) return [normalizeScalarRecord(path, scalar.data)];
@@ -282,30 +275,48 @@ function flattenKeyNode(
   return flattenKeyTree(value as KeyTree, errors, fullParts);
 }
 
-function normalizeConfigRecord(path: string, value: ConfigRecord): NormalizedRecord {
+function normalizeConfigRecord(
+  path: string,
+  input: ConfigRecord,
+  errors: string[]
+): NormalizedRecord {
   return {
     path,
     kind: "config",
-    group: value.group,
-    optional: value.optional ?? false,
-    description: value.description,
-    value: value.value,
-    default: value.default,
-    values: copyDefinedRecord(value.values)
+    group: input.group,
+    optional: input.optional ?? false,
+    description: input.description,
+    value: resolveBinding(path, input.value, input.default, errors),
+    values: copyDefinedRecord(input.values)
   };
 }
 
-function normalizeSecretRecord(path: string, value: SecretRecord): NormalizedRecord {
+function normalizeSecretRecord(
+  path: string,
+  input: SecretRecord,
+  errors: string[]
+): NormalizedRecord {
   return {
     path,
     kind: "secret",
-    group: value.group,
-    optional: value.optional ?? false,
-    description: value.description,
-    value: value.value,
-    default: value.default,
-    values: copyDefinedRecord(value.values)
+    group: input.group,
+    optional: input.optional ?? false,
+    description: input.description,
+    value: resolveBinding(path, input.value, input.default, errors),
+    values: copyDefinedRecord(input.values)
   };
+}
+
+function resolveBinding<T>(
+  path: string,
+  value: T | undefined,
+  fallback: T | undefined,
+  errors: string[]
+): T | undefined {
+  if (value !== undefined && fallback !== undefined) {
+    errors.push(`${path}: value and default are mutually exclusive`);
+  }
+  return value ?? fallback;
 }
 
 function normalizeScalarRecord(path: string, value: ConfigBinding): NormalizedRecord {
@@ -389,7 +400,6 @@ function validateTemplateRecord(
 function getTemplateReferences(record: Extract<NormalizedRecord, { kind: "config" }>): string[] {
   return [
     ...extractTemplateReferences(record.value),
-    ...extractTemplateReferences(record.default),
     ...Object.values(record.values ?? {}).flatMap((value) => extractTemplateReferences(value))
   ];
 }

--- a/packages/cli/src/v5/config/types.ts
+++ b/packages/cli/src/v5/config/types.ts
@@ -134,7 +134,6 @@ export type NormalizedRecord =
       optional: boolean;
       description?: string;
       value?: ConfigBinding;
-      default?: ConfigBinding;
       values?: Record<string, ConfigBinding>;
     }
   | {
@@ -144,7 +143,6 @@ export type NormalizedRecord =
       optional: boolean;
       description?: string;
       value?: BuiltinProviderRef;
-      default?: BuiltinProviderRef;
       values?: Record<string, BuiltinProviderRef>;
     };
 

--- a/packages/cli/test/unit/v5/config.test.ts
+++ b/packages/cli/test/unit/v5/config.test.ts
@@ -42,8 +42,7 @@ describe("v5 config factories and validation", () => {
         group: "app",
         optional: false,
         description: undefined,
-        value: undefined,
-        default: "localhost",
+        value: "localhost",
         values: { production: "db.example.com" }
       },
       {
@@ -53,7 +52,6 @@ describe("v5 config factories and validation", () => {
         optional: false,
         description: undefined,
         value: age({ identityFile: "./ci.txt" }),
-        default: undefined,
         values: undefined
       }
     ]);


### PR DESCRIPTION
## Summary

Phase 2 of #78 left both `value` and `default` on `NormalizedRecord` and the spec-defined alias unresolved, leaving every downstream consumer (Phase 3 resolver, `ls`, `set`, …) responsible for `value ?? default` fallbacks. This collapses the alias at normalize time so the rest of the pipeline sees one canonical field.

- `types.ts` — drop `default` from both `NormalizedRecord` variants.
- `schema.ts` — `normalizeConfigRecord` / `normalizeSecretRecord` now route the binding through a `resolveBinding(path, value, fallback, errors)` helper that emits the existing `value and default are mutually exclusive` error and returns `value ?? fallback`.
- The post-normalization `validateRecordValue` pass is gone (the check operates on the input shape, in the normalizer where both fields still exist).
- `validateSecretValue` and `getTemplateReferences` updated to read only `record.value`.
- Test for the canonical normalized shape updated: `db/host` now reports `value: \"localhost\"` instead of `value: undefined, default: \"localhost\"`. Mutex test untouched (error message is unchanged).

## Test plan

- [x] `npm run typecheck -w packages/cli`
- [x] `npm test -w packages/cli` — 232 passed, 4 skipped
- [x] `npm run build -w packages/cli`

🤖 Generated with [Claude Code](https://claude.com/claude-code)