### PR TITLE
refactor(v5): hoist jiti instance to module scope

### DIFF
--- a/packages/cli/src/v5/config/loader.ts
+++ b/packages/cli/src/v5/config/loader.ts
@@ -3,13 +3,27 @@ import { readFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { performance } from "node:perf_hooks";
-import { createJiti } from "jiti";
+import { createJiti, type Jiti } from "jiti";
 import { parseAppMapping, type AppMapping } from "../../config/app-mapping.js";
 import { normalizeConfig, validateAppMappingReferences } from "./schema.js";
 import type { KeyshelfConfig, NormalizedConfig } from "./types.js";
 
 const CONFIG_FILE = "keyshelf.config.ts";
 const APP_MAPPING_FILE = ".env.keyshelf";
+
+let cachedJiti: Jiti | undefined;
+
+function getJiti(): Jiti {
+  if (cachedJiti === undefined) {
+    const configModulePath = fileURLToPath(new URL("./index.js", import.meta.url));
+    cachedJiti = createJiti(import.meta.url, {
+      alias: {
+        "keyshelf/config": configModulePath
+      }
+    });
+  }
+  return cachedJiti;
+}
 
 export interface LoadedV5Config {
   rootDir: string;
@@ -70,13 +84,7 @@ export async function loadV5Config(
 }
 
 async function importConfig(configPath: string): Promise<KeyshelfConfig> {
-  const configModulePath = fileURLToPath(new URL("./index.js", import.meta.url));
-  const jiti = createJiti(import.meta.url, {
-    alias: {
-      "keyshelf/config": configModulePath
-    }
-  });
-  return await jiti.import<KeyshelfConfig>(configPath, { default: true });
+  return await getJiti().import<KeyshelfConfig>(configPath, { default: true });
 }
 
 async function loadAppMapping(mappingPath: string, required: boolean): Promise<AppMapping[]> {


### PR DESCRIPTION
## Summary
- cache a single jiti instance lazily across `loadV5Config` calls instead of constructing one per invocation
- repeated loads (tests, future resolver passes) reuse the same TS loader and module cache

Follow-up to review feedback on #82. Addresses item 4 from the Phase 2 review.

## Test plan
- [x] `npm run typecheck -w packages/cli`
- [x] `npm test -w packages/cli` — 232 passed / 4 skipped, including `test/integration/v5-loader.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)