### PR TITLE
chore(v5): address phase 2 review follow-ups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
 
       - run: npm run typecheck
 
+      - run: npm run typecheck:examples
+
       - run: npm test
 
   release-please:

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "types": [],
+    "ignoreDeprecations": "6.0"
+  },
+  "include": ["*.config.ts"]
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "lint": "eslint .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "typecheck": "npm run typecheck --workspaces --if-present"
+    "typecheck": "npm run typecheck --workspaces --if-present",
+    "typecheck:examples": "npm run build -w keyshelf && tsc -p examples"
   },
   "license": "MIT",
   "engines": {

--- a/packages/cli/src/v5/config/loader.ts
+++ b/packages/cli/src/v5/config/loader.ts
@@ -70,6 +70,12 @@ export async function loadV5Config(
 }
 
 async function importConfig(configPath: string): Promise<KeyshelfConfig> {
+  // Pin `keyshelf/config` to the running CLI build. If we let jiti resolve via
+  // node_modules, a user with a different keyshelf version installed would get
+  // factories whose `__kind` literals are produced by *that* package's source.
+  // The discriminated unions in schema.ts match by string equality, so values
+  // would parse — until the schemas drift. This alias keeps factory output and
+  // validators in lockstep regardless of what's installed.
   const configModulePath = fileURLToPath(new URL("./index.js", import.meta.url));
   const jiti = createJiti(import.meta.url, {
     alias: {

--- a/packages/cli/src/v5/config/schema.ts
+++ b/packages/cli/src/v5/config/schema.ts
@@ -243,29 +243,16 @@ function flattenKeyTree(
   prefix: string[] = []
 ): NormalizedRecord[] {
   const records: NormalizedRecord[] = [];
-  const seen = new Set<string>();
 
   for (const [rawKey, value] of Object.entries(tree)) {
     const fullParts = [...prefix, ...rawKey.split("/")];
     const path = fullParts.join("/");
-
-    if (hasSeenPath(path, seen, errors)) continue;
 
     validatePathParts(fullParts, errors);
     records.push(...flattenKeyNode(value, path, fullParts, errors));
   }
 
   return records;
-}
-
-function hasSeenPath(path: string, seen: Set<string>, errors: string[]): boolean {
-  if (seen.has(path)) {
-    errors.push(`${path}: duplicate flattened path`);
-    return true;
-  }
-
-  seen.add(path);
-  return false;
 }
 
 function flattenKeyNode(

--- a/packages/cli/src/v5/config/types.ts
+++ b/packages/cli/src/v5/config/types.ts
@@ -123,6 +123,9 @@ export interface KeyshelfConfig<
   envs: readonly EnvName[];
   groups?: readonly GroupName[];
   keys: KeyTree<EnvName, GroupName>;
+  // Phantom: carries the inferred union of flattened key paths for callers
+  // that index into `KeyshelfConfig<...>["__paths"]`. Never set at runtime —
+  // strict() parsing would reject it — and `defineConfig` does not assign it.
   __paths?: Path;
 }
 


### PR DESCRIPTION
## Summary

Addresses four review notes from the Phase 2 config loader review.

- **Dead code removal** (`schema.ts`): drop `hasSeenPath` and the local `seen` set in `flattenKeyTree`. JS object literals can't have duplicate sibling keys, so this check never fires; cross-recursion duplicates are caught by `validatePathConflicts`.
- **Comment the jiti alias** (`loader.ts`): explain why `keyshelf/config` is pinned to the running CLI build — the schema's `__kind` discriminants match by string equality, so factories from a different installed keyshelf version would silently parse until the schemas drift.
- **Comment the phantom field** (`types.ts`): document that `KeyshelfConfig.__paths` is type-only, never set at runtime, and would be rejected by `strict()` parsing if anyone tried.
- **`typecheck:examples` + CI**: add `examples/tsconfig.json` and a root `npm run typecheck:examples` script that builds keyshelf first (the package's `exports` resolve into `dist/`). Wired into `ci.yml` so drift between the published types and the example configs is caught.

The fifth review note (escape-marker test coverage) was a false positive: the existing test asserts on `normalizeConfig`'s output, and `normalizeConfig` throws on unknown template references — so an escape-regex regression would surface as a test failure. No change needed.

## Test plan

- [x] `npm run build -w keyshelf`
- [x] `npm run typecheck:examples`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm test -w keyshelf` (232 passed, 4 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)