### PR TITLE
feat(v5): Implement v5 phase 3 resolver

### DIFF
--- a/packages/cli/src/v5/index.ts
+++ b/packages/cli/src/v5/index.ts
@@ -1,2 +1,4 @@
 export { createV5Program } from "./cli/index.js";
 export * from "./config/index.js";
+export * from "./resolver/index.js";
+export type * from "./resolver/types.js";

--- a/packages/cli/src/v5/resolver/index.ts
+++ b/packages/cli/src/v5/resolver/index.ts
@@ -1,0 +1,401 @@
+import { isTemplateMapping, type AppMapping } from "../../config/app-mapping.js";
+import type { ProviderRegistry } from "../../providers/registry.js";
+import type {
+  BuiltinProviderRef,
+  ConfigBinding,
+  NormalizedConfig,
+  NormalizedRecord
+} from "../config/types.js";
+import type {
+  RenderedV5EnvVar,
+  ResolvedV5Key,
+  SelectedV5Record,
+  V5KeyResolutionStatus,
+  V5Resolution,
+  V5ValidationError
+} from "./types.js";
+
+const TEMPLATE_RE = /(?<!\$)\$\{([^}]+)\}/g;
+const ESCAPED_TEMPLATE_RE = /\$\$\{/g;
+
+export interface ResolveV5Options {
+  config: NormalizedConfig;
+  envName?: string;
+  rootDir: string;
+  registry: ProviderRegistry;
+  groups?: string[];
+  filters?: string[];
+}
+
+export async function resolve(options: ResolveV5Options): Promise<ResolvedV5Key[]> {
+  return (await resolveWithStatus(options)).resolved;
+}
+
+export async function validate(options: ResolveV5Options): Promise<V5ValidationError[]> {
+  const resolution = await resolveWithStatus(options);
+
+  return resolution.statuses
+    .filter((status): status is Extract<V5KeyResolutionStatus, { status: "error" }> => {
+      return status.status === "error";
+    })
+    .map((status) => ({
+      path: status.path,
+      message: status.message,
+      error: status.error
+    }));
+}
+
+export async function resolveWithStatus(options: ResolveV5Options): Promise<V5Resolution> {
+  assertValidEnv(options);
+  const selected = selectRecords(options.config, options.groups, options.filters);
+  assertEnvProvidedWhenRequired(selected, options.envName);
+
+  const selectedByPath = new Map(
+    selected
+      .filter((entry) => entry.selected)
+      .map((entry) => [entry.record.path, entry.record] as const)
+  );
+  const statusByPath = new Map<string, V5KeyResolutionStatus>();
+  const resolving = new Set<string>();
+
+  for (const entry of selected) {
+    if (!entry.selected) {
+      statusByPath.set(entry.record.path, {
+        path: entry.record.path,
+        status: "filtered",
+        reason: entry.reason ?? "filtered out"
+      });
+    }
+  }
+
+  async function resolveRecord(path: string): Promise<V5KeyResolutionStatus> {
+    const existing = statusByPath.get(path);
+    if (existing !== undefined) return existing;
+
+    const record = selectedByPath.get(path);
+    if (record === undefined) {
+      return {
+        path,
+        status: "filtered",
+        reason: `referenced key '${path}' is filtered out`
+      };
+    }
+
+    if (resolving.has(path)) {
+      return toErrorStatus(path, new Error(`template cycle detected while resolving "${path}"`));
+    }
+
+    resolving.add(path);
+    const status = await resolveSelectedRecord(record, options, resolveRecord);
+    resolving.delete(path);
+    statusByPath.set(path, status);
+    return status;
+  }
+
+  for (const entry of selected) {
+    if (entry.selected) {
+      await resolveRecord(entry.record.path);
+    }
+  }
+
+  const statuses = selected.map((entry) => statusByPath.get(entry.record.path)).filter(isDefined);
+  const resolved = statuses
+    .filter((status): status is Extract<V5KeyResolutionStatus, { status: "resolved" }> => {
+      return status.status === "resolved";
+    })
+    .map((status) => ({ path: status.path, value: status.value }));
+
+  return { statuses, resolved, statusByPath };
+}
+
+export function renderAppMapping(
+  mappings: AppMapping[],
+  resolution: V5Resolution
+): RenderedV5EnvVar[] {
+  const resolvedMap = new Map(resolution.resolved.map((key) => [key.path, key.value]));
+
+  return mappings.map((mapping) => {
+    if (isTemplateMapping(mapping)) {
+      for (const keyPath of mapping.keyPaths) {
+        if (!resolvedMap.has(keyPath)) {
+          return skippedEnvVar(mapping.envVar, mapping, keyPath, resolution);
+        }
+      }
+
+      return {
+        envVar: mapping.envVar,
+        status: "rendered",
+        value: renderTemplate(mapping.template, resolvedMap),
+        mapping
+      };
+    }
+
+    const value = resolvedMap.get(mapping.keyPath);
+    if (value === undefined) {
+      return skippedEnvVar(mapping.envVar, mapping, mapping.keyPath, resolution);
+    }
+
+    return {
+      envVar: mapping.envVar,
+      status: "rendered",
+      value,
+      mapping
+    };
+  });
+}
+
+function selectRecords(
+  config: NormalizedConfig,
+  groups: string[] | undefined,
+  filters: string[] | undefined
+): SelectedV5Record[] {
+  const groupSet = normalizeGroupFilter(config, groups);
+  const pathPrefixes = normalizePathFilters(filters);
+
+  return config.keys.map((record) => {
+    const groupReason = getGroupFilterReason(record, groupSet);
+    if (groupReason !== undefined) return { record, selected: false, reason: groupReason };
+
+    const filterReason = getPathFilterReason(record, pathPrefixes);
+    if (filterReason !== undefined) return { record, selected: false, reason: filterReason };
+
+    return { record, selected: true };
+  });
+}
+
+function normalizeGroupFilter(config: NormalizedConfig, groups: string[] | undefined): Set<string> {
+  const groupNames = [...new Set(groups ?? [])];
+  if (groupNames.length === 0) return new Set();
+  if (config.groups.length === 0) {
+    throw new Error("--group cannot be used because this config declares no groups");
+  }
+
+  const declaredGroups = new Set(config.groups);
+  for (const group of groupNames) {
+    if (!declaredGroups.has(group)) {
+      throw new Error(`Unknown group "${group}"`);
+    }
+  }
+
+  return new Set(groupNames);
+}
+
+function normalizePathFilters(filters: string[] | undefined): string[] {
+  return [...new Set(filters ?? [])].filter((filter) => filter.length > 0);
+}
+
+function getGroupFilterReason(record: NormalizedRecord, groupSet: Set<string>): string | undefined {
+  if (groupSet.size === 0) return undefined;
+  if (record.group === undefined) return undefined;
+  if (groupSet.has(record.group)) return undefined;
+  return `referenced key '${record.path}' is filtered out`;
+}
+
+function getPathFilterReason(record: NormalizedRecord, prefixes: string[]): string | undefined {
+  if (prefixes.length === 0) return undefined;
+  if (prefixes.some((prefix) => matchesPathPrefix(record.path, prefix))) return undefined;
+  return `referenced key '${record.path}' is filtered out`;
+}
+
+function matchesPathPrefix(path: string, prefix: string): boolean {
+  return path === prefix || path.startsWith(`${prefix}/`);
+}
+
+function assertValidEnv(options: ResolveV5Options): void {
+  if (options.envName === undefined) return;
+  if (options.config.envs.includes(options.envName)) return;
+  throw new Error(`Unknown env "${options.envName}"`);
+}
+
+function assertEnvProvidedWhenRequired(
+  selected: SelectedV5Record[],
+  envName: string | undefined
+): void {
+  if (envName !== undefined) return;
+
+  const envScopedRecord = selected
+    .filter((entry) => entry.selected)
+    .map((entry) => entry.record)
+    .find((record) => hasValuesWithoutFallback(record));
+
+  if (envScopedRecord !== undefined) {
+    throw new Error(
+      `--env is required because selected key "${envScopedRecord.path}" has env-specific values and no fallback`
+    );
+  }
+}
+
+function hasValuesWithoutFallback(record: NormalizedRecord): boolean {
+  return record.value === undefined && Object.keys(record.values ?? {}).length > 0;
+}
+
+async function resolveSelectedRecord(
+  record: NormalizedRecord,
+  options: ResolveV5Options,
+  resolveRecord: (path: string) => Promise<V5KeyResolutionStatus>
+): Promise<V5KeyResolutionStatus> {
+  const binding = getActiveBinding(record, options.envName);
+  if (binding === undefined) {
+    if (record.optional) {
+      return {
+        path: record.path,
+        status: "skipped",
+        reason: `optional key '${record.path}' has no value`
+      };
+    }
+    return toErrorStatus(record.path, new Error(`No value for required key "${record.path}"`));
+  }
+
+  try {
+    const value =
+      record.kind === "secret"
+        ? await resolveProvider(record.path, binding as BuiltinProviderRef, options)
+        : await resolveConfigBinding(record.path, binding as ConfigBinding, resolveRecord);
+    return { path: record.path, status: "resolved", value };
+  } catch (err) {
+    if (record.optional && isNotFoundError(err)) {
+      return {
+        path: record.path,
+        status: "skipped",
+        reason: `optional key '${record.path}' was not found`
+      };
+    }
+    return toErrorStatus(record.path, err);
+  }
+}
+
+function getActiveBinding(record: NormalizedRecord, envName: string | undefined): unknown {
+  if (
+    envName !== undefined &&
+    record.values !== undefined &&
+    Object.hasOwn(record.values, envName)
+  ) {
+    return record.values[envName];
+  }
+
+  return record.value;
+}
+
+async function resolveProvider(
+  keyPath: string,
+  providerRef: BuiltinProviderRef,
+  options: ResolveV5Options
+): Promise<string> {
+  const provider = options.registry.get(providerRef.name);
+  return provider.resolve({
+    keyPath,
+    envName: options.envName ?? "",
+    rootDir: options.rootDir,
+    config: { ...(providerRef.options as Record<string, unknown>) }
+  });
+}
+
+async function resolveConfigBinding(
+  path: string,
+  binding: ConfigBinding,
+  resolveRecord: (path: string) => Promise<V5KeyResolutionStatus>
+): Promise<string> {
+  if (typeof binding !== "string") return String(binding);
+  return interpolateConfigTemplate(path, binding, resolveRecord);
+}
+
+async function interpolateConfigTemplate(
+  path: string,
+  template: string,
+  resolveRecord: (path: string) => Promise<V5KeyResolutionStatus>
+): Promise<string> {
+  const replacements = new Map<string, string>();
+
+  TEMPLATE_RE.lastIndex = 0;
+  for (const match of template.matchAll(TEMPLATE_RE)) {
+    const reference = match[1].trim();
+    const status = await resolveRecord(reference);
+
+    if (status.status === "resolved") {
+      replacements.set(reference, status.value);
+      continue;
+    }
+
+    if (status.status === "filtered" || status.status === "skipped") {
+      throw new FilteredTemplateReferenceError(path, reference, status.reason);
+    }
+
+    throw new Error(`referenced key "${reference}" could not be resolved: ${status.message}`);
+  }
+
+  TEMPLATE_RE.lastIndex = 0;
+  return template
+    .replace(TEMPLATE_RE, (_, keyPath: string) => replacements.get(keyPath.trim()) ?? "")
+    .replace(ESCAPED_TEMPLATE_RE, "${");
+}
+
+function renderTemplate(template: string, resolvedMap: Map<string, string>): string {
+  TEMPLATE_RE.lastIndex = 0;
+  return template
+    .replace(TEMPLATE_RE, (_, keyPath: string) => resolvedMap.get(keyPath.trim()) ?? "")
+    .replace(ESCAPED_TEMPLATE_RE, "${");
+}
+
+function skippedEnvVar(
+  envVar: string,
+  mapping: AppMapping,
+  keyPath: string,
+  resolution: V5Resolution
+): RenderedV5EnvVar {
+  const status = resolution.statusByPath.get(keyPath);
+  return {
+    envVar,
+    status: "skipped",
+    keyPath,
+    reason: statusToSkipReason(keyPath, status),
+    mapping
+  };
+}
+
+function statusToSkipReason(
+  keyPath: string,
+  status: V5KeyResolutionStatus | undefined
+): string {
+  if (status?.status === "filtered") return `referenced key '${keyPath}' is filtered out`;
+  if (status?.status === "skipped") return `referenced key '${keyPath}' is unavailable`;
+  if (status?.status === "error") {
+    return `referenced key '${keyPath}' could not be resolved: ${status.message}`;
+  }
+  return `referenced key '${keyPath}' is unavailable`;
+}
+
+class FilteredTemplateReferenceError extends Error {
+  constructor(
+    readonly keyPath: string,
+    readonly reference: string,
+    readonly reason: string
+  ) {
+    super(`referenced key "${reference}" is unavailable for "${keyPath}": ${reason}`);
+  }
+}
+
+function toErrorStatus(path: string, err: unknown): V5KeyResolutionStatus {
+  if (err instanceof FilteredTemplateReferenceError) {
+    return {
+      path,
+      status: "skipped",
+      reason: err.reason
+    };
+  }
+
+  return {
+    path,
+    status: "error",
+    message: err instanceof Error ? err.message : String(err),
+    error: err instanceof Error ? err : undefined
+  };
+}
+
+function isNotFoundError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  return /(^|[^a-z])not[ _-]?found([^a-z]|$)|NOT_FOUND/.test(message);
+}
+
+function isDefined<T>(value: T | undefined): value is T {
+  return value !== undefined;
+}

--- a/packages/cli/src/v5/resolver/index.ts
+++ b/packages/cli/src/v5/resolver/index.ts
@@ -12,7 +12,8 @@ import type {
   SelectedV5Record,
   V5KeyResolutionStatus,
   V5Resolution,
-  V5ValidationError
+  V5TopLevelError,
+  V5ValidationResult
 } from "./types.js";
 
 const TEMPLATE_RE = /(?<!\$)\$\{([^}]+)\}/g;
@@ -31,10 +32,27 @@ export async function resolve(options: ResolveV5Options): Promise<ResolvedV5Key[
   return (await resolveWithStatus(options)).resolved;
 }
 
-export async function validate(options: ResolveV5Options): Promise<V5ValidationError[]> {
-  const resolution = await resolveWithStatus(options);
+export async function validate(options: ResolveV5Options): Promise<V5ValidationResult> {
+  const topLevelErrors: V5TopLevelError[] = [];
 
-  return resolution.statuses
+  const envError = checkValidEnv(options);
+  if (envError !== undefined) topLevelErrors.push(envError);
+
+  const groupCheck = checkGroupFilter(options.config, options.groups);
+  topLevelErrors.push(...groupCheck.errors);
+
+  if (topLevelErrors.length > 0) {
+    return { topLevelErrors, keyErrors: [] };
+  }
+
+  const selected = selectRecords(options.config, options.groups, options.filters);
+  const envRequiredError = checkEnvProvidedWhenRequired(selected, options.envName);
+  if (envRequiredError !== undefined) {
+    return { topLevelErrors: [envRequiredError], keyErrors: [] };
+  }
+
+  const resolution = await resolveWithStatus(options);
+  const keyErrors = resolution.statuses
     .filter((status): status is Extract<V5KeyResolutionStatus, { status: "error" }> => {
       return status.status === "error";
     })
@@ -43,6 +61,8 @@ export async function validate(options: ResolveV5Options): Promise<V5ValidationE
       message: status.message,
       error: status.error
     }));
+
+  return { topLevelErrors: [], keyErrors };
 }
 
 export async function resolveWithStatus(options: ResolveV5Options): Promise<V5Resolution> {
@@ -164,20 +184,34 @@ function selectRecords(
 }
 
 function normalizeGroupFilter(config: NormalizedConfig, groups: string[] | undefined): Set<string> {
+  const { errors, groupSet } = checkGroupFilter(config, groups);
+  if (errors.length > 0) throw new Error(errors[0].message);
+  return groupSet;
+}
+
+function checkGroupFilter(
+  config: NormalizedConfig,
+  groups: string[] | undefined
+): { errors: V5TopLevelError[]; groupSet: Set<string> } {
   const groupNames = [...new Set(groups ?? [])];
-  if (groupNames.length === 0) return new Set();
+  if (groupNames.length === 0) return { errors: [], groupSet: new Set() };
+
   if (config.groups.length === 0) {
-    throw new Error("--group cannot be used because this config declares no groups");
+    return {
+      errors: [{ message: "--group cannot be used because this config declares no groups" }],
+      groupSet: new Set()
+    };
   }
 
   const declaredGroups = new Set(config.groups);
+  const errors: V5TopLevelError[] = [];
   for (const group of groupNames) {
     if (!declaredGroups.has(group)) {
-      throw new Error(`Unknown group "${group}"`);
+      errors.push({ message: `Unknown group "${group}"` });
     }
   }
 
-  return new Set(groupNames);
+  return { errors, groupSet: new Set(groupNames.filter((g) => declaredGroups.has(g))) };
 }
 
 function normalizePathFilters(filters: string[] | undefined): string[] {
@@ -202,27 +236,39 @@ function matchesPathPrefix(path: string, prefix: string): boolean {
 }
 
 function assertValidEnv(options: ResolveV5Options): void {
-  if (options.envName === undefined) return;
-  if (options.config.envs.includes(options.envName)) return;
-  throw new Error(`Unknown env "${options.envName}"`);
+  const error = checkValidEnv(options);
+  if (error !== undefined) throw new Error(error.message);
+}
+
+function checkValidEnv(options: ResolveV5Options): V5TopLevelError | undefined {
+  if (options.envName === undefined) return undefined;
+  if (options.config.envs.includes(options.envName)) return undefined;
+  return { message: `Unknown env "${options.envName}"` };
 }
 
 function assertEnvProvidedWhenRequired(
   selected: SelectedV5Record[],
   envName: string | undefined
 ): void {
-  if (envName !== undefined) return;
+  const error = checkEnvProvidedWhenRequired(selected, envName);
+  if (error !== undefined) throw new Error(error.message);
+}
+
+function checkEnvProvidedWhenRequired(
+  selected: SelectedV5Record[],
+  envName: string | undefined
+): V5TopLevelError | undefined {
+  if (envName !== undefined) return undefined;
 
   const envScopedRecord = selected
     .filter((entry) => entry.selected)
     .map((entry) => entry.record)
     .find((record) => hasValuesWithoutFallback(record));
 
-  if (envScopedRecord !== undefined) {
-    throw new Error(
-      `--env is required because selected key "${envScopedRecord.path}" has env-specific values and no fallback`
-    );
-  }
+  if (envScopedRecord === undefined) return undefined;
+  return {
+    message: `--env is required because selected key "${envScopedRecord.path}" has env-specific values and no fallback`
+  };
 }
 
 function hasValuesWithoutFallback(record: NormalizedRecord): boolean {
@@ -352,10 +398,7 @@ function skippedEnvVar(
   };
 }
 
-function statusToSkipReason(
-  keyPath: string,
-  status: V5KeyResolutionStatus | undefined
-): string {
+function statusToSkipReason(keyPath: string, status: V5KeyResolutionStatus | undefined): string {
   if (status?.status === "filtered") return `referenced key '${keyPath}' is filtered out`;
   if (status?.status === "skipped") return `referenced key '${keyPath}' is unavailable`;
   if (status?.status === "error") {

--- a/packages/cli/src/v5/resolver/types.ts
+++ b/packages/cli/src/v5/resolver/types.ts
@@ -1,0 +1,63 @@
+import type { AppMapping } from "../../config/app-mapping.js";
+import type { NormalizedRecord } from "../config/types.js";
+
+export interface ResolvedV5Key {
+  path: string;
+  value: string;
+}
+
+export interface V5ValidationError {
+  path: string;
+  message: string;
+  error?: Error;
+}
+
+export type V5KeyResolutionStatus =
+  | {
+      path: string;
+      status: "resolved";
+      value: string;
+    }
+  | {
+      path: string;
+      status: "filtered";
+      reason: string;
+    }
+  | {
+      path: string;
+      status: "skipped";
+      reason: string;
+    }
+  | {
+      path: string;
+      status: "error";
+      message: string;
+      error?: Error;
+    };
+
+export interface V5Resolution {
+  statuses: V5KeyResolutionStatus[];
+  resolved: ResolvedV5Key[];
+  statusByPath: Map<string, V5KeyResolutionStatus>;
+}
+
+export type RenderedV5EnvVar =
+  | {
+      envVar: string;
+      status: "rendered";
+      value: string;
+      mapping: AppMapping;
+    }
+  | {
+      envVar: string;
+      status: "skipped";
+      reason: string;
+      keyPath: string;
+      mapping: AppMapping;
+    };
+
+export interface SelectedV5Record {
+  record: NormalizedRecord;
+  selected: boolean;
+  reason?: string;
+}

--- a/packages/cli/src/v5/resolver/types.ts
+++ b/packages/cli/src/v5/resolver/types.ts
@@ -12,6 +12,16 @@ export interface V5ValidationError {
   error?: Error;
 }
 
+export interface V5TopLevelError {
+  message: string;
+  error?: Error;
+}
+
+export interface V5ValidationResult {
+  topLevelErrors: V5TopLevelError[];
+  keyErrors: V5ValidationError[];
+}
+
 export type V5KeyResolutionStatus =
   | {
       path: string;

--- a/packages/cli/test/unit/v5/resolver.test.ts
+++ b/packages/cli/test/unit/v5/resolver.test.ts
@@ -80,19 +80,22 @@ describe("v5 resolver", () => {
       })
     );
 
-    const errors = await validate({
+    const result = await validate({
       config: normalized,
       envName: "dev",
       rootDir: "/repo",
       registry: registry()
     });
 
-    expect(errors).toMatchObject([
-      {
-        path: "required",
-        message: 'No value for required key "required"'
-      }
-    ]);
+    expect(result).toMatchObject({
+      topLevelErrors: [],
+      keyErrors: [
+        {
+          path: "required",
+          message: 'No value for required key "required"'
+        }
+      ]
+    });
 
     const resolution = await resolveWithStatus({
       config: normalized,
@@ -337,12 +340,109 @@ describe("v5 resolver", () => {
       })
     ).resolves.toEqual([]);
 
-    const errors = await validate({
+    const result = await validate({
       config: normalized,
       envName: "dev",
       rootDir: "/repo",
       registry: registry(authProvider)
     });
-    expect(errors).toMatchObject([{ path: "token", message: "auth failed" }]);
+    expect(result).toMatchObject({
+      topLevelErrors: [],
+      keyErrors: [{ path: "token", message: "auth failed" }]
+    });
+  });
+
+  it("collects unknown env, unknown groups, and missing --env as topLevelErrors", async () => {
+    const normalized = normalizeConfig(
+      defineConfig({
+        envs: ["dev", "production"],
+        groups: ["app", "ci"],
+        keys: {
+          app: config({ group: "app", value: "envless" }),
+          ci: config({ group: "ci", values: { production: "ci-prod" } })
+        }
+      })
+    );
+
+    const unknownEnv = await validate({
+      config: normalized,
+      envName: "prod",
+      rootDir: "/repo",
+      registry: registry()
+    });
+    expect(unknownEnv).toMatchObject({
+      topLevelErrors: [{ message: 'Unknown env "prod"' }],
+      keyErrors: []
+    });
+
+    const unknownGroups = await validate({
+      config: normalized,
+      groups: ["does-not-exist", "also-missing"],
+      envName: "dev",
+      rootDir: "/repo",
+      registry: registry()
+    });
+    expect(unknownGroups).toMatchObject({
+      topLevelErrors: [
+        { message: 'Unknown group "does-not-exist"' },
+        { message: 'Unknown group "also-missing"' }
+      ],
+      keyErrors: []
+    });
+
+    const groupless = normalizeConfig(defineConfig({ envs: ["dev"], keys: { app: "keyshelf" } }));
+    const groupOnGroupless = await validate({
+      config: groupless,
+      groups: ["app"],
+      envName: "dev",
+      rootDir: "/repo",
+      registry: registry()
+    });
+    expect(groupOnGroupless).toMatchObject({
+      topLevelErrors: [
+        { message: "--group cannot be used because this config declares no groups" }
+      ],
+      keyErrors: []
+    });
+
+    const envRequired = await validate({
+      config: normalized,
+      groups: ["ci"],
+      rootDir: "/repo",
+      registry: registry()
+    });
+    expect(envRequired).toMatchObject({
+      topLevelErrors: [
+        {
+          message:
+            '--env is required because selected key "ci" has env-specific values and no fallback'
+        }
+      ],
+      keyErrors: []
+    });
+  });
+
+  it("resolve still throws on top-level errors (unchanged fast-fail behavior)", async () => {
+    const normalized = normalizeConfig(
+      defineConfig({
+        envs: ["dev"],
+        groups: ["app"],
+        keys: { app: config({ group: "app", value: "k" }) }
+      })
+    );
+
+    await expect(
+      resolve({ config: normalized, envName: "prod", rootDir: "/repo", registry: registry() })
+    ).rejects.toThrow('Unknown env "prod"');
+
+    await expect(
+      resolve({
+        config: normalized,
+        groups: ["ci"],
+        envName: "dev",
+        rootDir: "/repo",
+        registry: registry()
+      })
+    ).rejects.toThrow('Unknown group "ci"');
   });
 });

--- a/packages/cli/test/unit/v5/resolver.test.ts
+++ b/packages/cli/test/unit/v5/resolver.test.ts
@@ -1,0 +1,348 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Provider } from "../../../src/providers/types.js";
+import { ProviderRegistry } from "../../../src/providers/registry.js";
+import {
+  age,
+  config,
+  defineConfig,
+  normalizeConfig,
+  renderAppMapping,
+  resolve,
+  resolveWithStatus,
+  secret,
+  validate
+} from "../../../src/v5/index.js";
+
+function mockProvider(name: string, resolveValue = "provider-value"): Provider {
+  return {
+    name,
+    resolve: vi.fn().mockResolvedValue(resolveValue),
+    validate: vi.fn().mockResolvedValue(true),
+    set: vi.fn().mockResolvedValue(undefined)
+  };
+}
+
+function registry(...providers: Provider[]): ProviderRegistry {
+  const value = new ProviderRegistry();
+  for (const provider of providers) value.register(provider);
+  return value;
+}
+
+describe("v5 resolver", () => {
+  it("resolves values by env before falling back to value/default", async () => {
+    const provider = mockProvider("age", "secret-dev");
+    const normalized = normalizeConfig(
+      defineConfig({
+        envs: ["dev", "production"],
+        keys: {
+          host: config({
+            default: "localhost",
+            values: { production: "prod-db" }
+          }),
+          port: 5432,
+          token: secret({
+            values: { dev: age({ identityFile: "./dev.txt" }) },
+            default: age({ identityFile: "./shared.txt" })
+          })
+        }
+      })
+    );
+
+    await expect(
+      resolve({
+        config: normalized,
+        envName: "dev",
+        rootDir: "/repo",
+        registry: registry(provider)
+      })
+    ).resolves.toEqual([
+      { path: "host", value: "localhost" },
+      { path: "port", value: "5432" },
+      { path: "token", value: "secret-dev" }
+    ]);
+
+    expect(provider.resolve).toHaveBeenCalledWith({
+      keyPath: "token",
+      envName: "dev",
+      rootDir: "/repo",
+      config: { identityFile: "./dev.txt" }
+    });
+  });
+
+  it("reports required missing keys and skips optional keys with no active binding", async () => {
+    const normalized = normalizeConfig(
+      defineConfig({
+        envs: ["dev", "production"],
+        keys: {
+          required: config({ values: { production: "prod" } }),
+          optional: config({ optional: true, values: { production: "prod" } })
+        }
+      })
+    );
+
+    const errors = await validate({
+      config: normalized,
+      envName: "dev",
+      rootDir: "/repo",
+      registry: registry()
+    });
+
+    expect(errors).toMatchObject([
+      {
+        path: "required",
+        message: 'No value for required key "required"'
+      }
+    ]);
+
+    const resolution = await resolveWithStatus({
+      config: normalized,
+      envName: "dev",
+      rootDir: "/repo",
+      registry: registry()
+    });
+    expect(resolution.statusByPath.get("optional")).toMatchObject({
+      status: "skipped",
+      reason: "optional key 'optional' has no value"
+    });
+  });
+
+  it("requires env only when a selected key has env-specific values without a fallback", async () => {
+    const normalized = normalizeConfig(
+      defineConfig({
+        envs: ["dev", "production"],
+        groups: ["app", "ci"],
+        keys: {
+          app: config({ group: "app", value: "envless", values: { production: "prod" } }),
+          ci: config({ group: "ci", values: { production: "ci-prod" } })
+        }
+      })
+    );
+
+    await expect(
+      resolve({
+        config: normalized,
+        groups: ["app"],
+        rootDir: "/repo",
+        registry: registry()
+      })
+    ).resolves.toEqual([{ path: "app", value: "envless" }]);
+
+    await expect(
+      resolve({
+        config: normalized,
+        groups: ["ci"],
+        rootDir: "/repo",
+        registry: registry()
+      })
+    ).rejects.toThrow('--env is required because selected key "ci"');
+  });
+
+  it("filters by group and path prefix while keeping groupless records shared", async () => {
+    const normalized = normalizeConfig(
+      defineConfig({
+        envs: ["dev"],
+        groups: ["app", "ci"],
+        keys: {
+          shared: "yes",
+          app: {
+            name: config({ group: "app", value: "keyshelf" }),
+            url: config({ group: "app", value: "https://example.test" })
+          },
+          ci: {
+            token: secret({ group: "ci", value: age({ identityFile: "./ci.txt" }) })
+          }
+        }
+      })
+    );
+
+    await expect(
+      resolve({
+        config: normalized,
+        groups: ["app"],
+        filters: ["app/name", "shared"],
+        envName: "dev",
+        rootDir: "/repo",
+        registry: registry(mockProvider("age"))
+      })
+    ).resolves.toEqual([
+      { path: "shared", value: "yes" },
+      { path: "app/name", value: "keyshelf" }
+    ]);
+  });
+
+  it("rejects unknown envs, unknown groups, and group filters on groupless configs", async () => {
+    const groupless = normalizeConfig(
+      defineConfig({
+        envs: ["dev"],
+        keys: { app: "keyshelf" }
+      })
+    );
+    const grouped = normalizeConfig(
+      defineConfig({
+        envs: ["dev"],
+        groups: ["app"],
+        keys: { app: config({ group: "app", value: "keyshelf" }) }
+      })
+    );
+
+    await expect(
+      resolve({ config: grouped, envName: "prod", rootDir: "/repo", registry: registry() })
+    ).rejects.toThrow('Unknown env "prod"');
+
+    await expect(
+      resolve({
+        config: grouped,
+        groups: ["ci"],
+        envName: "dev",
+        rootDir: "/repo",
+        registry: registry()
+      })
+    ).rejects.toThrow('Unknown group "ci"');
+
+    await expect(
+      resolve({
+        config: groupless,
+        groups: ["app"],
+        envName: "dev",
+        rootDir: "/repo",
+        registry: registry()
+      })
+    ).rejects.toThrow("--group cannot be used");
+  });
+
+  it("interpolates config templates and treats filtered references as unavailable", async () => {
+    const provider = mockProvider("age", "s3cr3t");
+    const normalized = normalizeConfig(
+      defineConfig({
+        envs: ["dev"],
+        groups: ["app", "ci"],
+        keys: {
+          db: {
+            host: config({ group: "app", value: "localhost" }),
+            password: secret({ group: "ci", value: age({ identityFile: "./ci.txt" }) }),
+            url: config({
+              group: "app",
+              value: "postgres://${db/password}@${db/host}/app"
+            })
+          }
+        }
+      })
+    );
+
+    const all = await resolve({
+      config: normalized,
+      envName: "dev",
+      rootDir: "/repo",
+      registry: registry(provider)
+    });
+    expect(all).toContainEqual({ path: "db/url", value: "postgres://s3cr3t@localhost/app" });
+
+    const appOnly = await resolveWithStatus({
+      config: normalized,
+      groups: ["app"],
+      envName: "dev",
+      rootDir: "/repo",
+      registry: registry(provider)
+    });
+    expect(appOnly.statusByPath.get("db/url")).toMatchObject({
+      status: "skipped",
+      reason: "referenced key 'db/password' is filtered out"
+    });
+  });
+
+  it("renders app mappings with per-env-var skip statuses", async () => {
+    const normalized = normalizeConfig(
+      defineConfig({
+        envs: ["dev"],
+        groups: ["app", "ci"],
+        keys: {
+          app: {
+            host: config({ group: "app", value: "localhost" }),
+            optional: config({ group: "app", optional: true })
+          },
+          ci: {
+            token: secret({ group: "ci", value: age({ identityFile: "./ci.txt" }) })
+          }
+        }
+      })
+    );
+    const resolution = await resolveWithStatus({
+      config: normalized,
+      groups: ["app"],
+      envName: "dev",
+      rootDir: "/repo",
+      registry: registry(mockProvider("age"))
+    });
+
+    expect(
+      renderAppMapping(
+        [
+          { envVar: "APP_HOST", keyPath: "app/host" },
+          { envVar: "TOKEN", keyPath: "ci/token" },
+          {
+            envVar: "COMBINED",
+            template: "${app/host}:${ci/token}",
+            keyPaths: ["app/host", "ci/token"]
+          },
+          { envVar: "OPTIONAL", keyPath: "app/optional" }
+        ],
+        resolution
+      )
+    ).toMatchObject([
+      { envVar: "APP_HOST", status: "rendered", value: "localhost" },
+      {
+        envVar: "TOKEN",
+        status: "skipped",
+        keyPath: "ci/token",
+        reason: "referenced key 'ci/token' is filtered out"
+      },
+      {
+        envVar: "COMBINED",
+        status: "skipped",
+        keyPath: "ci/token",
+        reason: "referenced key 'ci/token' is filtered out"
+      },
+      {
+        envVar: "OPTIONAL",
+        status: "skipped",
+        keyPath: "app/optional",
+        reason: "referenced key 'app/optional' is unavailable"
+      }
+    ]);
+  });
+
+  it("skips optional not-found provider errors and propagates other provider errors", async () => {
+    const notFoundProvider = mockProvider("age");
+    (notFoundProvider.resolve as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("NOT_FOUND: Secret not found")
+    );
+    const authProvider = mockProvider("age");
+    (authProvider.resolve as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("auth failed"));
+
+    const normalized = normalizeConfig(
+      defineConfig({
+        envs: ["dev"],
+        keys: {
+          token: secret({ optional: true, value: age({ identityFile: "./ci.txt" }) })
+        }
+      })
+    );
+
+    await expect(
+      resolve({
+        config: normalized,
+        envName: "dev",
+        rootDir: "/repo",
+        registry: registry(notFoundProvider)
+      })
+    ).resolves.toEqual([]);
+
+    const errors = await validate({
+      config: normalized,
+      envName: "dev",
+      rootDir: "/repo",
+      registry: registry(authProvider)
+    });
+    expect(errors).toMatchObject([{ path: "token", message: "auth failed" }]);
+  });
+});


### PR DESCRIPTION
## Summary
- add the v5 resolver with per-key resolution status, group filtering, path-prefix filtering, and conditional env requirements
- add template interpolation and app-mapping render statuses for filtered or unavailable references
- export resolver APIs from the v5 entrypoint

## Tests
- npm test -w packages/cli -- test/unit/v5/resolver.test.ts test/unit/v5/config.test.ts test/unit/v5/cli.test.ts
- npm run typecheck -w packages/cli
- npm test -w packages/cli

Closes phase 3 of #78