### PR TITLE
test(v5): cover template-ref validation across values entries

### DIFF
--- a/packages/cli/test/unit/v5/config.test.ts
+++ b/packages/cli/test/unit/v5/config.test.ts
@@ -192,10 +192,38 @@ describe("v5 config factories and validation", () => {
     expect(() =>
       normalizeConfig(
         defineConfig({
+          envs: ["dev", "production"],
+          keys: {
+            db: {
+              host: "localhost",
+              url: config({
+                values: { production: "postgres://${db/host}/${db/typo}" }
+              })
+            }
+          }
+        })
+      )
+    ).toThrow('template references unknown key "db/typo"');
+
+    expect(() =>
+      normalizeConfig(
+        defineConfig({
           envs: ["dev"],
           keys: {
             a: config({ value: "${b}" }),
             b: config({ value: "${a}" })
+          }
+        })
+      )
+    ).toThrow("template cycle detected");
+
+    expect(() =>
+      normalizeConfig(
+        defineConfig({
+          envs: ["dev", "production"],
+          keys: {
+            a: config({ values: { production: "${b}" } }),
+            b: config({ values: { production: "${a}" } })
           }
         })
       )


### PR DESCRIPTION
## Summary

Investigated PR #87 review concern about undeclared template references being conflated with filtered ones in the resolver. **The fix already exists in main** — phase 2's `validateTemplateReferences` (`packages/cli/src/v5/config/schema.ts:348`) rejects undeclared `${...}` refs at normalize time, with cycle detection. It walks both `record.value` and `record.values[*]` (`getTemplateReferences`, schema.ts:388).

The resolver's "filtered out" branch (`resolver/index.ts:67-75` in PR #87) is therefore unreachable for undeclared refs through the normal load path, because the config never normalizes successfully if a ref is undeclared.

The only real gap was test coverage: the existing test exercised refs in `value` only. This PR adds:
- Undeclared ref inside `values[<env>]` → rejected
- Cycle detection through `values[<env>]` chains

## Why a PR if the code is already there

To make the contract explicit and prevent regression. If a future refactor of `getTemplateReferences` accidentally drops the `values[*]` branch, the existing test wouldn't catch it.

## Test plan

- [x] `npm test -w packages/cli -- test/unit/v5/config.test.ts` — 12/12 pass
- [x] `npm test -w packages/cli` — 232/232 pass (4 pre-existing skips)
- [x] `npm run typecheck -w packages/cli` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)