### PR TITLE
refactor(v5): split validate result into top-level + per-key errors

### DIFF
--- a/packages/cli/src/v5/resolver/index.ts
+++ b/packages/cli/src/v5/resolver/index.ts
@@ -12,7 +12,8 @@ import type {
   SelectedV5Record,
   V5KeyResolutionStatus,
   V5Resolution,
-  V5ValidationError
+  V5TopLevelError,
+  V5ValidationResult
 } from "./types.js";
 
 const TEMPLATE_RE = /(?<!\$)\$\{([^}]+)\}/g;
@@ -31,10 +32,27 @@ export async function resolve(options: ResolveV5Options): Promise<ResolvedV5Key[
   return (await resolveWithStatus(options)).resolved;
 }
 
-export async function validate(options: ResolveV5Options): Promise<V5ValidationError[]> {
-  const resolution = await resolveWithStatus(options);
+export async function validate(options: ResolveV5Options): Promise<V5ValidationResult> {
+  const topLevelErrors: V5TopLevelError[] = [];
 
-  return resolution.statuses
+  const envError = checkValidEnv(options);
+  if (envError !== undefined) topLevelErrors.push(envError);
+
+  const groupCheck = checkGroupFilter(options.config, options.groups);
+  topLevelErrors.push(...groupCheck.errors);
+
+  if (topLevelErrors.length > 0) {
+    return { topLevelErrors, keyErrors: [] };
+  }
+
+  const selected = selectRecords(options.config, options.groups, options.filters);
+  const envRequiredError = checkEnvProvidedWhenRequired(selected, options.envName);
+  if (envRequiredError !== undefined) {
+    return { topLevelErrors: [envRequiredError], keyErrors: [] };
+  }
+
+  const resolution = await resolveWithStatus(options);
+  const keyErrors = resolution.statuses
     .filter((status): status is Extract<V5KeyResolutionStatus, { status: "error" }> => {
       return status.status === "error";
     })
@@ -43,6 +61,8 @@ export async function validate(options: ResolveV5Options): Promise<V5ValidationE
       message: status.message,
       error: status.error
     }));
+
+  return { topLevelErrors: [], keyErrors };
 }
 
 export async function resolveWithStatus(options: ResolveV5Options): Promise<V5Resolution> {
@@ -164,20 +184,34 @@ function selectRecords(
 }
 
 function normalizeGroupFilter(config: NormalizedConfig, groups: string[] | undefined): Set<string> {
+  const { errors, groupSet } = checkGroupFilter(config, groups);
+  if (errors.length > 0) throw new Error(errors[0].message);
+  return groupSet;
+}
+
+function checkGroupFilter(
+  config: NormalizedConfig,
+  groups: string[] | undefined
+): { errors: V5TopLevelError[]; groupSet: Set<string> } {
   const groupNames = [...new Set(groups ?? [])];
-  if (groupNames.length === 0) return new Set();
+  if (groupNames.length === 0) return { errors: [], groupSet: new Set() };
+
   if (config.groups.length === 0) {
-    throw new Error("--group cannot be used because this config declares no groups");
+    return {
+      errors: [{ message: "--group cannot be used because this config declares no groups" }],
+      groupSet: new Set()
+    };
   }
 
   const declaredGroups = new Set(config.groups);
+  const errors: V5TopLevelError[] = [];
   for (const group of groupNames) {
     if (!declaredGroups.has(group)) {
-      throw new Error(`Unknown group "${group}"`);
+      errors.push({ message: `Unknown group "${group}"` });
     }
   }
 
-  return new Set(groupNames);
+  return { errors, groupSet: new Set(groupNames.filter((g) => declaredGroups.has(g))) };
 }
 
 function normalizePathFilters(filters: string[] | undefined): string[] {
@@ -202,27 +236,39 @@ function matchesPathPrefix(path: string, prefix: string): boolean {
 }
 
 function assertValidEnv(options: ResolveV5Options): void {
-  if (options.envName === undefined) return;
-  if (options.config.envs.includes(options.envName)) return;
-  throw new Error(`Unknown env "${options.envName}"`);
+  const error = checkValidEnv(options);
+  if (error !== undefined) throw new Error(error.message);
+}
+
+function checkValidEnv(options: ResolveV5Options): V5TopLevelError | undefined {
+  if (options.envName === undefined) return undefined;
+  if (options.config.envs.includes(options.envName)) return undefined;
+  return { message: `Unknown env "${options.envName}"` };
 }
 
 function assertEnvProvidedWhenRequired(
   selected: SelectedV5Record[],
   envName: string | undefined
 ): void {
-  if (envName !== undefined) return;
+  const error = checkEnvProvidedWhenRequired(selected, envName);
+  if (error !== undefined) throw new Error(error.message);
+}
+
+function checkEnvProvidedWhenRequired(
+  selected: SelectedV5Record[],
+  envName: string | undefined
+): V5TopLevelError | undefined {
+  if (envName !== undefined) return undefined;
 
   const envScopedRecord = selected
     .filter((entry) => entry.selected)
     .map((entry) => entry.record)
     .find((record) => hasValuesWithoutFallback(record));
 
-  if (envScopedRecord !== undefined) {
-    throw new Error(
-      `--env is required because selected key "${envScopedRecord.path}" has env-specific values and no fallback`
-    );
-  }
+  if (envScopedRecord === undefined) return undefined;
+  return {
+    message: `--env is required because selected key "${envScopedRecord.path}" has env-specific values and no fallback`
+  };
 }
 
 function hasValuesWithoutFallback(record: NormalizedRecord): boolean {
@@ -352,10 +398,7 @@ function skippedEnvVar(
   };
 }
 
-function statusToSkipReason(
-  keyPath: string,
-  status: V5KeyResolutionStatus | undefined
-): string {
+function statusToSkipReason(keyPath: string, status: V5KeyResolutionStatus | undefined): string {
   if (status?.status === "filtered") return `referenced key '${keyPath}' is filtered out`;
   if (status?.status === "skipped") return `referenced key '${keyPath}' is unavailable`;
   if (status?.status === "error") {

--- a/packages/cli/src/v5/resolver/types.ts
+++ b/packages/cli/src/v5/resolver/types.ts
@@ -12,6 +12,16 @@ export interface V5ValidationError {
   error?: Error;
 }
 
+export interface V5TopLevelError {
+  message: string;
+  error?: Error;
+}
+
+export interface V5ValidationResult {
+  topLevelErrors: V5TopLevelError[];
+  keyErrors: V5ValidationError[];
+}
+
 export type V5KeyResolutionStatus =
   | {
       path: string;

--- a/packages/cli/test/unit/v5/resolver.test.ts
+++ b/packages/cli/test/unit/v5/resolver.test.ts
@@ -80,19 +80,22 @@ describe("v5 resolver", () => {
       })
     );
 
-    const errors = await validate({
+    const result = await validate({
       config: normalized,
       envName: "dev",
       rootDir: "/repo",
       registry: registry()
     });
 
-    expect(errors).toMatchObject([
-      {
-        path: "required",
-        message: 'No value for required key "required"'
-      }
-    ]);
+    expect(result).toMatchObject({
+      topLevelErrors: [],
+      keyErrors: [
+        {
+          path: "required",
+          message: 'No value for required key "required"'
+        }
+      ]
+    });
 
     const resolution = await resolveWithStatus({
       config: normalized,
@@ -337,12 +340,109 @@ describe("v5 resolver", () => {
       })
     ).resolves.toEqual([]);
 
-    const errors = await validate({
+    const result = await validate({
       config: normalized,
       envName: "dev",
       rootDir: "/repo",
       registry: registry(authProvider)
     });
-    expect(errors).toMatchObject([{ path: "token", message: "auth failed" }]);
+    expect(result).toMatchObject({
+      topLevelErrors: [],
+      keyErrors: [{ path: "token", message: "auth failed" }]
+    });
+  });
+
+  it("collects unknown env, unknown groups, and missing --env as topLevelErrors", async () => {
+    const normalized = normalizeConfig(
+      defineConfig({
+        envs: ["dev", "production"],
+        groups: ["app", "ci"],
+        keys: {
+          app: config({ group: "app", value: "envless" }),
+          ci: config({ group: "ci", values: { production: "ci-prod" } })
+        }
+      })
+    );
+
+    const unknownEnv = await validate({
+      config: normalized,
+      envName: "prod",
+      rootDir: "/repo",
+      registry: registry()
+    });
+    expect(unknownEnv).toMatchObject({
+      topLevelErrors: [{ message: 'Unknown env "prod"' }],
+      keyErrors: []
+    });
+
+    const unknownGroups = await validate({
+      config: normalized,
+      groups: ["does-not-exist", "also-missing"],
+      envName: "dev",
+      rootDir: "/repo",
+      registry: registry()
+    });
+    expect(unknownGroups).toMatchObject({
+      topLevelErrors: [
+        { message: 'Unknown group "does-not-exist"' },
+        { message: 'Unknown group "also-missing"' }
+      ],
+      keyErrors: []
+    });
+
+    const groupless = normalizeConfig(defineConfig({ envs: ["dev"], keys: { app: "keyshelf" } }));
+    const groupOnGroupless = await validate({
+      config: groupless,
+      groups: ["app"],
+      envName: "dev",
+      rootDir: "/repo",
+      registry: registry()
+    });
+    expect(groupOnGroupless).toMatchObject({
+      topLevelErrors: [
+        { message: "--group cannot be used because this config declares no groups" }
+      ],
+      keyErrors: []
+    });
+
+    const envRequired = await validate({
+      config: normalized,
+      groups: ["ci"],
+      rootDir: "/repo",
+      registry: registry()
+    });
+    expect(envRequired).toMatchObject({
+      topLevelErrors: [
+        {
+          message:
+            '--env is required because selected key "ci" has env-specific values and no fallback'
+        }
+      ],
+      keyErrors: []
+    });
+  });
+
+  it("resolve still throws on top-level errors (unchanged fast-fail behavior)", async () => {
+    const normalized = normalizeConfig(
+      defineConfig({
+        envs: ["dev"],
+        groups: ["app"],
+        keys: { app: config({ group: "app", value: "k" }) }
+      })
+    );
+
+    await expect(
+      resolve({ config: normalized, envName: "prod", rootDir: "/repo", registry: registry() })
+    ).rejects.toThrow('Unknown env "prod"');
+
+    await expect(
+      resolve({
+        config: normalized,
+        groups: ["ci"],
+        envName: "dev",
+        rootDir: "/repo",
+        registry: registry()
+      })
+    ).rejects.toThrow('Unknown group "ci"');
   });
 });


### PR DESCRIPTION
## Summary

Addresses review issue #2 on PR #87.

`validate` previously threw on unknown env, unknown group, missing `--env`, and group-on-groupless configs — only per-key resolution problems came back as a list. That meant callers had to wrap `validate` in try/catch and could only see one problem at a time.

Now `validate` returns:

```ts
{
  topLevelErrors: V5TopLevelError[],   // unknown env, unknown groups, missing --env
  keyErrors:      V5ValidationError[], // per-key resolution failures
}
```

`resolve` and `resolveWithStatus` keep fast-fail throwing (callers there want abort-on-invalid).

Refactor approach:
- New `checkValidEnv`, `checkGroupFilter`, `checkEnvProvidedWhenRequired` helpers return `V5TopLevelError | undefined` (or arrays).
- The existing `assertX` wrappers throw using the same checks, so resolve-path behavior is byte-identical.
- `validate` collects the cheap top-level checks together (env + group), short-circuits if any, then proceeds to selection + env-required check, then per-key resolution.

Stacks on `issue-78-v5-phase-3-resolver` (PR #87).

## Test plan
- [x] `npm run typecheck -w packages/cli`
- [x] `npm test -w packages/cli -- test/unit/v5/` — 24/24 passing
- [x] New tests assert `validate` collects unknown env, multiple unknown groups, group-on-groupless, and missing-`--env` as `topLevelErrors`
- [x] New test asserts `resolve` still throws on the same conditions

🤖 Generated with [Claude Code](https://claude.com/claude-code)