### PR TITLE
feat(v5): phase 4 — port providers, namespaced gcp secret ids

### DIFF
--- a/docs/v5/spec.md
+++ b/docs/v5/spec.md
@@ -14,6 +14,7 @@ must default-export the result of `defineConfig({ ... })`.
 import { defineConfig } from "keyshelf/config";
 
 export default defineConfig({
+  name: "myapp",
   envs: ["dev", "staging", "production"],
   groups: ["app", "ci"],
   keys: {
@@ -30,12 +31,18 @@ The `.env.keyshelf` file (app-name → key-path mapping) is unchanged from v4.
 
 ```ts
 defineConfig({
+  name:   string;            // required; lower-kebab-case identity for this config
   envs:   string[];          // required, non-empty, unique
   groups?: string[];          // optional, unique; if omitted, no group filtering
   keys:   KeyTree;           // required, non-empty
 })
 ```
 
+- `name` is the keyshelf project's stable identity. Providers that share a
+  backend with other keyshelf configs (e.g. multiple apps using one GCP
+  project) use `name` to namespace their secrets so they don't collide. Must
+  match `/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/` — lowercase letters, digits, and
+  internal dashes only. Required; there is no fallback.
 - `envs` enumerates every environment name the config recognises. Any
   `values` map elsewhere in the config may only use names from this list. There
   is no implicit / dynamic env support in v5.
@@ -175,32 +182,38 @@ Provider factories are imported from `keyshelf/config` and return a
 
 ```ts
 age({
-  identityFile?: string;   // path, used for decryption
-  recipient?: string;      // age public key, used for `keyshelf set` encryption
+  identityFile: string;   // path to the age identity (private key) — used to
+                          // decrypt and to derive the recipient on `set`
+  secretsDir: string;     // directory holding the .age ciphertext files
 })
 ```
 
-At least one of `identityFile` or `recipient` is required (validator). The
-encrypted payload itself is stored alongside the config in the provider's
-own conventions, not inline.
+Both fields are required. Ciphertext is stored as
+`<secretsDir>/<keyPath-with-/-as-_>.age`.
 
 ### `gcp(options)`
 
 ```ts
 gcp({
-  project: string;
-  secret?: string;         // explicit Secret Manager name; defaults to a
-                           // path-derived convention
-  version?: string;        // defaults to 'latest'
+  project: string;        // GCP project hosting the Secret Manager secrets
 })
 ```
+
+The Secret Manager secret id is derived from the keyshelf config `name`,
+the active `envName`, and the key path:
+
+- env-scoped: `keyshelf__<name>__<env>__<keyPath-with-/-as-__>`
+- envless: `keyshelf__<name>__<keyPath-with-/-as-__>`
+
+`/` is not a valid character in GCP secret ids, so path separators are
+mangled to `__`.
 
 ### `sops(options)`
 
 ```ts
 sops({
-  file: string;            // path, relative to repo root
-  path?: string;           // dot/jsonpath into the decrypted document
+  identityFile: string;   // path to the age identity used to unlock the data key
+  secretsFile: string;    // path to the encrypted JSON document
 })
 ```
 

--- a/examples/01-basic.config.ts
+++ b/examples/01-basic.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from "keyshelf/config";
 
 export default defineConfig({
+  name: "example-01-basic",
   envs: ["dev"],
 
   keys: {

--- a/examples/02-env-and-group.config.ts
+++ b/examples/02-env-and-group.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig, config, secret, age, gcp } from "keyshelf/config";
 
 export default defineConfig({
+  name: "example-02-env-and-group",
   envs: ["dev", "staging", "production"],
   groups: ["app"],
 
@@ -25,7 +26,7 @@ export default defineConfig({
       }),
       password: secret({
         group: "app",
-        default: age({ identityFile: "./keys/dev.txt" }),
+        default: age({ identityFile: "./keys/dev.txt", secretsDir: "./secrets" }),
         values: {
           production: gcp({ project: "myproj" })
         }

--- a/examples/03-envless-shared-secret.config.ts
+++ b/examples/03-envless-shared-secret.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig, config, secret, age } from "keyshelf/config";
 
 export default defineConfig({
+  name: "example-03-envless-shared-secret",
   envs: ["dev", "production"],
   groups: ["app", "ci"],
 
@@ -8,7 +9,7 @@ export default defineConfig({
     github: {
       token: secret({
         group: "ci",
-        value: age({ identityFile: "./keys/ci.txt" })
+        value: age({ identityFile: "./keys/ci.txt", secretsDir: "./secrets" })
       })
     },
 

--- a/examples/04-optional-secrets.config.ts
+++ b/examples/04-optional-secrets.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig, secret, age, gcp } from "keyshelf/config";
 
 export default defineConfig({
+  name: "example-04-optional-secrets",
   envs: ["dev", "production"],
   groups: ["app"],
 
@@ -19,9 +20,9 @@ export default defineConfig({
       "config-passphrase": secret({
         group: "app",
         optional: true,
-        default: age({ identityFile: "./keys/dev.txt" }),
+        default: age({ identityFile: "./keys/dev.txt", secretsDir: "./secrets" }),
         values: {
-          production: gcp({ project: "myproj", secret: "pulumi-passphrase" })
+          production: gcp({ project: "myproj" })
         }
       })
     }

--- a/examples/05-nested-namespaces.config.ts
+++ b/examples/05-nested-namespaces.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig, config, secret, age } from "keyshelf/config";
 
 export default defineConfig({
+  name: "example-05-nested-namespaces",
   envs: ["dev", "production"],
 
   keys: {
@@ -9,7 +10,7 @@ export default defineConfig({
         api: {
           url: "http://localhost:4000",
           key: secret({
-            value: age({ identityFile: "./keys/dev.txt" })
+            value: age({ identityFile: "./keys/dev.txt", secretsDir: "./secrets" })
           })
         }
       },
@@ -32,7 +33,7 @@ export default defineConfig({
     },
 
     "feature-flags/launch-darkly/sdk-key": secret({
-      value: age({ identityFile: "./keys/dev.txt" })
+      value: age({ identityFile: "./keys/dev.txt", secretsDir: "./secrets" })
     }),
     "feature-flags/launch-darkly/environment": config({ value: "dev" })
   }

--- a/examples/06-template-config.config.ts
+++ b/examples/06-template-config.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig, config, secret, age } from "keyshelf/config";
 
 export default defineConfig({
+  name: "example-06-template-config",
   envs: ["dev", "production"],
 
   keys: {
@@ -14,7 +15,7 @@ export default defineConfig({
       port: 5432,
       user: "app",
       password: secret({
-        value: age({ identityFile: "./keys/dev.txt" })
+        value: age({ identityFile: "./keys/dev.txt", secretsDir: "./secrets" })
       }),
 
       url: config({

--- a/examples/07-full.config.ts
+++ b/examples/07-full.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig, config, secret, age, gcp, sops } from "keyshelf/config";
 
 export default defineConfig({
+  name: "example-07-full",
   envs: ["dev", "staging", "production"],
   groups: ["app", "ci", "ops"],
 
@@ -27,9 +28,9 @@ export default defineConfig({
       user: config({ group: "app", value: "app" }),
       password: secret({
         group: "app",
-        default: age({ identityFile: "./keys/dev.txt" }),
+        default: age({ identityFile: "./keys/dev.txt", secretsDir: "./secrets" }),
         values: {
-          staging: sops({ file: "./secrets/staging.yaml", path: "db.password" }),
+          staging: sops({ identityFile: "./keys/sops.txt", secretsFile: "./secrets/staging.json" }),
           production: gcp({ project: "myproj" })
         }
       }),
@@ -53,7 +54,7 @@ export default defineConfig({
       token: secret({
         group: "ci",
         description: "Shared CI token, not env-scoped",
-        value: age({ identityFile: "./keys/ci.txt" })
+        value: age({ identityFile: "./keys/ci.txt", secretsDir: "./secrets" })
       })
     },
 
@@ -65,7 +66,7 @@ export default defineConfig({
         }),
         token: secret({
           group: "ops",
-          value: gcp({ project: "myproj", secret: "grafana-api-token" })
+          value: gcp({ project: "myproj" })
         })
       }
     }

--- a/packages/cli/src/providers/gcp-sm.ts
+++ b/packages/cli/src/providers/gcp-sm.ts
@@ -33,8 +33,17 @@ function isAuthError(err: unknown): boolean {
   return AUTH_ERROR_PATTERNS.some((pattern) => msg.includes(pattern));
 }
 
-function toSecretId(envName: string, keyPath: string): string {
-  return `keyshelf__${envName}__${keyPath.replace(/\//g, "__")}`;
+function toSecretId(
+  keyshelfName: string | undefined,
+  envName: string | undefined,
+  keyPath: string
+): string {
+  const path = keyPath.replace(/\//g, "__");
+  const segments = ["keyshelf"];
+  if (keyshelfName !== undefined) segments.push(keyshelfName);
+  if (envName !== undefined && envName !== "") segments.push(envName);
+  segments.push(path);
+  return segments.join("__");
 }
 
 export class GcpSmProvider implements Provider {
@@ -58,7 +67,7 @@ export class GcpSmProvider implements Provider {
 
   async resolve(ctx: ProviderContext): Promise<string> {
     const opts = this.resolveOptions(ctx);
-    const secretId = toSecretId(ctx.envName, ctx.keyPath);
+    const secretId = toSecretId(ctx.keyshelfName, ctx.envName, ctx.keyPath);
 
     let version;
     try {
@@ -81,7 +90,7 @@ export class GcpSmProvider implements Provider {
   async validate(ctx: ProviderContext): Promise<boolean> {
     try {
       const opts = this.resolveOptions(ctx);
-      const secretId = toSecretId(ctx.envName, ctx.keyPath);
+      const secretId = toSecretId(ctx.keyshelfName, ctx.envName, ctx.keyPath);
 
       await this.client.getSecret({
         name: `projects/${opts.project}/secrets/${secretId}`
@@ -95,7 +104,7 @@ export class GcpSmProvider implements Provider {
 
   async set(ctx: ProviderContext, value: string): Promise<void> {
     const opts = this.resolveOptions(ctx);
-    const secretId = toSecretId(ctx.envName, ctx.keyPath);
+    const secretId = toSecretId(ctx.keyshelfName, ctx.envName, ctx.keyPath);
     const parent = `projects/${opts.project}`;
 
     // Create secret if it doesn't exist

--- a/packages/cli/src/providers/types.ts
+++ b/packages/cli/src/providers/types.ts
@@ -1,8 +1,9 @@
 export interface ProviderContext {
   keyPath: string;
-  envName: string;
+  envName: string | undefined;
   rootDir: string;
   config: Record<string, unknown>;
+  keyshelfName?: string;
 }
 
 export interface Provider {

--- a/packages/cli/src/v5/config/schema.ts
+++ b/packages/cli/src/v5/config/schema.ts
@@ -13,6 +13,7 @@ import type {
 
 const PATH_SEGMENT_RE = /^[A-Za-z_][A-Za-z0-9_-]*$/;
 const TEMPLATE_RE = /(?<!\$)\$\{([^}]+)\}/g;
+const CONFIG_NAME_RE = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
 
 const configScalarSchema = z.union([z.string(), z.number(), z.boolean()]);
 
@@ -22,13 +23,10 @@ const ageProviderSchema = z
     name: z.literal("age"),
     options: z
       .object({
-        identityFile: z.string().optional(),
-        recipient: z.string().optional()
+        identityFile: z.string().min(1),
+        secretsDir: z.string().min(1)
       })
       .strict()
-      .refine((options) => options.identityFile !== undefined || options.recipient !== undefined, {
-        message: "age provider requires identityFile or recipient"
-      })
   })
   .strict();
 
@@ -38,9 +36,7 @@ const gcpProviderSchema = z
     name: z.literal("gcp"),
     options: z
       .object({
-        project: z.string().min(1),
-        secret: z.string().optional(),
-        version: z.string().optional()
+        project: z.string().min(1)
       })
       .strict()
   })
@@ -52,8 +48,8 @@ const sopsProviderSchema = z
     name: z.literal("sops"),
     options: z
       .object({
-        file: z.string().min(1),
-        path: z.string().optional()
+        identityFile: z.string().min(1),
+        secretsFile: z.string().min(1)
       })
       .strict()
   })
@@ -122,6 +118,13 @@ const keyNodeSchema: z.ZodType<KeyNode> = z.lazy(() =>
 const keyshelfConfigSchema = z
   .object({
     __kind: z.literal("keyshelf:config"),
+    name: z
+      .string()
+      .min(1)
+      .refine((value) => CONFIG_NAME_RE.test(value), {
+        message:
+          "name must match /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/ (lowercase, digits, dashes; no leading or trailing dash)"
+      }),
     envs: z.array(z.string().min(1)).nonempty(),
     groups: z.array(z.string().min(1)).optional(),
     keys: z.record(z.string(), keyNodeSchema).refine((value) => Object.keys(value).length > 0, {
@@ -154,6 +157,7 @@ export function normalizeConfig(input: unknown): NormalizedConfig {
   }
 
   return {
+    name: parsed.name,
     envs: [...parsed.envs],
     groups,
     keys: flattened

--- a/packages/cli/src/v5/config/types.ts
+++ b/packages/cli/src/v5/config/types.ts
@@ -8,19 +8,17 @@ export interface ProviderRef<Name extends string = string, Options = unknown> {
 }
 
 export interface AgeProviderOptions {
-  identityFile?: string;
-  recipient?: string;
+  identityFile: string;
+  secretsDir: string;
 }
 
 export interface GcpProviderOptions {
   project: string;
-  secret?: string;
-  version?: string;
 }
 
 export interface SopsProviderOptions {
-  file: string;
-  path?: string;
+  identityFile: string;
+  secretsFile: string;
 }
 
 export type BuiltinProviderRef =
@@ -83,6 +81,7 @@ export interface DefineConfigInput<
     GroupNames[number]
   >
 > {
+  name: string;
   envs: EnvNames;
   groups?: GroupNames;
   keys: Keys;
@@ -120,6 +119,7 @@ export interface KeyshelfConfig<
   Path extends string = string
 > {
   __kind: "keyshelf:config";
+  name: string;
   envs: readonly EnvName[];
   groups?: readonly GroupName[];
   keys: KeyTree<EnvName, GroupName>;
@@ -150,6 +150,7 @@ export type NormalizedRecord =
     };
 
 export interface NormalizedConfig {
+  name: string;
   envs: string[];
   groups: string[];
   keys: NormalizedRecord[];

--- a/packages/cli/src/v5/resolver/index.ts
+++ b/packages/cli/src/v5/resolver/index.ts
@@ -330,9 +330,10 @@ async function resolveProvider(
   const provider = options.registry.get(providerRef.name);
   return provider.resolve({
     keyPath,
-    envName: options.envName ?? "",
+    envName: options.envName,
     rootDir: options.rootDir,
-    config: { ...(providerRef.options as Record<string, unknown>) }
+    config: { ...(providerRef.options as unknown as Record<string, unknown>) },
+    keyshelfName: options.config.name
   });
 }
 

--- a/packages/cli/test/integration/v5-loader.test.ts
+++ b/packages/cli/test/integration/v5-loader.test.ts
@@ -12,12 +12,13 @@ async function createFixture() {
       'import { age, config, defineConfig, secret } from "keyshelf/config";',
       "",
       "export default defineConfig({",
+      '  name: "test",',
       '  envs: ["dev", "production"],',
       '  groups: ["app", "ci"],',
       "  keys: {",
       '    log: { level: "info" },',
       '    "db/host": config({ group: "app", default: "localhost", values: { production: "prod-db" } }),',
-      '    "github/token": secret({ group: "ci", value: age({ identityFile: "./ci.txt" }) })',
+      '    "github/token": secret({ group: "ci", value: age({ identityFile: "./ci.txt", secretsDir: "./secrets" }) })',
       "  }",
       "});"
     ].join("\n")

--- a/packages/cli/test/integration/v5-providers.test.ts
+++ b/packages/cli/test/integration/v5-providers.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it, vi } from "vitest";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { SecretManagerServiceClient } from "@google-cloud/secret-manager";
+import { age, config, defineConfig, secret, gcp } from "../../src/v5/config/index.js";
+import { normalizeConfig } from "../../src/v5/config/index.js";
+import { resolve as v5resolve } from "../../src/v5/resolver/index.js";
+import { ProviderRegistry } from "../../src/providers/registry.js";
+import { AgeProvider, generateIdentity } from "../../src/providers/age.js";
+import { GcpSmProvider } from "../../src/providers/gcp-sm.js";
+
+async function ageFixture() {
+  const dir = await mkdtemp(join(tmpdir(), "keyshelf-v5-age-"));
+  const identityFile = join(dir, "id.txt");
+  const secretsDir = join(dir, "secrets");
+  await writeFile(identityFile, await generateIdentity());
+  return { dir, identityFile, secretsDir };
+}
+
+describe("v5 resolver → providers", () => {
+  it("resolves an age secret end-to-end through the resolver", async () => {
+    const { dir, identityFile, secretsDir } = await ageFixture();
+
+    const registry = new ProviderRegistry();
+    const ageProvider = new AgeProvider();
+    registry.register(ageProvider);
+
+    await ageProvider.set(
+      {
+        keyPath: "github/token",
+        envName: undefined,
+        rootDir: dir,
+        config: { identityFile, secretsDir }
+      },
+      "ghp_secret_value"
+    );
+
+    const normalized = normalizeConfig(
+      defineConfig({
+        name: "myapp",
+        envs: ["dev"],
+        keys: {
+          github: {
+            token: secret({
+              value: age({ identityFile, secretsDir })
+            })
+          }
+        }
+      })
+    );
+
+    const resolved = await v5resolve({
+      config: normalized,
+      rootDir: dir,
+      registry
+    });
+
+    expect(resolved).toEqual([{ path: "github/token", value: "ghp_secret_value" }]);
+  });
+
+  it("uses keyshelf name + env in the gcp secret id", async () => {
+    const accessSecretVersion = vi
+      .fn()
+      .mockResolvedValue([{ payload: { data: Buffer.from("dbpass") } }]);
+    const client = {
+      accessSecretVersion,
+      getSecret: vi.fn(),
+      createSecret: vi.fn(),
+      addSecretVersion: vi.fn()
+    };
+
+    const registry = new ProviderRegistry();
+    registry.register(new GcpSmProvider(client as unknown as SecretManagerServiceClient));
+
+    const normalized = normalizeConfig(
+      defineConfig({
+        name: "myapp",
+        envs: ["staging"],
+        keys: {
+          db: {
+            password: secret({
+              value: gcp({ project: "my-gcp-proj" })
+            })
+          }
+        }
+      })
+    );
+
+    const resolved = await v5resolve({
+      config: normalized,
+      rootDir: "/repo",
+      envName: "staging",
+      registry
+    });
+
+    expect(resolved).toEqual([{ path: "db/password", value: "dbpass" }]);
+    expect(accessSecretVersion).toHaveBeenCalledWith({
+      name: "projects/my-gcp-proj/secrets/keyshelf__myapp__staging__db__password/versions/latest"
+    });
+  });
+
+  it("omits the env segment for envless gcp secrets", async () => {
+    const accessSecretVersion = vi
+      .fn()
+      .mockResolvedValue([{ payload: { data: Buffer.from("ghp_xxx") } }]);
+    const client = {
+      accessSecretVersion,
+      getSecret: vi.fn(),
+      createSecret: vi.fn(),
+      addSecretVersion: vi.fn()
+    };
+
+    const registry = new ProviderRegistry();
+    registry.register(new GcpSmProvider(client as unknown as SecretManagerServiceClient));
+
+    const normalized = normalizeConfig(
+      defineConfig({
+        name: "myapp",
+        envs: ["dev"],
+        keys: {
+          github: {
+            token: secret({
+              value: gcp({ project: "my-gcp-proj" })
+            })
+          },
+          // template ref so the resolver still has a config record
+          dummy: config({ value: "x" })
+        }
+      })
+    );
+
+    const resolved = await v5resolve({
+      config: normalized,
+      rootDir: "/repo",
+      registry
+    });
+
+    expect(resolved.find((entry) => entry.path === "github/token")).toEqual({
+      path: "github/token",
+      value: "ghp_xxx"
+    });
+    expect(accessSecretVersion).toHaveBeenCalledWith({
+      name: "projects/my-gcp-proj/secrets/keyshelf__myapp__github__token/versions/latest"
+    });
+  });
+});

--- a/packages/cli/test/unit/providers/gcp-sm.test.ts
+++ b/packages/cli/test/unit/providers/gcp-sm.test.ts
@@ -25,7 +25,7 @@ describe("GcpSmProvider", () => {
   }
 
   describe("secret ID derivation", () => {
-    it("generates keyshelf__{env}__{path} format", async () => {
+    it("generates keyshelf__{env}__{path} when keyshelfName is absent (v4 callers)", async () => {
       client.accessSecretVersion.mockResolvedValue([{ payload: { data: Buffer.from("val") } }]);
 
       await provider.resolve(ctx("db/password", "staging"));
@@ -42,6 +42,54 @@ describe("GcpSmProvider", () => {
 
       expect(client.accessSecretVersion).toHaveBeenCalledWith({
         name: "projects/my-proj/secrets/keyshelf__dev__services__api__db__password/versions/latest"
+      });
+    });
+
+    it("includes keyshelfName segment when provided", async () => {
+      client.accessSecretVersion.mockResolvedValue([{ payload: { data: Buffer.from("val") } }]);
+
+      await provider.resolve({
+        keyPath: "db/password",
+        envName: "staging",
+        rootDir: "/tmp",
+        config: { project: "my-proj" },
+        keyshelfName: "myapp"
+      });
+
+      expect(client.accessSecretVersion).toHaveBeenCalledWith({
+        name: "projects/my-proj/secrets/keyshelf__myapp__staging__db__password/versions/latest"
+      });
+    });
+
+    it("omits env segment when envName is undefined (envless secret)", async () => {
+      client.accessSecretVersion.mockResolvedValue([{ payload: { data: Buffer.from("val") } }]);
+
+      await provider.resolve({
+        keyPath: "github/token",
+        envName: undefined,
+        rootDir: "/tmp",
+        config: { project: "my-proj" },
+        keyshelfName: "myapp"
+      });
+
+      expect(client.accessSecretVersion).toHaveBeenCalledWith({
+        name: "projects/my-proj/secrets/keyshelf__myapp__github__token/versions/latest"
+      });
+    });
+
+    it("omits env segment when envName is empty string (legacy callers)", async () => {
+      client.accessSecretVersion.mockResolvedValue([{ payload: { data: Buffer.from("val") } }]);
+
+      await provider.resolve({
+        keyPath: "github/token",
+        envName: "",
+        rootDir: "/tmp",
+        config: { project: "my-proj" },
+        keyshelfName: "myapp"
+      });
+
+      expect(client.accessSecretVersion).toHaveBeenCalledWith({
+        name: "projects/my-proj/secrets/keyshelf__myapp__github__token/versions/latest"
       });
     });
   });

--- a/packages/cli/test/unit/v5/config.test.ts
+++ b/packages/cli/test/unit/v5/config.test.ts
@@ -13,6 +13,7 @@ describe("v5 config factories and validation", () => {
   it("normalizes nested namespaces, string paths, bare scalars, config, and secrets", () => {
     const normalized = normalizeConfig(
       defineConfig({
+        name: "test",
         envs: ["dev", "production"],
         groups: ["app", "ci"],
         keys: {
@@ -27,7 +28,7 @@ describe("v5 config factories and validation", () => {
           github: {
             token: secret({
               group: "ci",
-              value: age({ identityFile: "./ci.txt" })
+              value: age({ identityFile: "./ci.txt", secretsDir: "./secrets" })
             })
           }
         }
@@ -51,7 +52,7 @@ describe("v5 config factories and validation", () => {
         group: "ci",
         optional: false,
         description: undefined,
-        value: age({ identityFile: "./ci.txt" }),
+        value: age({ identityFile: "./ci.txt", secretsDir: "./secrets" }),
         values: undefined
       }
     ]);
@@ -61,6 +62,7 @@ describe("v5 config factories and validation", () => {
     expect(() =>
       normalizeConfig(
         defineConfig({
+          name: "test",
           envs: ["dev"],
           keys: {
             host: config({ value: "localhost", default: "127.0.0.1" })
@@ -74,6 +76,7 @@ describe("v5 config factories and validation", () => {
     expect(() =>
       normalizeConfig(
         defineConfig({
+          name: "test",
           envs: ["dev"],
           groups: ["app"],
           keys: {
@@ -91,6 +94,7 @@ describe("v5 config factories and validation", () => {
     expect(() =>
       normalizeConfig(
         defineConfig({
+          name: "test",
           envs: ["dev"],
           keys: {
             token: secret({})
@@ -112,6 +116,7 @@ describe("v5 config factories and validation", () => {
     expect(() =>
       normalizeConfig(
         defineConfig({
+          name: "test",
           envs: ["dev"],
           keys: {
             db: {}
@@ -125,19 +130,22 @@ describe("v5 config factories and validation", () => {
     expect(() =>
       normalizeConfig(
         defineConfig({
+          name: "test",
           envs: ["dev"],
           keys: {
-            token: secret({ value: age({}) })
+            // @ts-expect-error secretsDir is required
+            token: secret({ value: age({ identityFile: "./ci.txt" }) })
           }
         })
       )
-    ).toThrow("age provider requires identityFile or recipient");
+    ).toThrow(/factory objects with __kind must match their declared schema/);
   });
 
   it("rejects duplicate flattened paths", () => {
     expect(() =>
       normalizeConfig(
         defineConfig({
+          name: "test",
           envs: ["dev"],
           keys: {
             db: { host: "localhost" },
@@ -152,6 +160,7 @@ describe("v5 config factories and validation", () => {
     expect(() =>
       normalizeConfig(
         defineConfig({
+          name: "test",
           envs: ["dev"],
           keys: {
             db: "localhost",
@@ -166,6 +175,7 @@ describe("v5 config factories and validation", () => {
     expect(() =>
       normalizeConfig(
         defineConfig({
+          name: "test",
           envs: ["dev"],
           keys: {
             "db.host": "localhost"
@@ -179,6 +189,7 @@ describe("v5 config factories and validation", () => {
     expect(() =>
       normalizeConfig(
         defineConfig({
+          name: "test",
           envs: ["dev"],
           keys: {
             db: {
@@ -192,6 +203,7 @@ describe("v5 config factories and validation", () => {
     expect(() =>
       normalizeConfig(
         defineConfig({
+          name: "test",
           envs: ["dev", "production"],
           keys: {
             db: {
@@ -208,6 +220,7 @@ describe("v5 config factories and validation", () => {
     expect(() =>
       normalizeConfig(
         defineConfig({
+          name: "test",
           envs: ["dev"],
           keys: {
             a: config({ value: "${b}" }),
@@ -220,6 +233,7 @@ describe("v5 config factories and validation", () => {
     expect(() =>
       normalizeConfig(
         defineConfig({
+          name: "test",
           envs: ["dev", "production"],
           keys: {
             a: config({ values: { production: "${b}" } }),
@@ -233,6 +247,7 @@ describe("v5 config factories and validation", () => {
   it("allows templates to reference secrets and ignores escaped template markers", () => {
     const normalized = normalizeConfig(
       defineConfig({
+        name: "test",
         envs: ["dev"],
         keys: {
           token: secret({ value: gcp({ project: "my-project" }) }),
@@ -247,6 +262,7 @@ describe("v5 config factories and validation", () => {
   it("validates app mapping references against flattened keys", () => {
     const normalized = normalizeConfig(
       defineConfig({
+        name: "test",
         envs: ["dev"],
         keys: {
           db: { host: "localhost" }

--- a/packages/cli/test/unit/v5/resolver.test.ts
+++ b/packages/cli/test/unit/v5/resolver.test.ts
@@ -33,6 +33,7 @@ describe("v5 resolver", () => {
     const provider = mockProvider("age", "secret-dev");
     const normalized = normalizeConfig(
       defineConfig({
+        name: "test",
         envs: ["dev", "production"],
         keys: {
           host: config({
@@ -41,8 +42,8 @@ describe("v5 resolver", () => {
           }),
           port: 5432,
           token: secret({
-            values: { dev: age({ identityFile: "./dev.txt" }) },
-            default: age({ identityFile: "./shared.txt" })
+            values: { dev: age({ identityFile: "./dev.txt", secretsDir: "./secrets" }) },
+            default: age({ identityFile: "./shared.txt", secretsDir: "./secrets" })
           })
         }
       })
@@ -65,13 +66,15 @@ describe("v5 resolver", () => {
       keyPath: "token",
       envName: "dev",
       rootDir: "/repo",
-      config: { identityFile: "./dev.txt" }
+      config: { identityFile: "./dev.txt", secretsDir: "./secrets" },
+      keyshelfName: "test"
     });
   });
 
   it("reports required missing keys and skips optional keys with no active binding", async () => {
     const normalized = normalizeConfig(
       defineConfig({
+        name: "test",
         envs: ["dev", "production"],
         keys: {
           required: config({ values: { production: "prod" } }),
@@ -112,6 +115,7 @@ describe("v5 resolver", () => {
   it("requires env only when a selected key has env-specific values without a fallback", async () => {
     const normalized = normalizeConfig(
       defineConfig({
+        name: "test",
         envs: ["dev", "production"],
         groups: ["app", "ci"],
         keys: {
@@ -143,6 +147,7 @@ describe("v5 resolver", () => {
   it("filters by group and path prefix while keeping groupless records shared", async () => {
     const normalized = normalizeConfig(
       defineConfig({
+        name: "test",
         envs: ["dev"],
         groups: ["app", "ci"],
         keys: {
@@ -152,7 +157,10 @@ describe("v5 resolver", () => {
             url: config({ group: "app", value: "https://example.test" })
           },
           ci: {
-            token: secret({ group: "ci", value: age({ identityFile: "./ci.txt" }) })
+            token: secret({
+              group: "ci",
+              value: age({ identityFile: "./ci.txt", secretsDir: "./secrets" })
+            })
           }
         }
       })
@@ -176,12 +184,14 @@ describe("v5 resolver", () => {
   it("rejects unknown envs, unknown groups, and group filters on groupless configs", async () => {
     const groupless = normalizeConfig(
       defineConfig({
+        name: "test",
         envs: ["dev"],
         keys: { app: "keyshelf" }
       })
     );
     const grouped = normalizeConfig(
       defineConfig({
+        name: "test",
         envs: ["dev"],
         groups: ["app"],
         keys: { app: config({ group: "app", value: "keyshelf" }) }
@@ -217,12 +227,16 @@ describe("v5 resolver", () => {
     const provider = mockProvider("age", "s3cr3t");
     const normalized = normalizeConfig(
       defineConfig({
+        name: "test",
         envs: ["dev"],
         groups: ["app", "ci"],
         keys: {
           db: {
             host: config({ group: "app", value: "localhost" }),
-            password: secret({ group: "ci", value: age({ identityFile: "./ci.txt" }) }),
+            password: secret({
+              group: "ci",
+              value: age({ identityFile: "./ci.txt", secretsDir: "./secrets" })
+            }),
             url: config({
               group: "app",
               value: "postgres://${db/password}@${db/host}/app"
@@ -256,6 +270,7 @@ describe("v5 resolver", () => {
   it("renders app mappings with per-env-var skip statuses", async () => {
     const normalized = normalizeConfig(
       defineConfig({
+        name: "test",
         envs: ["dev"],
         groups: ["app", "ci"],
         keys: {
@@ -264,7 +279,10 @@ describe("v5 resolver", () => {
             optional: config({ group: "app", optional: true })
           },
           ci: {
-            token: secret({ group: "ci", value: age({ identityFile: "./ci.txt" }) })
+            token: secret({
+              group: "ci",
+              value: age({ identityFile: "./ci.txt", secretsDir: "./secrets" })
+            })
           }
         }
       })
@@ -324,9 +342,13 @@ describe("v5 resolver", () => {
 
     const normalized = normalizeConfig(
       defineConfig({
+        name: "test",
         envs: ["dev"],
         keys: {
-          token: secret({ optional: true, value: age({ identityFile: "./ci.txt" }) })
+          token: secret({
+            optional: true,
+            value: age({ identityFile: "./ci.txt", secretsDir: "./secrets" })
+          })
         }
       })
     );
@@ -355,6 +377,7 @@ describe("v5 resolver", () => {
   it("collects unknown env, unknown groups, and missing --env as topLevelErrors", async () => {
     const normalized = normalizeConfig(
       defineConfig({
+        name: "test",
         envs: ["dev", "production"],
         groups: ["app", "ci"],
         keys: {
@@ -390,7 +413,9 @@ describe("v5 resolver", () => {
       keyErrors: []
     });
 
-    const groupless = normalizeConfig(defineConfig({ envs: ["dev"], keys: { app: "keyshelf" } }));
+    const groupless = normalizeConfig(
+      defineConfig({ name: "test", envs: ["dev"], keys: { app: "keyshelf" } })
+    );
     const groupOnGroupless = await validate({
       config: groupless,
       groups: ["app"],
@@ -425,6 +450,7 @@ describe("v5 resolver", () => {
   it("resolve still throws on top-level errors (unchanged fast-fail behavior)", async () => {
     const normalized = normalizeConfig(
       defineConfig({
+        name: "test",
         envs: ["dev"],
         groups: ["app"],
         keys: { app: config({ group: "app", value: "k" }) }


### PR DESCRIPTION
Phase 4 of #78.

## Summary

- Adds required top-level `name: string` to `defineConfig` (validated `[a-z0-9-]+`). Namespaces secrets in shared backends so multiple keyshelf configs can share one GCP project without colliding.
- `ProviderContext.envName` is now `string | undefined`; new optional `keyshelfName` field carries the config name through to providers. v4 callers still type-check and keep the old gcp secret-id format.
- New gcp secret id: `keyshelf__<name>__<env>__<path>` (env-scoped) or `keyshelf__<name>__<path>` (envless). Path separators are still mangled to `__` (`/` isn't valid in GCP secret ids).
- Factory option shapes now match the provider implementations:
  - `age({ identityFile, secretsDir })`
  - `gcp({ project })`
  - `sops({ identityFile, secretsFile })`
  - dropped speculative `recipient` / `secret` / `version` / `path` (unused)
- Spec doc + all `examples/` updated. v4 README intentionally left alone — Phase 9 owns the docs rewrite.

## Test plan

- [x] cli unit + integration: `npm test -w keyshelf` (248 pass, 4 skipped)
- [x] action unit tests still pass (6 pass)
- [x] new gcp-sm unit tests cover: legacy v4 callers (no `keyshelfName`), namespaced v5 callers, envless secret, empty-string `envName`
- [x] new `v5-providers.test.ts` integration test exercises age + gcp end-to-end through the resolver
- [x] `npm run typecheck` (cli + action)
- [x] `npm run typecheck:examples`
- [x] `npm run lint`
- [x] `npm run format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)