### PR TITLE
feat(v5): phase 5 — wire run/ls/set/import to v5 loader and resolver

### DIFF
--- a/packages/cli/src/v5/cli/import.ts
+++ b/packages/cli/src/v5/cli/import.ts
@@ -1,0 +1,113 @@
+import { Command } from "commander";
+import { readFile } from "node:fs/promises";
+import { loadV5Config } from "../config/index.js";
+import { isTemplateMapping } from "../../config/app-mapping.js";
+import { createDefaultRegistry } from "../../providers/setup.js";
+import type { BuiltinProviderRef, NormalizedRecord } from "../config/types.js";
+
+interface ImportOptions {
+  env?: string;
+  file: string;
+  map?: string;
+}
+
+function parseDotEnv(content: string): Record<string, string> {
+  const vars: Record<string, string> = {};
+  for (const raw of content.split("\n")) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eqIndex = line.indexOf("=");
+    if (eqIndex === -1) continue;
+    const key = line.slice(0, eqIndex).trim();
+    const value = line.slice(eqIndex + 1).trim();
+    if (key) vars[key] = value;
+  }
+  return vars;
+}
+
+export const importCommand = new Command("import")
+  .description("Bulk import secret values from a .env file via their bound providers")
+  .requiredOption("--file <file>", "Path to .env file to import")
+  .option("--env <env>", "Environment name")
+  .option("--map <map>", "Path to app mapping file (default: .env.keyshelf)")
+  .action(async (opts: ImportOptions) => {
+    const appDir = process.cwd();
+    const loaded = await loadV5Config(appDir, { mappingFile: opts.map });
+
+    const recordByPath = new Map(loaded.config.keys.map((record) => [record.path, record]));
+    const reverseMap = new Map(
+      loaded.appMapping
+        .filter((mapping) => !isTemplateMapping(mapping))
+        .map((mapping) => [mapping.envVar, (mapping as { keyPath: string }).keyPath])
+    );
+
+    const dotEnvContent = await readFile(opts.file, "utf-8");
+    const dotEnvVars = parseDotEnv(dotEnvContent);
+
+    const registry = createDefaultRegistry();
+    let imported = 0;
+    let skipped = 0;
+
+    for (const [envVar, value] of Object.entries(dotEnvVars)) {
+      const keyPath = reverseMap.get(envVar);
+      if (keyPath === undefined) {
+        skipped++;
+        continue;
+      }
+
+      const record = recordByPath.get(keyPath);
+      if (record === undefined) {
+        console.error(`warning: ${envVar} maps to "${keyPath}" which is not declared in config`);
+        skipped++;
+        continue;
+      }
+
+      if (record.kind === "config") {
+        console.error(
+          `warning: ${envVar} -> ${keyPath} is a config key. v5 does not write config via import — edit keyshelf.config.ts directly.`
+        );
+        skipped++;
+        continue;
+      }
+
+      const providerRef = pickProviderRef(record, opts.env);
+      if (providerRef === undefined) {
+        const envHint = opts.env ?? "(envless)";
+        console.error(
+          `warning: ${envVar} -> ${keyPath} has no provider binding for env ${envHint}; skipping`
+        );
+        skipped++;
+        continue;
+      }
+
+      const provider = registry.get(providerRef.name);
+      await provider.set(
+        {
+          keyPath,
+          envName: opts.env,
+          rootDir: loaded.rootDir,
+          config: { ...(providerRef.options as unknown as Record<string, unknown>) },
+          keyshelfName: loaded.config.name
+        },
+        value
+      );
+      console.log(`  secret: ${envVar} -> ${keyPath} (via ${providerRef.name})`);
+      imported++;
+    }
+
+    console.log(`\nImported ${imported} values, skipped ${skipped}`);
+  });
+
+function pickProviderRef(
+  record: NormalizedRecord & { kind: "secret" },
+  envName: string | undefined
+): BuiltinProviderRef | undefined {
+  if (
+    envName !== undefined &&
+    record.values !== undefined &&
+    Object.hasOwn(record.values, envName)
+  ) {
+    return record.values[envName];
+  }
+  return record.value;
+}

--- a/packages/cli/src/v5/cli/index.ts
+++ b/packages/cli/src/v5/cli/index.ts
@@ -1,4 +1,8 @@
 import { Command } from "commander";
+import { runCommand } from "./run.js";
+import { lsCommand } from "./ls.js";
+import { setCommand } from "./set.js";
+import { importCommand } from "./import.js";
 
 const V5_VERSION = "5.0.0-alpha.0";
 
@@ -7,13 +11,10 @@ export function createV5Program(): Command {
     .description("Keyshelf v5 development CLI")
     .version(V5_VERSION);
 
-  program.addCommand(createStatusCommand());
+  program.addCommand(runCommand);
+  program.addCommand(lsCommand);
+  program.addCommand(setCommand);
+  program.addCommand(importCommand);
 
   return program;
-}
-
-function createStatusCommand(): Command {
-  return new Command("status").description("Show v5 implementation status").action(() => {
-    console.log("keyshelf v5 phase 2 config loader is installed");
-  });
 }

--- a/packages/cli/src/v5/cli/ls.ts
+++ b/packages/cli/src/v5/cli/ls.ts
@@ -1,0 +1,250 @@
+import { Command } from "commander";
+import { loadV5Config } from "../config/index.js";
+import { renderAppMapping, resolveWithStatus, validate } from "../resolver/index.js";
+import { createDefaultRegistry } from "../../providers/setup.js";
+import { splitList } from "./options.js";
+import type { BuiltinProviderRef, ConfigBinding, NormalizedRecord } from "../config/types.js";
+import type { V5KeyResolutionStatus, V5Resolution } from "../resolver/types.js";
+import type { AppMapping } from "../../config/app-mapping.js";
+
+type LsFormat = "table" | "json";
+
+interface LsOptions {
+  env?: string;
+  group?: string;
+  filter?: string;
+  reveal?: boolean;
+  map?: string;
+  format?: string;
+}
+
+interface KeyRow {
+  path: string;
+  kind: string;
+  group: string;
+  detail: string;
+}
+
+interface JsonVar {
+  envVar: string;
+  keyPath: string | null;
+  value: string;
+  secret: boolean;
+  template?: true;
+}
+
+export const lsCommand = new Command("ls")
+  .description("List keys defined in the config")
+  .option("--env <env>", "Environment name")
+  .option("--group <names>", "Comma-separated group filter")
+  .option("--filter <prefixes>", "Comma-separated key-path prefix filter")
+  .option("--reveal", "Resolve and show actual values (requires --env)")
+  .option("--map <file>", "Path to app mapping file")
+  .option("--format <format>", "Output format: table (default) or json", "table")
+  .action(async (opts: LsOptions) => {
+    const format = parseFormat(opts.format);
+
+    if (opts.reveal && !opts.env) {
+      console.error("error: --reveal requires --env");
+      process.exit(1);
+    }
+    if (format === "json" && !(opts.reveal && opts.env && opts.map)) {
+      console.error("error: --format json requires --reveal, --env, and --map");
+      process.exit(1);
+    }
+
+    const appDir = process.cwd();
+    const loaded = await loadV5Config(appDir, { mappingFile: opts.map });
+    const groups = splitList(opts.group);
+    const filters = splitList(opts.filter);
+
+    if (opts.reveal && opts.env !== undefined) {
+      const registry = createDefaultRegistry();
+      const resolveOpts = {
+        config: loaded.config,
+        envName: opts.env,
+        rootDir: loaded.rootDir,
+        registry,
+        groups,
+        filters
+      };
+
+      const validation = await validate(resolveOpts);
+      if (validation.topLevelErrors.length > 0) {
+        for (const err of validation.topLevelErrors) console.error(`error: ${err.message}`);
+        process.exit(1);
+      }
+      if (validation.keyErrors.length > 0) {
+        console.error("Validation errors:");
+        for (const err of validation.keyErrors) console.error(`  - ${err.path}: ${err.message}`);
+        process.exit(1);
+      }
+
+      const resolution = await resolveWithStatus(resolveOpts);
+
+      if (format === "json") {
+        const vars = buildJsonVars(loaded.appMapping, loaded.config.keys, resolution);
+        process.stdout.write(JSON.stringify({ env: opts.env, vars }, null, 2) + "\n");
+        return;
+      }
+
+      console.error("warning: revealing secret values");
+      printRows(buildRevealedRows(loaded.config.keys, resolution));
+      return;
+    }
+
+    printRows(buildSchemaRows(loaded.config.keys, opts.env, groups, filters));
+  });
+
+function parseFormat(raw: string | undefined): LsFormat {
+  if (raw === undefined || raw === "table") return "table";
+  if (raw === "json") return "json";
+  console.error(`error: unknown --format value "${raw}" (expected "table" or "json")`);
+  process.exit(1);
+}
+
+function buildSchemaRows(
+  records: NormalizedRecord[],
+  envName: string | undefined,
+  groups: string[] | undefined,
+  filters: string[] | undefined
+): KeyRow[] {
+  const groupSet = groups ? new Set(groups) : undefined;
+  const filterPrefixes = filters ?? [];
+
+  return records.map((record): KeyRow => {
+    const filtered = isFiltered(record, groupSet, filterPrefixes);
+    return {
+      path: record.path,
+      kind: record.kind,
+      group: record.group ?? "",
+      detail: filtered ? "(filtered)" : describeSource(record, envName)
+    };
+  });
+}
+
+function buildRevealedRows(records: NormalizedRecord[], resolution: V5Resolution): KeyRow[] {
+  return records.map((record): KeyRow => {
+    const status = resolution.statusByPath.get(record.path);
+    return {
+      path: record.path,
+      kind: record.kind,
+      group: record.group ?? "",
+      detail: describeStatus(record, status)
+    };
+  });
+}
+
+function describeStatus(
+  record: NormalizedRecord,
+  status: V5KeyResolutionStatus | undefined
+): string {
+  if (status?.status === "resolved") return status.value;
+  if (status?.status === "filtered") return "(filtered)";
+  if (status?.status === "skipped") {
+    return record.optional ? "(optional, no value)" : status.reason;
+  }
+  if (status?.status === "error") return `error: ${status.message}`;
+  return "(missing)";
+}
+
+function describeSource(record: NormalizedRecord, envName: string | undefined): string {
+  const binding = getActiveBinding(record, envName);
+
+  if (record.kind === "secret") {
+    if (binding !== undefined) {
+      return `provider: ${(binding as BuiltinProviderRef).name}`;
+    }
+    if (record.optional) return "(optional, no provider)";
+    return "(no provider bound)";
+  }
+
+  if (binding !== undefined) {
+    return `value: ${formatScalar(binding as ConfigBinding)}`;
+  }
+  if (record.optional) return "(optional, no value)";
+  return "(missing)";
+}
+
+function getActiveBinding(record: NormalizedRecord, envName: string | undefined): unknown {
+  if (
+    envName !== undefined &&
+    record.values !== undefined &&
+    Object.hasOwn(record.values, envName)
+  ) {
+    return record.values[envName];
+  }
+  return record.value;
+}
+
+function formatScalar(value: ConfigBinding): string {
+  return typeof value === "string" ? value : String(value);
+}
+
+function isFiltered(
+  record: NormalizedRecord,
+  groupSet: Set<string> | undefined,
+  filterPrefixes: string[]
+): boolean {
+  if (groupSet !== undefined && groupSet.size > 0) {
+    if (record.group !== undefined && !groupSet.has(record.group)) return true;
+  }
+  if (filterPrefixes.length > 0) {
+    const matches = filterPrefixes.some(
+      (prefix) => record.path === prefix || record.path.startsWith(`${prefix}/`)
+    );
+    if (!matches) return true;
+  }
+  return false;
+}
+
+function buildJsonVars(
+  mappings: AppMapping[],
+  records: NormalizedRecord[],
+  resolution: V5Resolution
+): JsonVar[] {
+  const recordByPath = new Map(records.map((record) => [record.path, record]));
+  const rendered = renderAppMapping(mappings, resolution);
+
+  return rendered.flatMap((result): JsonVar[] => {
+    if (result.status !== "rendered") return [];
+
+    if ("template" in result.mapping) {
+      const secret = result.mapping.keyPaths.some(
+        (path) => recordByPath.get(path)?.kind === "secret"
+      );
+      return [
+        {
+          envVar: result.envVar,
+          keyPath: null,
+          value: result.value,
+          secret,
+          template: true
+        }
+      ];
+    }
+
+    return [
+      {
+        envVar: result.envVar,
+        keyPath: result.mapping.keyPath,
+        value: result.value,
+        secret: recordByPath.get(result.mapping.keyPath)?.kind === "secret"
+      }
+    ];
+  });
+}
+
+function printRows(rows: KeyRow[]): void {
+  if (rows.length === 0) return;
+  const pathWidth = Math.max(...rows.map((r) => r.path.length));
+  const kindWidth = Math.max(...rows.map((r) => r.kind.length));
+  const groupWidth = Math.max(...rows.map((r) => r.group.length));
+
+  for (const row of rows) {
+    const parts = [row.path.padEnd(pathWidth), row.kind.padEnd(kindWidth)];
+    if (groupWidth > 0) parts.push(row.group.padEnd(groupWidth));
+    parts.push(row.detail);
+    console.log(parts.filter((p) => p !== "").join("   "));
+  }
+}

--- a/packages/cli/src/v5/cli/options.ts
+++ b/packages/cli/src/v5/cli/options.ts
@@ -1,0 +1,8 @@
+export function splitList(value: string | undefined): string[] | undefined {
+  if (value === undefined) return undefined;
+  const parts = value
+    .split(",")
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+  return parts.length === 0 ? undefined : parts;
+}

--- a/packages/cli/src/v5/cli/run.ts
+++ b/packages/cli/src/v5/cli/run.ts
@@ -1,0 +1,74 @@
+import { Command } from "commander";
+import spawn from "cross-spawn";
+import { loadV5Config } from "../config/index.js";
+import { renderAppMapping, resolveWithStatus, validate } from "../resolver/index.js";
+import { createDefaultRegistry } from "../../providers/setup.js";
+import { splitList } from "./options.js";
+
+interface RunOptions {
+  env?: string;
+  group?: string;
+  filter?: string;
+  map?: string;
+}
+
+export const runCommand = new Command("run")
+  .description("Resolve keys and run a command with env vars injected")
+  .option("--env <env>", "Environment name")
+  .option("--group <names>", "Comma-separated group filter")
+  .option("--filter <prefixes>", "Comma-separated key-path prefix filter")
+  .option("--map <file>", "Path to app mapping file (default: .env.keyshelf)")
+  .argument("<command...>", "Command to run")
+  .allowExcessArguments(true)
+  .action(async (commandArgs: string[], opts: RunOptions) => {
+    const appDir = process.cwd();
+    const loaded = await loadV5Config(appDir, { mappingFile: opts.map });
+    const registry = createDefaultRegistry();
+
+    const resolveOpts = {
+      config: loaded.config,
+      envName: opts.env,
+      rootDir: loaded.rootDir,
+      registry,
+      groups: splitList(opts.group),
+      filters: splitList(opts.filter)
+    };
+
+    const validation = await validate(resolveOpts);
+    if (validation.topLevelErrors.length > 0) {
+      for (const err of validation.topLevelErrors) console.error(`error: ${err.message}`);
+      process.exit(1);
+    }
+    if (validation.keyErrors.length > 0) {
+      console.error("Validation errors:");
+      for (const err of validation.keyErrors) console.error(`  - ${err.path}: ${err.message}`);
+      process.exit(1);
+    }
+
+    const resolution = await resolveWithStatus(resolveOpts);
+    const rendered = renderAppMapping(loaded.appMapping, resolution);
+
+    const envVars: Record<string, string> = {};
+    for (const result of rendered) {
+      if (result.status === "rendered") {
+        envVars[result.envVar] = result.value;
+      } else {
+        console.error(`keyshelf: skipping ${result.envVar} — ${result.reason}`);
+      }
+    }
+
+    const [cmd, ...args] = commandArgs;
+    const child = spawn(cmd, args, {
+      stdio: "inherit",
+      env: { ...envVars, ...process.env }
+    });
+
+    child.on("close", (code) => {
+      process.exit(code ?? 1);
+    });
+
+    child.on("error", (err) => {
+      console.error(`Failed to start command: ${err.message}`);
+      process.exit(1);
+    });
+  });

--- a/packages/cli/src/v5/cli/set.ts
+++ b/packages/cli/src/v5/cli/set.ts
@@ -1,0 +1,105 @@
+import { Command } from "commander";
+import { createInterface } from "node:readline";
+import { loadV5Config } from "../config/index.js";
+import { createDefaultRegistry } from "../../providers/setup.js";
+import type { BuiltinProviderRef, NormalizedRecord } from "../config/types.js";
+
+interface SetOptions {
+  env?: string;
+  value?: string;
+}
+
+export const setCommand = new Command("set")
+  .description("Store a secret value via its bound provider")
+  .option("--env <env>", "Environment name")
+  .option("--value <value>", "Value to set (non-interactive)")
+  .argument("<key>", "Key path (e.g. db/password)")
+  .action(async (keyPath: string, opts: SetOptions) => {
+    const appDir = process.cwd();
+    const loaded = await loadV5Config(appDir);
+    const record = loaded.config.keys.find((entry) => entry.path === keyPath);
+
+    if (record === undefined) {
+      console.error(`error: key "${keyPath}" is not defined in keyshelf.config.ts`);
+      process.exit(1);
+    }
+
+    if (record.kind === "config") {
+      console.error(
+        `error: "${keyPath}" is a config key. v5 does not write config values via set — edit keyshelf.config.ts directly.`
+      );
+      process.exit(1);
+    }
+
+    const providerRef = pickProviderRef(record, opts.env);
+    if (providerRef === undefined) {
+      const envHint = opts.env ?? "(envless)";
+      console.error(
+        `error: no provider binding for "${keyPath}" in env ${envHint}. Add a value/default or values[${envHint}] entry in keyshelf.config.ts.`
+      );
+      process.exit(1);
+    }
+
+    const value = await readValue(keyPath, opts.value);
+    const registry = createDefaultRegistry();
+    const provider = registry.get(providerRef.name);
+
+    await provider.set(
+      {
+        keyPath,
+        envName: opts.env,
+        rootDir: loaded.rootDir,
+        config: { ...(providerRef.options as unknown as Record<string, unknown>) },
+        keyshelfName: loaded.config.name
+      },
+      value
+    );
+
+    const where = opts.env ? ` for ${opts.env}` : "";
+    console.log(`Stored "${keyPath}" via ${providerRef.name} provider${where}`);
+  });
+
+function pickProviderRef(
+  record: NormalizedRecord & { kind: "secret" },
+  envName: string | undefined
+): BuiltinProviderRef | undefined {
+  if (
+    envName !== undefined &&
+    record.values !== undefined &&
+    Object.hasOwn(record.values, envName)
+  ) {
+    return record.values[envName];
+  }
+  return record.value;
+}
+
+async function readValue(keyPath: string, explicit: string | undefined): Promise<string> {
+  if (explicit !== undefined) return explicit;
+  if (!process.stdin.isTTY) return readStdinPipe();
+  return readHiddenInput(`Enter value for ${keyPath}: `);
+}
+
+function readStdinPipe(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = "";
+    process.stdin.setEncoding("utf-8");
+    process.stdin.on("data", (chunk) => (data += chunk));
+    process.stdin.on("end", () => resolve(data.trim()));
+    process.stdin.on("error", reject);
+  });
+}
+
+function readHiddenInput(prompt: string): Promise<string> {
+  const rl = createInterface({
+    input: process.stdin,
+    output: process.stderr
+  });
+
+  return new Promise((resolve) => {
+    process.stderr.write(prompt);
+    rl.on("line", (line) => {
+      rl.close();
+      resolve(line);
+    });
+  });
+}

--- a/packages/cli/test/e2e/helpers/v5-cli.ts
+++ b/packages/cli/test/e2e/helpers/v5-cli.ts
@@ -1,0 +1,7 @@
+import { join } from "node:path";
+import { TSX } from "./cli.js";
+
+const PACKAGE_ROOT = join(import.meta.dirname, "..", "..", "..");
+
+export const V5_CLI = join(PACKAGE_ROOT, "bin", "keyshelf-next.ts");
+export { TSX };

--- a/packages/cli/test/e2e/v5-import.test.ts
+++ b/packages/cli/test/e2e/v5-import.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { writeFileSync as fsWriteFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+import { generateIdentity } from "../../src/providers/age.js";
+import { V5_CLI, TSX } from "./helpers/v5-cli.js";
+
+function writeFileSync(path: string, lines: string[]): void {
+  fsWriteFileSync(path, lines.join("\n") + "\n");
+}
+
+async function writeFixture(root: string) {
+  const identityFile = join(root, "key.txt");
+  const secretsDir = join(root, ".keyshelf", "secrets");
+  await writeFile(identityFile, await generateIdentity());
+  await mkdir(secretsDir, { recursive: true });
+
+  await writeFile(
+    join(root, "keyshelf.config.ts"),
+    [
+      `import { defineConfig, config, secret, age } from "keyshelf/config";`,
+      ``,
+      `export default defineConfig({`,
+      `  name: "demo",`,
+      `  envs: ["dev"],`,
+      `  keys: {`,
+      `    db: {`,
+      `      host: config({ default: "localhost" }),`,
+      `      password: secret({ value: age({ identityFile: ${JSON.stringify(identityFile)}, secretsDir: ${JSON.stringify(secretsDir)} }) }),`,
+      `      apiKey: secret({ value: age({ identityFile: ${JSON.stringify(identityFile)}, secretsDir: ${JSON.stringify(secretsDir)} }) }),`,
+      `    },`,
+      `  },`,
+      `});`,
+      ``
+    ].join("\n")
+  );
+  await writeFile(
+    join(root, ".env.keyshelf"),
+    ["DB_HOST=db/host", "DB_PASSWORD=db/password", "DB_API_KEY=db/apiKey"].join("\n")
+  );
+}
+
+describe("keyshelf-next import", () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "keyshelf-v5-import-"));
+    await writeFixture(root);
+  });
+
+  it("imports secrets via their bound providers and warns about config keys", () => {
+    const envFile = join(root, ".env.values");
+    writeFileSync(envFile, ["DB_HOST=imported-host", "DB_PASSWORD=imported-pw", "DB_API_KEY=k1"]);
+
+    const out = execFileSync(TSX, [V5_CLI, "import", "--env", "dev", "--file", envFile], {
+      cwd: root,
+      encoding: "utf-8",
+      stdio: ["inherit", "pipe", "pipe"]
+    });
+
+    expect(out).toContain("Imported 2 values");
+
+    const result = execFileSync(
+      TSX,
+      [
+        V5_CLI,
+        "run",
+        "--env",
+        "dev",
+        "--",
+        "node",
+        "-e",
+        "console.log(JSON.stringify({h: process.env.DB_HOST, p: process.env.DB_PASSWORD, k: process.env.DB_API_KEY}))"
+      ],
+      { cwd: root, encoding: "utf-8" }
+    );
+    // DB_HOST stays at the config default (config keys are not written by import).
+    expect(JSON.parse(result.trim())).toEqual({
+      h: "localhost",
+      p: "imported-pw",
+      k: "k1"
+    });
+  });
+
+  it("skips unmapped env vars", () => {
+    const envFile = join(root, ".env.values");
+    writeFileSync(envFile, ["UNMAPPED=foo", "DB_PASSWORD=imported-pw"]);
+
+    const out = execFileSync(TSX, [V5_CLI, "import", "--env", "dev", "--file", envFile], {
+      cwd: root,
+      encoding: "utf-8"
+    });
+    expect(out).toContain("Imported 1 values, skipped 1");
+  });
+});

--- a/packages/cli/test/e2e/v5-ls.test.ts
+++ b/packages/cli/test/e2e/v5-ls.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+import { generateIdentity } from "../../src/providers/age.js";
+import { V5_CLI, TSX } from "./helpers/v5-cli.js";
+
+async function writeAgeFixture(root: string) {
+  const identityFile = join(root, "key.txt");
+  const secretsDir = join(root, ".keyshelf", "secrets");
+  await writeFile(identityFile, await generateIdentity());
+  await mkdir(secretsDir, { recursive: true });
+
+  await writeFile(
+    join(root, "keyshelf.config.ts"),
+    [
+      `import { defineConfig, config, secret, age } from "keyshelf/config";`,
+      ``,
+      `export default defineConfig({`,
+      `  name: "demo",`,
+      `  envs: ["dev", "production"],`,
+      `  groups: ["app", "ci"],`,
+      `  keys: {`,
+      `    db: {`,
+      `      host: config({ group: "app", default: "localhost", values: { production: "prod-db" } }),`,
+      `      password: secret({ group: "app", value: age({ identityFile: ${JSON.stringify(identityFile)}, secretsDir: ${JSON.stringify(secretsDir)} }) }),`,
+      `    },`,
+      `    ci: {`,
+      `      token: secret({ group: "ci", value: age({ identityFile: ${JSON.stringify(identityFile)}, secretsDir: ${JSON.stringify(secretsDir)} }) }),`,
+      `    },`,
+      `  },`,
+      `});`,
+      ``
+    ].join("\n")
+  );
+  await writeFile(
+    join(root, ".env.keyshelf"),
+    ["DB_HOST=db/host", "DB_PASSWORD=db/password", "CI_TOKEN=ci/token"].join("\n")
+  );
+}
+
+describe("keyshelf-next ls", () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "keyshelf-v5-ls-"));
+    await writeAgeFixture(root);
+  });
+
+  it("lists schema with kind, group, and source columns", () => {
+    const result = execFileSync(TSX, [V5_CLI, "ls"], { cwd: root, encoding: "utf-8" });
+    const lines = result.trim().split("\n");
+    expect(lines).toEqual([
+      expect.stringMatching(/^db\/host\s+config\s+app\s+value: localhost$/),
+      expect.stringMatching(/^db\/password\s+secret\s+app\s+provider: age$/),
+      expect.stringMatching(/^ci\/token\s+secret\s+ci\s+provider: age$/)
+    ]);
+  });
+
+  it("uses values[env] override in source description", () => {
+    const result = execFileSync(TSX, [V5_CLI, "ls", "--env", "production"], {
+      cwd: root,
+      encoding: "utf-8"
+    });
+    expect(result).toMatch(/db\/host\s+config\s+app\s+value: prod-db/);
+  });
+
+  it("--group ci marks app keys as filtered", () => {
+    const result = execFileSync(TSX, [V5_CLI, "ls", "--group", "ci"], {
+      cwd: root,
+      encoding: "utf-8"
+    });
+    expect(result).toMatch(/db\/host\s+\S+\s+app\s+\(filtered\)/);
+    expect(result).toMatch(/ci\/token\s+secret\s+ci\s+provider: age/);
+  });
+
+  it("--reveal without --env errors", () => {
+    try {
+      execFileSync(TSX, [V5_CLI, "ls", "--reveal"], {
+        cwd: root,
+        encoding: "utf-8",
+        stdio: "pipe"
+      });
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect((err as { stderr: string }).stderr).toContain("--reveal requires --env");
+    }
+  });
+});
+
+describe("keyshelf-next ls (reveal)", () => {
+  let root: string;
+
+  beforeAll(async () => {
+    root = await mkdtemp(join(tmpdir(), "keyshelf-v5-ls-reveal-"));
+    await writeAgeFixture(root);
+    execFileSync(TSX, [V5_CLI, "set", "--env", "dev", "--value", "host-pw", "db/password"], {
+      cwd: root,
+      encoding: "utf-8"
+    });
+    execFileSync(TSX, [V5_CLI, "set", "--env", "dev", "--value", "ci-pw", "ci/token"], {
+      cwd: root,
+      encoding: "utf-8"
+    });
+  });
+
+  it("--reveal --env shows resolved values", () => {
+    const result = execFileSync(TSX, [V5_CLI, "ls", "--reveal", "--env", "dev"], {
+      cwd: root,
+      encoding: "utf-8",
+      stdio: ["inherit", "pipe", "pipe"]
+    });
+    expect(result).toMatch(/db\/host\s+\S+\s+app\s+localhost/);
+    expect(result).toMatch(/db\/password\s+secret\s+app\s+host-pw/);
+    expect(result).toMatch(/ci\/token\s+secret\s+ci\s+ci-pw/);
+  });
+
+  it("--format json --reveal --env --map emits structured vars", () => {
+    const result = execFileSync(
+      TSX,
+      [V5_CLI, "ls", "--reveal", "--env", "dev", "--map", ".env.keyshelf", "--format", "json"],
+      { cwd: root, encoding: "utf-8" }
+    );
+    const parsed = JSON.parse(result);
+    expect(parsed).toMatchObject({
+      env: "dev",
+      vars: [
+        { envVar: "DB_HOST", keyPath: "db/host", value: "localhost", secret: false },
+        { envVar: "DB_PASSWORD", keyPath: "db/password", value: "host-pw", secret: true },
+        { envVar: "CI_TOKEN", keyPath: "ci/token", value: "ci-pw", secret: true }
+      ]
+    });
+  });
+});

--- a/packages/cli/test/e2e/v5-run.test.ts
+++ b/packages/cli/test/e2e/v5-run.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, beforeEach, beforeAll } from "vitest";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+import { generateIdentity } from "../../src/providers/age.js";
+import { V5_CLI, TSX } from "./helpers/v5-cli.js";
+
+async function writeBaseFixture(root: string) {
+  await writeFile(
+    join(root, "keyshelf.config.ts"),
+    [
+      `import { defineConfig, config } from "keyshelf/config";`,
+      ``,
+      `export default defineConfig({`,
+      `  name: "demo",`,
+      `  envs: ["dev", "production"],`,
+      `  keys: {`,
+      `    db: {`,
+      `      host: config({ default: "localhost", values: { production: "prod-db" } }),`,
+      `      port: 5432,`,
+      `    },`,
+      `  },`,
+      `});`,
+      ``
+    ].join("\n")
+  );
+  await writeFile(join(root, ".env.keyshelf"), ["DB_HOST=db/host", "DB_PORT=db/port"].join("\n"));
+}
+
+async function writeGroupFixture(root: string) {
+  const identityFile = join(root, "key.txt");
+  const secretsDir = join(root, ".keyshelf", "secrets");
+  await writeFile(identityFile, await generateIdentity());
+  await mkdir(secretsDir, { recursive: true });
+
+  await writeFile(
+    join(root, "keyshelf.config.ts"),
+    [
+      `import { defineConfig, config, secret, age } from "keyshelf/config";`,
+      ``,
+      `export default defineConfig({`,
+      `  name: "demo",`,
+      `  envs: ["dev"],`,
+      `  groups: ["app", "ci"],`,
+      `  keys: {`,
+      `    app: {`,
+      `      host: config({ group: "app", value: "localhost" }),`,
+      `    },`,
+      `    ci: {`,
+      `      token: secret({ group: "ci", value: age({ identityFile: ${JSON.stringify(identityFile)}, secretsDir: ${JSON.stringify(secretsDir)} }) }),`,
+      `    },`,
+      `  },`,
+      `});`,
+      ``
+    ].join("\n")
+  );
+
+  await writeFile(
+    join(root, ".env.keyshelf"),
+    ["APP_HOST=app/host", "CI_TOKEN=ci/token"].join("\n")
+  );
+
+  return { identityFile, secretsDir };
+}
+
+describe("keyshelf-next run", () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "keyshelf-v5-run-"));
+    await writeBaseFixture(root);
+  });
+
+  it("injects env vars from config defaults when no --env is given", () => {
+    const result = execFileSync(
+      TSX,
+      [
+        V5_CLI,
+        "run",
+        "--",
+        "node",
+        "-e",
+        "console.log(JSON.stringify({h: process.env.DB_HOST, p: process.env.DB_PORT}))"
+      ],
+      { cwd: root, encoding: "utf-8" }
+    );
+    expect(JSON.parse(result.trim())).toEqual({ h: "localhost", p: "5432" });
+  });
+
+  it("uses values[env] override when --env is provided", () => {
+    const result = execFileSync(
+      TSX,
+      [
+        V5_CLI,
+        "run",
+        "--env",
+        "production",
+        "--",
+        "node",
+        "-e",
+        "console.log(process.env.DB_HOST)"
+      ],
+      { cwd: root, encoding: "utf-8" }
+    );
+    expect(result.trim()).toBe("prod-db");
+  });
+
+  it("forwards child exit code", () => {
+    try {
+      execFileSync(TSX, [V5_CLI, "run", "--", "node", "-e", "process.exit(42)"], {
+        cwd: root,
+        encoding: "utf-8",
+        stdio: "pipe"
+      });
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect((err as { status: number }).status).toBe(42);
+    }
+  });
+
+  it("rejects unknown --env with a top-level error", () => {
+    try {
+      execFileSync(TSX, [V5_CLI, "run", "--env", "staging", "--", "echo", "hi"], {
+        cwd: root,
+        encoding: "utf-8",
+        stdio: "pipe"
+      });
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect((err as { stderr: string }).stderr).toContain('Unknown env "staging"');
+    }
+  });
+});
+
+describe("keyshelf-next run (groups)", () => {
+  let root: string;
+  let identityFile: string;
+  let secretsDir: string;
+
+  beforeAll(async () => {
+    root = await mkdtemp(join(tmpdir(), "keyshelf-v5-run-groups-"));
+    const fixture = await writeGroupFixture(root);
+    identityFile = fixture.identityFile;
+    secretsDir = fixture.secretsDir;
+
+    execFileSync(TSX, [V5_CLI, "set", "--env", "dev", "--value", "ci-secret-value", "ci/token"], {
+      cwd: root,
+      encoding: "utf-8"
+    });
+    expect(identityFile).toContain(root);
+    expect(secretsDir).toContain(root);
+  });
+
+  it("--group app skips ci/token mapping with stderr warning", () => {
+    const result = execFileSync(
+      TSX,
+      [
+        V5_CLI,
+        "run",
+        "--env",
+        "dev",
+        "--group",
+        "app",
+        "--",
+        "node",
+        "-e",
+        "console.log(JSON.stringify({h: process.env.APP_HOST ?? null, t: process.env.CI_TOKEN ?? null}))"
+      ],
+      { cwd: root, encoding: "utf-8", stdio: ["inherit", "pipe", "pipe"] }
+    );
+    expect(JSON.parse(result.trim())).toEqual({ h: "localhost", t: null });
+  });
+
+  it("--group ci resolves the secret", () => {
+    const result = execFileSync(
+      TSX,
+      [
+        V5_CLI,
+        "run",
+        "--env",
+        "dev",
+        "--group",
+        "ci",
+        "--",
+        "node",
+        "-e",
+        "console.log(process.env.CI_TOKEN)"
+      ],
+      { cwd: root, encoding: "utf-8" }
+    );
+    expect(result.trim()).toBe("ci-secret-value");
+  });
+});

--- a/packages/cli/test/e2e/v5-set.test.ts
+++ b/packages/cli/test/e2e/v5-set.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+import { generateIdentity } from "../../src/providers/age.js";
+import { V5_CLI, TSX } from "./helpers/v5-cli.js";
+
+async function writeFixture(root: string) {
+  const identityFile = join(root, "key.txt");
+  const secretsDir = join(root, ".keyshelf", "secrets");
+  await writeFile(identityFile, await generateIdentity());
+  await mkdir(secretsDir, { recursive: true });
+
+  await writeFile(
+    join(root, "keyshelf.config.ts"),
+    [
+      `import { defineConfig, config, secret, age } from "keyshelf/config";`,
+      ``,
+      `export default defineConfig({`,
+      `  name: "demo",`,
+      `  envs: ["dev"],`,
+      `  keys: {`,
+      `    db: {`,
+      `      host: config({ default: "localhost" }),`,
+      `      password: secret({ value: age({ identityFile: ${JSON.stringify(identityFile)}, secretsDir: ${JSON.stringify(secretsDir)} }) }),`,
+      `    },`,
+      `  },`,
+      `});`,
+      ``
+    ].join("\n")
+  );
+  await writeFile(
+    join(root, ".env.keyshelf"),
+    ["DB_HOST=db/host", "DB_PASSWORD=db/password"].join("\n")
+  );
+}
+
+describe("keyshelf-next set", () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "keyshelf-v5-set-"));
+    await writeFixture(root);
+  });
+
+  it("stores secret via the bound provider and run reads it back", () => {
+    execFileSync(TSX, [V5_CLI, "set", "--env", "dev", "--value", "stored-pw", "db/password"], {
+      cwd: root,
+      encoding: "utf-8"
+    });
+
+    const result = execFileSync(
+      TSX,
+      [V5_CLI, "run", "--env", "dev", "--", "node", "-e", "console.log(process.env.DB_PASSWORD)"],
+      { cwd: root, encoding: "utf-8" }
+    );
+    expect(result.trim()).toBe("stored-pw");
+  });
+
+  it("rejects setting a config key", () => {
+    try {
+      execFileSync(TSX, [V5_CLI, "set", "--env", "dev", "--value", "x", "db/host"], {
+        cwd: root,
+        encoding: "utf-8",
+        stdio: "pipe"
+      });
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect((err as { stderr: string }).stderr).toContain("v5 does not write config values");
+    }
+  });
+
+  it("rejects unknown key", () => {
+    try {
+      execFileSync(TSX, [V5_CLI, "set", "--env", "dev", "--value", "x", "does/not/exist"], {
+        cwd: root,
+        encoding: "utf-8",
+        stdio: "pipe"
+      });
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect((err as { stderr: string }).stderr).toContain('"does/not/exist" is not defined');
+    }
+  });
+
+  it("reads value from stdin pipe when --value is omitted", () => {
+    execFileSync(TSX, [V5_CLI, "set", "--env", "dev", "db/password"], {
+      cwd: root,
+      encoding: "utf-8",
+      input: "piped-pw\n"
+    });
+
+    const result = execFileSync(
+      TSX,
+      [V5_CLI, "run", "--env", "dev", "--", "node", "-e", "console.log(process.env.DB_PASSWORD)"],
+      { cwd: root, encoding: "utf-8" }
+    );
+    expect(result.trim()).toBe("piped-pw");
+  });
+});

--- a/packages/cli/test/unit/v5/cli.test.ts
+++ b/packages/cli/test/unit/v5/cli.test.ts
@@ -1,20 +1,15 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { createV5Program } from "../../../src/v5/index.js";
 
 describe("createV5Program", () => {
-  it("creates an isolated keyshelf-next program", () => {
+  it("registers run, ls, set, and import commands", () => {
     const program = createV5Program();
-
     expect(program.name()).toBe("keyshelf-next");
-    expect(program.commands.map((command) => command.name())).toEqual(["status"]);
-  });
-
-  it("reports phase 2 status", async () => {
-    const log = vi.spyOn(console, "log").mockImplementation(() => {});
-
-    await createV5Program().parseAsync(["node", "keyshelf-next", "status"]);
-
-    expect(log).toHaveBeenCalledWith("keyshelf v5 phase 2 config loader is installed");
-    log.mockRestore();
+    expect(program.commands.map((command) => command.name()).sort()).toEqual([
+      "import",
+      "ls",
+      "run",
+      "set"
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- Replaces the `keyshelf-next` `status` stub with real `run`, `ls`, `set`, and `import` commands backed by the v5 loader and resolver.
- `run` adds `--group` / `--filter` and makes `--env` optional; emits `keyshelf: skipping ENV_VAR — <reason>` to stderr per the spec when an app-mapping reference is filtered or unresolved.
- `ls` lists `path / kind / group / source` with `--group`/`--filter` for filtering and `--reveal --env` for resolved values. `--format json` (requires `--reveal --env --map`) emits structured `{ env, vars }` like v4.
- `set` is provider-only — picks the bound `ProviderRef` for the active env (`values[env]` → `value`/`default`) and rejects config keys with a clear error. Reads value from `--value`, stdin pipe, or hidden prompt.
- `import` routes secret keys through their bound provider; warns and skips config keys (per "set is provider-only" rule); reports imported/skipped counts.

## Test plan
- [x] `npm --workspace packages/cli run typecheck` clean
- [x] `npm --workspace packages/cli test` — 265 tests / 27 files pass
- [x] New e2e tests cover: env validation, group filter skip-with-warning, `--reveal --format json`, config-key rejection on `set`/`import`, stdin-pipe `set`, child exit-code forwarding
- [x] eslint clean on new files

🤖 Generated with [Claude Code](https://claude.com/claude-code)