### PR TITLE
feat(v5): enrich resolver skip statuses with structured causes

### DIFF
--- a/packages/cli/src/v5/cli/ls.ts
+++ b/packages/cli/src/v5/cli/ls.ts
@@ -1,6 +1,11 @@
 import { Command } from "commander";
 import { loadV5Config } from "../config/index.js";
-import { renderAppMapping, resolveWithStatus, validate } from "../resolver/index.js";
+import {
+  formatSkipCause,
+  renderAppMapping,
+  resolveWithStatus,
+  validate
+} from "../resolver/index.js";
 import { createDefaultRegistry } from "../../providers/setup.js";
 import { splitList } from "./options.js";
 import type { BuiltinProviderRef, ConfigBinding, NormalizedRecord } from "../config/types.js";
@@ -142,7 +147,8 @@ function describeStatus(
   if (status?.status === "resolved") return status.value;
   if (status?.status === "filtered") return "(filtered)";
   if (status?.status === "skipped") {
-    return record.optional ? "(optional, no value)" : status.reason;
+    if (record.optional) return "(optional, no value)";
+    return `key '${record.path}' ${formatSkipCause(status.cause)}`;
   }
   if (status?.status === "error") return `error: ${status.message}`;
   return "(missing)";

--- a/packages/cli/src/v5/cli/run.ts
+++ b/packages/cli/src/v5/cli/run.ts
@@ -1,7 +1,12 @@
 import { Command } from "commander";
 import spawn from "cross-spawn";
 import { loadV5Config } from "../config/index.js";
-import { renderAppMapping, resolveWithStatus, validate } from "../resolver/index.js";
+import {
+  formatSkipCause,
+  renderAppMapping,
+  resolveWithStatus,
+  validate
+} from "../resolver/index.js";
 import { createDefaultRegistry } from "../../providers/setup.js";
 import { splitList } from "./options.js";
 
@@ -53,7 +58,9 @@ export const runCommand = new Command("run")
       if (result.status === "rendered") {
         envVars[result.envVar] = result.value;
       } else {
-        console.error(`keyshelf: skipping ${result.envVar} — ${result.reason}`);
+        console.error(
+          `keyshelf: skipping ${result.envVar} — referenced key '${result.keyPath}' ${formatSkipCause(result.cause)}`
+        );
       }
     }
 

--- a/packages/cli/src/v5/resolver/format.ts
+++ b/packages/cli/src/v5/resolver/format.ts
@@ -1,0 +1,16 @@
+import type { V5SkipCause } from "./types.js";
+
+export function formatSkipCause(cause: V5SkipCause): string {
+  switch (cause.type) {
+    case "group-filter":
+      return `is filtered out by --group=${cause.activeGroups.join(",")}`;
+    case "path-filter":
+      return `is filtered out by --filter=${cause.activePrefixes.join(",")}`;
+    case "optional-no-value":
+      return "is optional and has no value";
+    case "optional-not-found":
+      return "is optional and was not found in its provider";
+    case "template-ref-unavailable":
+      return `is unavailable: referenced key '${cause.reference}' ${formatSkipCause(cause.referenceCause)}`;
+  }
+}

--- a/packages/cli/src/v5/resolver/index.ts
+++ b/packages/cli/src/v5/resolver/index.ts
@@ -12,9 +12,12 @@ import type {
   SelectedV5Record,
   V5KeyResolutionStatus,
   V5Resolution,
+  V5SkipCause,
   V5TopLevelError,
   V5ValidationResult
 } from "./types.js";
+
+export { formatSkipCause } from "./format.js";
 
 const TEMPLATE_RE = /(?<!\$)\$\{([^}]+)\}/g;
 const ESCAPED_TEMPLATE_RE = /\$\$\{/g;
@@ -79,11 +82,11 @@ export async function resolveWithStatus(options: ResolveV5Options): Promise<V5Re
   const resolving = new Set<string>();
 
   for (const entry of selected) {
-    if (!entry.selected) {
+    if (!entry.selected && entry.cause !== undefined) {
       statusByPath.set(entry.record.path, {
         path: entry.record.path,
         status: "filtered",
-        reason: entry.reason ?? "filtered out"
+        cause: entry.cause
       });
     }
   }
@@ -94,11 +97,7 @@ export async function resolveWithStatus(options: ResolveV5Options): Promise<V5Re
 
     const record = selectedByPath.get(path);
     if (record === undefined) {
-      return {
-        path,
-        status: "filtered",
-        reason: `referenced key '${path}' is filtered out`
-      };
+      return toErrorStatus(path, new Error(`unknown key reference "${path}"`));
     }
 
     if (resolving.has(path)) {
@@ -170,15 +169,24 @@ function selectRecords(
   filters: string[] | undefined
 ): SelectedV5Record[] {
   const groupSet = normalizeGroupFilter(config, groups);
+  const activeGroups = [...groupSet];
   const pathPrefixes = normalizePathFilters(filters);
 
   return config.keys.map((record) => {
-    const groupReason = getGroupFilterReason(record, groupSet);
-    if (groupReason !== undefined) return { record, selected: false, reason: groupReason };
-
-    const filterReason = getPathFilterReason(record, pathPrefixes);
-    if (filterReason !== undefined) return { record, selected: false, reason: filterReason };
-
+    if (isExcludedByGroup(record, groupSet)) {
+      return {
+        record,
+        selected: false,
+        cause: { type: "group-filter", activeGroups }
+      };
+    }
+    if (isExcludedByPath(record, pathPrefixes)) {
+      return {
+        record,
+        selected: false,
+        cause: { type: "path-filter", activePrefixes: pathPrefixes }
+      };
+    }
     return { record, selected: true };
   });
 }
@@ -218,17 +226,15 @@ function normalizePathFilters(filters: string[] | undefined): string[] {
   return [...new Set(filters ?? [])].filter((filter) => filter.length > 0);
 }
 
-function getGroupFilterReason(record: NormalizedRecord, groupSet: Set<string>): string | undefined {
-  if (groupSet.size === 0) return undefined;
-  if (record.group === undefined) return undefined;
-  if (groupSet.has(record.group)) return undefined;
-  return `referenced key '${record.path}' is filtered out`;
+function isExcludedByGroup(record: NormalizedRecord, groupSet: Set<string>): boolean {
+  if (groupSet.size === 0) return false;
+  if (record.group === undefined) return false;
+  return !groupSet.has(record.group);
 }
 
-function getPathFilterReason(record: NormalizedRecord, prefixes: string[]): string | undefined {
-  if (prefixes.length === 0) return undefined;
-  if (prefixes.some((prefix) => matchesPathPrefix(record.path, prefix))) return undefined;
-  return `referenced key '${record.path}' is filtered out`;
+function isExcludedByPath(record: NormalizedRecord, prefixes: string[]): boolean {
+  if (prefixes.length === 0) return false;
+  return !prefixes.some((prefix) => matchesPathPrefix(record.path, prefix));
 }
 
 function matchesPathPrefix(path: string, prefix: string): boolean {
@@ -286,7 +292,7 @@ async function resolveSelectedRecord(
       return {
         path: record.path,
         status: "skipped",
-        reason: `optional key '${record.path}' has no value`
+        cause: { type: "optional-no-value" }
       };
     }
     return toErrorStatus(record.path, new Error(`No value for required key "${record.path}"`));
@@ -299,11 +305,22 @@ async function resolveSelectedRecord(
         : await resolveConfigBinding(record.path, binding as ConfigBinding, resolveRecord);
     return { path: record.path, status: "resolved", value };
   } catch (err) {
+    if (err instanceof FilteredTemplateReferenceError) {
+      return {
+        path: record.path,
+        status: "skipped",
+        cause: {
+          type: "template-ref-unavailable",
+          reference: err.reference,
+          referenceCause: err.referenceCause
+        }
+      };
+    }
     if (record.optional && isNotFoundError(err)) {
       return {
         path: record.path,
         status: "skipped",
-        reason: `optional key '${record.path}' was not found`
+        cause: { type: "optional-not-found" }
       };
     }
     return toErrorStatus(record.path, err);
@@ -364,7 +381,7 @@ async function interpolateConfigTemplate(
     }
 
     if (status.status === "filtered" || status.status === "skipped") {
-      throw new FilteredTemplateReferenceError(path, reference, status.reason);
+      throw new FilteredTemplateReferenceError(path, reference, status.cause);
     }
 
     throw new Error(`referenced key "${reference}" could not be resolved: ${status.message}`);
@@ -394,39 +411,28 @@ function skippedEnvVar(
     envVar,
     status: "skipped",
     keyPath,
-    reason: statusToSkipReason(keyPath, status),
+    cause: statusToSkipCause(status),
     mapping
   };
 }
 
-function statusToSkipReason(keyPath: string, status: V5KeyResolutionStatus | undefined): string {
-  if (status?.status === "filtered") return `referenced key '${keyPath}' is filtered out`;
-  if (status?.status === "skipped") return `referenced key '${keyPath}' is unavailable`;
-  if (status?.status === "error") {
-    return `referenced key '${keyPath}' could not be resolved: ${status.message}`;
-  }
-  return `referenced key '${keyPath}' is unavailable`;
+function statusToSkipCause(status: V5KeyResolutionStatus | undefined): V5SkipCause {
+  if (status?.status === "filtered" || status?.status === "skipped") return status.cause;
+  // Defensive fallback — shouldn't be reached with a validated config.
+  return { type: "optional-no-value" };
 }
 
 class FilteredTemplateReferenceError extends Error {
   constructor(
     readonly keyPath: string,
     readonly reference: string,
-    readonly reason: string
+    readonly referenceCause: V5SkipCause
   ) {
-    super(`referenced key "${reference}" is unavailable for "${keyPath}": ${reason}`);
+    super(`referenced key "${reference}" is unavailable for "${keyPath}"`);
   }
 }
 
 function toErrorStatus(path: string, err: unknown): V5KeyResolutionStatus {
-  if (err instanceof FilteredTemplateReferenceError) {
-    return {
-      path,
-      status: "skipped",
-      reason: err.reason
-    };
-  }
-
   return {
     path,
     status: "error",

--- a/packages/cli/src/v5/resolver/types.ts
+++ b/packages/cli/src/v5/resolver/types.ts
@@ -22,6 +22,13 @@ export interface V5ValidationResult {
   keyErrors: V5ValidationError[];
 }
 
+export type V5SkipCause =
+  | { type: "group-filter"; activeGroups: readonly string[] }
+  | { type: "path-filter"; activePrefixes: readonly string[] }
+  | { type: "optional-no-value" }
+  | { type: "optional-not-found" }
+  | { type: "template-ref-unavailable"; reference: string; referenceCause: V5SkipCause };
+
 export type V5KeyResolutionStatus =
   | {
       path: string;
@@ -31,12 +38,12 @@ export type V5KeyResolutionStatus =
   | {
       path: string;
       status: "filtered";
-      reason: string;
+      cause: V5SkipCause;
     }
   | {
       path: string;
       status: "skipped";
-      reason: string;
+      cause: V5SkipCause;
     }
   | {
       path: string;
@@ -61,13 +68,13 @@ export type RenderedV5EnvVar =
   | {
       envVar: string;
       status: "skipped";
-      reason: string;
       keyPath: string;
+      cause: V5SkipCause;
       mapping: AppMapping;
     };
 
 export interface SelectedV5Record {
   record: NormalizedRecord;
   selected: boolean;
-  reason?: string;
+  cause?: V5SkipCause;
 }

--- a/packages/cli/test/e2e/v5-run.test.ts
+++ b/packages/cli/test/e2e/v5-run.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, beforeAll } from "vitest";
 import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { generateIdentity } from "../../src/providers/age.js";
 import { V5_CLI, TSX } from "./helpers/v5-cli.js";
 
@@ -152,8 +152,8 @@ describe("keyshelf-next run (groups)", () => {
     expect(secretsDir).toContain(root);
   });
 
-  it("--group app skips ci/token mapping with stderr warning", () => {
-    const result = execFileSync(
+  it("--group app skips ci/token mapping with stderr warning naming the active filter", () => {
+    const result = spawnSync(
       TSX,
       [
         V5_CLI,
@@ -167,9 +167,13 @@ describe("keyshelf-next run (groups)", () => {
         "-e",
         "console.log(JSON.stringify({h: process.env.APP_HOST ?? null, t: process.env.CI_TOKEN ?? null}))"
       ],
-      { cwd: root, encoding: "utf-8", stdio: ["inherit", "pipe", "pipe"] }
+      { cwd: root, encoding: "utf-8" }
     );
-    expect(JSON.parse(result.trim())).toEqual({ h: "localhost", t: null });
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout.trim())).toEqual({ h: "localhost", t: null });
+    expect(result.stderr).toContain(
+      "keyshelf: skipping CI_TOKEN — referenced key 'ci/token' is filtered out by --group=app"
+    );
   });
 
   it("--group ci resolves the secret", () => {

--- a/packages/cli/test/unit/v5/format.test.ts
+++ b/packages/cli/test/unit/v5/format.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { formatSkipCause } from "../../../src/v5/index.js";
+
+describe("formatSkipCause", () => {
+  it("formats group-filter with active group list", () => {
+    expect(formatSkipCause({ type: "group-filter", activeGroups: ["app", "ci"] })).toBe(
+      "is filtered out by --group=app,ci"
+    );
+  });
+
+  it("formats path-filter with active prefix list", () => {
+    expect(formatSkipCause({ type: "path-filter", activePrefixes: ["db", "log/level"] })).toBe(
+      "is filtered out by --filter=db,log/level"
+    );
+  });
+
+  it("formats optional-no-value", () => {
+    expect(formatSkipCause({ type: "optional-no-value" })).toBe("is optional and has no value");
+  });
+
+  it("formats optional-not-found", () => {
+    expect(formatSkipCause({ type: "optional-not-found" })).toBe(
+      "is optional and was not found in its provider"
+    );
+  });
+
+  it("formats template-ref-unavailable recursively", () => {
+    expect(
+      formatSkipCause({
+        type: "template-ref-unavailable",
+        reference: "db/password",
+        referenceCause: { type: "group-filter", activeGroups: ["app"] }
+      })
+    ).toBe("is unavailable: referenced key 'db/password' is filtered out by --group=app");
+  });
+});

--- a/packages/cli/test/unit/v5/resolver.test.ts
+++ b/packages/cli/test/unit/v5/resolver.test.ts
@@ -108,7 +108,7 @@ describe("v5 resolver", () => {
     });
     expect(resolution.statusByPath.get("optional")).toMatchObject({
       status: "skipped",
-      reason: "optional key 'optional' has no value"
+      cause: { type: "optional-no-value" }
     });
   });
 
@@ -263,7 +263,11 @@ describe("v5 resolver", () => {
     });
     expect(appOnly.statusByPath.get("db/url")).toMatchObject({
       status: "skipped",
-      reason: "referenced key 'db/password' is filtered out"
+      cause: {
+        type: "template-ref-unavailable",
+        reference: "db/password",
+        referenceCause: { type: "group-filter", activeGroups: ["app"] }
+      }
     });
   });
 
@@ -315,19 +319,19 @@ describe("v5 resolver", () => {
         envVar: "TOKEN",
         status: "skipped",
         keyPath: "ci/token",
-        reason: "referenced key 'ci/token' is filtered out"
+        cause: { type: "group-filter", activeGroups: ["app"] }
       },
       {
         envVar: "COMBINED",
         status: "skipped",
         keyPath: "ci/token",
-        reason: "referenced key 'ci/token' is filtered out"
+        cause: { type: "group-filter", activeGroups: ["app"] }
       },
       {
         envVar: "OPTIONAL",
         status: "skipped",
         keyPath: "app/optional",
-        reason: "referenced key 'app/optional' is unavailable"
+        cause: { type: "optional-no-value" }
       }
     ]);
   });


### PR DESCRIPTION
## Summary

- Replace free-form `reason: string` on filtered/skipped statuses with a discriminated `cause: V5SkipCause` union that carries the active filter context (group names or path prefixes).
- `run` skip warnings now name the flag that excluded the key, e.g. `keyshelf: skipping TOKEN — referenced key 'ci/token' is filtered out by --group=app`, instead of the prior generic "is filtered out".
- Add `formatSkipCause()` helper exported from the v5 entrypoint; `ls --reveal` uses it for non-optional skip details.

Sets up phase 6+ work (and gives `run`/`ls` better UX today). Part of #78.

## Test plan

- [x] `npm --prefix packages/cli test` — 271 passed (4 skipped), no regressions
- [x] `npm --prefix packages/cli run typecheck` — clean
- [x] New unit tests cover all five `V5SkipCause` variants including recursive template-ref-unavailable
- [x] e2e `v5-run` test now captures stderr and asserts the full enriched message end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)