### PR TITLE
feat(v5): port the keyshelf action to v5 TS configs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5291,7 +5291,7 @@
     },
     "packages/action": {
       "name": "@keyshelf/action",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.5.0",
@@ -5306,7 +5306,7 @@
     },
     "packages/cli": {
       "name": "keyshelf",
-      "version": "4.5.0",
+      "version": "4.6.0",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/secret-manager": "^6.1.1",

--- a/packages/action/action.yml
+++ b/packages/action/action.yml
@@ -6,29 +6,43 @@ branding:
 
 inputs:
   env:
-    description: Environment name (matches .keyshelf/<env>.yaml)
-    required: true
+    description: Environment name. Required for v4 configs; for v5 configs only required when at least one selected key has env-specific values without a fallback.
+    required: false
+    default: ""
   map:
     description: Path(s) to .env.keyshelf mapping file(s); newline-separated for multiple
     required: true
   identity:
-    description: Raw identity material (e.g. age private key). Written to the path declared in .keyshelf/<env>.yaml with mode 0600. Pass via secrets.* — never hard-code.
+    description: Raw identity material (e.g. age private key). Written to the path declared on the matching age provider with mode 0600. Pass via secrets.* — never hard-code.
     required: false
     default: ""
   working-directory:
-    description: Directory containing keyshelf.yaml (project root)
+    description: Directory containing keyshelf.config.ts (v5) or keyshelf.yaml (v4)
     required: false
     default: "."
+  groups:
+    description: (v5 only) Comma- or newline-separated list of groups to include
+    required: false
+    default: ""
+  filters:
+    description: (v5 only) Comma- or newline-separated list of key-path prefixes to include
+    required: false
+    default: ""
 
 runs:
   using: composite
   steps:
-    - name: Validate inputs
+    - name: Detect config mode
+      id: mode
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
-        if [ ! -f ".keyshelf/${{ inputs.env }}.yaml" ]; then
-          echo "::error::Env file .keyshelf/${{ inputs.env }}.yaml not found in $(pwd)"
+        if [ -f "keyshelf.config.ts" ]; then
+          echo "mode=v5" >> "$GITHUB_OUTPUT"
+        elif [ -f "keyshelf.yaml" ]; then
+          echo "mode=v4" >> "$GITHUB_OUTPUT"
+        else
+          echo "::error::Neither keyshelf.config.ts (v5) nor keyshelf.yaml (v4) found in $(pwd)"
           exit 1
         fi
         if [ -z "${{ inputs.map }}" ]; then
@@ -36,8 +50,33 @@ runs:
           exit 1
         fi
 
-    - name: Write identity
-      if: inputs.identity != ''
+    - name: Validate v4 inputs
+      if: steps.mode.outputs.mode == 'v4'
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        if [ -z "${{ inputs.env }}" ]; then
+          echo "::error::'env' is required for v4 configs"
+          exit 1
+        fi
+        if [ ! -f ".keyshelf/${{ inputs.env }}.yaml" ]; then
+          echo "::error::Env file .keyshelf/${{ inputs.env }}.yaml not found in $(pwd)"
+          exit 1
+        fi
+
+    - name: Install v5 runtime deps
+      if: steps.mode.outputs.mode == 'v5'
+      shell: bash
+      working-directory: ${{ github.action_path }}
+      run: |
+        # jiti and zod are externalized from the bundle (see tsup.config.ts).
+        # Install them locally to the action so dist/*.mjs can resolve them.
+        if [ ! -d "node_modules/jiti" ] || [ ! -d "node_modules/zod" ]; then
+          npm install --no-save --no-audit --no-fund --no-package-lock jiti@^2.6.1 zod@^4.4.1
+        fi
+
+    - name: Write identity (v4)
+      if: steps.mode.outputs.mode == 'v4' && inputs.identity != ''
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       env:
@@ -45,10 +84,32 @@ runs:
         KEYSHELF_IDENTITY: ${{ inputs.identity }}
       run: node "${{ github.action_path }}/dist/write-identity.mjs"
 
-    - name: Resolve and emit env vars
+    - name: Write identity (v5)
+      if: steps.mode.outputs.mode == 'v5' && inputs.identity != ''
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        KEYSHELF_IDENTITY: ${{ inputs.identity }}
+        KEYSHELF_CONFIG_MODULE_PATH: ${{ github.action_path }}/dist/keyshelf-config.mjs
+      run: node "${{ github.action_path }}/dist/write-identity-v5.mjs"
+
+    - name: Resolve and emit env vars (v4)
+      if: steps.mode.outputs.mode == 'v4'
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       env:
         KEYSHELF_ENV: ${{ inputs.env }}
         KEYSHELF_MAPS: ${{ inputs.map }}
       run: node "${{ github.action_path }}/dist/emit-env.mjs"
+
+    - name: Resolve and emit env vars (v5)
+      if: steps.mode.outputs.mode == 'v5'
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        KEYSHELF_ENV: ${{ inputs.env }}
+        KEYSHELF_MAPS: ${{ inputs.map }}
+        KEYSHELF_GROUPS: ${{ inputs.groups }}
+        KEYSHELF_FILTERS: ${{ inputs.filters }}
+        KEYSHELF_CONFIG_MODULE_PATH: ${{ github.action_path }}/dist/keyshelf-config.mjs
+      run: node "${{ github.action_path }}/dist/emit-env-v5.mjs"

--- a/packages/action/dist/emit-env-v5.mjs
+++ b/packages/action/dist/emit-env-v5.mjs
@@ -2,2783 +2,17 @@
 import { appendFileSync, existsSync } from 'fs';
 import { randomBytes as randomBytes$1, createDecipheriv, createCipheriv, createHmac } from 'crypto';
 import { readFile, mkdir, writeFile } from 'fs/promises';
-import { join, resolve, dirname, isAbsolute } from 'path';
+import { dirname, resolve, join, isAbsolute } from 'path';
+import { fileURLToPath } from 'url';
+import { performance } from 'perf_hooks';
+import { createJiti } from 'jiti';
+import { z } from 'zod';
 import { homedir } from 'os';
-
-// ../../node_modules/js-yaml/dist/js-yaml.mjs
-function isNothing(subject) {
-  return typeof subject === "undefined" || subject === null;
-}
-function isObject(subject) {
-  return typeof subject === "object" && subject !== null;
-}
-function toArray(sequence) {
-  if (Array.isArray(sequence)) return sequence;
-  else if (isNothing(sequence)) return [];
-  return [sequence];
-}
-function extend(target, source) {
-  var index, length, key, sourceKeys;
-  if (source) {
-    sourceKeys = Object.keys(source);
-    for (index = 0, length = sourceKeys.length; index < length; index += 1) {
-      key = sourceKeys[index];
-      target[key] = source[key];
-    }
-  }
-  return target;
-}
-function repeat(string, count) {
-  var result = "", cycle;
-  for (cycle = 0; cycle < count; cycle += 1) {
-    result += string;
-  }
-  return result;
-}
-function isNegativeZero(number) {
-  return number === 0 && Number.NEGATIVE_INFINITY === 1 / number;
-}
-var isNothing_1 = isNothing;
-var isObject_1 = isObject;
-var toArray_1 = toArray;
-var repeat_1 = repeat;
-var isNegativeZero_1 = isNegativeZero;
-var extend_1 = extend;
-var common = {
-  isNothing: isNothing_1,
-  isObject: isObject_1,
-  toArray: toArray_1,
-  repeat: repeat_1,
-  isNegativeZero: isNegativeZero_1,
-  extend: extend_1
-};
-function formatError(exception2, compact) {
-  var where = "", message = exception2.reason || "(unknown reason)";
-  if (!exception2.mark) return message;
-  if (exception2.mark.name) {
-    where += 'in "' + exception2.mark.name + '" ';
-  }
-  where += "(" + (exception2.mark.line + 1) + ":" + (exception2.mark.column + 1) + ")";
-  if (!compact && exception2.mark.snippet) {
-    where += "\n\n" + exception2.mark.snippet;
-  }
-  return message + " " + where;
-}
-function YAMLException$1(reason, mark) {
-  Error.call(this);
-  this.name = "YAMLException";
-  this.reason = reason;
-  this.mark = mark;
-  this.message = formatError(this, false);
-  if (Error.captureStackTrace) {
-    Error.captureStackTrace(this, this.constructor);
-  } else {
-    this.stack = new Error().stack || "";
-  }
-}
-YAMLException$1.prototype = Object.create(Error.prototype);
-YAMLException$1.prototype.constructor = YAMLException$1;
-YAMLException$1.prototype.toString = function toString(compact) {
-  return this.name + ": " + formatError(this, compact);
-};
-var exception = YAMLException$1;
-function getLine(buffer, lineStart, lineEnd, position, maxLineLength) {
-  var head = "";
-  var tail = "";
-  var maxHalfLength = Math.floor(maxLineLength / 2) - 1;
-  if (position - lineStart > maxHalfLength) {
-    head = " ... ";
-    lineStart = position - maxHalfLength + head.length;
-  }
-  if (lineEnd - position > maxHalfLength) {
-    tail = " ...";
-    lineEnd = position + maxHalfLength - tail.length;
-  }
-  return {
-    str: head + buffer.slice(lineStart, lineEnd).replace(/\t/g, "\u2192") + tail,
-    pos: position - lineStart + head.length
-    // relative position
-  };
-}
-function padStart(string, max) {
-  return common.repeat(" ", max - string.length) + string;
-}
-function makeSnippet(mark, options) {
-  options = Object.create(options || null);
-  if (!mark.buffer) return null;
-  if (!options.maxLength) options.maxLength = 79;
-  if (typeof options.indent !== "number") options.indent = 1;
-  if (typeof options.linesBefore !== "number") options.linesBefore = 3;
-  if (typeof options.linesAfter !== "number") options.linesAfter = 2;
-  var re = /\r?\n|\r|\0/g;
-  var lineStarts = [0];
-  var lineEnds = [];
-  var match;
-  var foundLineNo = -1;
-  while (match = re.exec(mark.buffer)) {
-    lineEnds.push(match.index);
-    lineStarts.push(match.index + match[0].length);
-    if (mark.position <= match.index && foundLineNo < 0) {
-      foundLineNo = lineStarts.length - 2;
-    }
-  }
-  if (foundLineNo < 0) foundLineNo = lineStarts.length - 1;
-  var result = "", i, line;
-  var lineNoLength = Math.min(mark.line + options.linesAfter, lineEnds.length).toString().length;
-  var maxLineLength = options.maxLength - (options.indent + lineNoLength + 3);
-  for (i = 1; i <= options.linesBefore; i++) {
-    if (foundLineNo - i < 0) break;
-    line = getLine(
-      mark.buffer,
-      lineStarts[foundLineNo - i],
-      lineEnds[foundLineNo - i],
-      mark.position - (lineStarts[foundLineNo] - lineStarts[foundLineNo - i]),
-      maxLineLength
-    );
-    result = common.repeat(" ", options.indent) + padStart((mark.line - i + 1).toString(), lineNoLength) + " | " + line.str + "\n" + result;
-  }
-  line = getLine(mark.buffer, lineStarts[foundLineNo], lineEnds[foundLineNo], mark.position, maxLineLength);
-  result += common.repeat(" ", options.indent) + padStart((mark.line + 1).toString(), lineNoLength) + " | " + line.str + "\n";
-  result += common.repeat("-", options.indent + lineNoLength + 3 + line.pos) + "^\n";
-  for (i = 1; i <= options.linesAfter; i++) {
-    if (foundLineNo + i >= lineEnds.length) break;
-    line = getLine(
-      mark.buffer,
-      lineStarts[foundLineNo + i],
-      lineEnds[foundLineNo + i],
-      mark.position - (lineStarts[foundLineNo] - lineStarts[foundLineNo + i]),
-      maxLineLength
-    );
-    result += common.repeat(" ", options.indent) + padStart((mark.line + i + 1).toString(), lineNoLength) + " | " + line.str + "\n";
-  }
-  return result.replace(/\n$/, "");
-}
-var snippet = makeSnippet;
-var TYPE_CONSTRUCTOR_OPTIONS = [
-  "kind",
-  "multi",
-  "resolve",
-  "construct",
-  "instanceOf",
-  "predicate",
-  "represent",
-  "representName",
-  "defaultStyle",
-  "styleAliases"
-];
-var YAML_NODE_KINDS = [
-  "scalar",
-  "sequence",
-  "mapping"
-];
-function compileStyleAliases(map2) {
-  var result = {};
-  if (map2 !== null) {
-    Object.keys(map2).forEach(function(style) {
-      map2[style].forEach(function(alias) {
-        result[String(alias)] = style;
-      });
-    });
-  }
-  return result;
-}
-function Type$1(tag, options) {
-  options = options || {};
-  Object.keys(options).forEach(function(name) {
-    if (TYPE_CONSTRUCTOR_OPTIONS.indexOf(name) === -1) {
-      throw new exception('Unknown option "' + name + '" is met in definition of "' + tag + '" YAML type.');
-    }
-  });
-  this.options = options;
-  this.tag = tag;
-  this.kind = options["kind"] || null;
-  this.resolve = options["resolve"] || function() {
-    return true;
-  };
-  this.construct = options["construct"] || function(data) {
-    return data;
-  };
-  this.instanceOf = options["instanceOf"] || null;
-  this.predicate = options["predicate"] || null;
-  this.represent = options["represent"] || null;
-  this.representName = options["representName"] || null;
-  this.defaultStyle = options["defaultStyle"] || null;
-  this.multi = options["multi"] || false;
-  this.styleAliases = compileStyleAliases(options["styleAliases"] || null);
-  if (YAML_NODE_KINDS.indexOf(this.kind) === -1) {
-    throw new exception('Unknown kind "' + this.kind + '" is specified for "' + tag + '" YAML type.');
-  }
-}
-var type = Type$1;
-function compileList(schema2, name) {
-  var result = [];
-  schema2[name].forEach(function(currentType) {
-    var newIndex = result.length;
-    result.forEach(function(previousType, previousIndex) {
-      if (previousType.tag === currentType.tag && previousType.kind === currentType.kind && previousType.multi === currentType.multi) {
-        newIndex = previousIndex;
-      }
-    });
-    result[newIndex] = currentType;
-  });
-  return result;
-}
-function compileMap() {
-  var result = {
-    scalar: {},
-    sequence: {},
-    mapping: {},
-    fallback: {},
-    multi: {
-      scalar: [],
-      sequence: [],
-      mapping: [],
-      fallback: []
-    }
-  }, index, length;
-  function collectType(type2) {
-    if (type2.multi) {
-      result.multi[type2.kind].push(type2);
-      result.multi["fallback"].push(type2);
-    } else {
-      result[type2.kind][type2.tag] = result["fallback"][type2.tag] = type2;
-    }
-  }
-  for (index = 0, length = arguments.length; index < length; index += 1) {
-    arguments[index].forEach(collectType);
-  }
-  return result;
-}
-function Schema$1(definition) {
-  return this.extend(definition);
-}
-Schema$1.prototype.extend = function extend2(definition) {
-  var implicit = [];
-  var explicit = [];
-  if (definition instanceof type) {
-    explicit.push(definition);
-  } else if (Array.isArray(definition)) {
-    explicit = explicit.concat(definition);
-  } else if (definition && (Array.isArray(definition.implicit) || Array.isArray(definition.explicit))) {
-    if (definition.implicit) implicit = implicit.concat(definition.implicit);
-    if (definition.explicit) explicit = explicit.concat(definition.explicit);
-  } else {
-    throw new exception("Schema.extend argument should be a Type, [ Type ], or a schema definition ({ implicit: [...], explicit: [...] })");
-  }
-  implicit.forEach(function(type$1) {
-    if (!(type$1 instanceof type)) {
-      throw new exception("Specified list of YAML types (or a single Type object) contains a non-Type object.");
-    }
-    if (type$1.loadKind && type$1.loadKind !== "scalar") {
-      throw new exception("There is a non-scalar type in the implicit list of a schema. Implicit resolving of such types is not supported.");
-    }
-    if (type$1.multi) {
-      throw new exception("There is a multi type in the implicit list of a schema. Multi tags can only be listed as explicit.");
-    }
-  });
-  explicit.forEach(function(type$1) {
-    if (!(type$1 instanceof type)) {
-      throw new exception("Specified list of YAML types (or a single Type object) contains a non-Type object.");
-    }
-  });
-  var result = Object.create(Schema$1.prototype);
-  result.implicit = (this.implicit || []).concat(implicit);
-  result.explicit = (this.explicit || []).concat(explicit);
-  result.compiledImplicit = compileList(result, "implicit");
-  result.compiledExplicit = compileList(result, "explicit");
-  result.compiledTypeMap = compileMap(result.compiledImplicit, result.compiledExplicit);
-  return result;
-};
-var schema = Schema$1;
-var str = new type("tag:yaml.org,2002:str", {
-  kind: "scalar",
-  construct: function(data) {
-    return data !== null ? data : "";
-  }
-});
-var seq = new type("tag:yaml.org,2002:seq", {
-  kind: "sequence",
-  construct: function(data) {
-    return data !== null ? data : [];
-  }
-});
-var map = new type("tag:yaml.org,2002:map", {
-  kind: "mapping",
-  construct: function(data) {
-    return data !== null ? data : {};
-  }
-});
-var failsafe = new schema({
-  explicit: [
-    str,
-    seq,
-    map
-  ]
-});
-function resolveYamlNull(data) {
-  if (data === null) return true;
-  var max = data.length;
-  return max === 1 && data === "~" || max === 4 && (data === "null" || data === "Null" || data === "NULL");
-}
-function constructYamlNull() {
-  return null;
-}
-function isNull(object) {
-  return object === null;
-}
-var _null = new type("tag:yaml.org,2002:null", {
-  kind: "scalar",
-  resolve: resolveYamlNull,
-  construct: constructYamlNull,
-  predicate: isNull,
-  represent: {
-    canonical: function() {
-      return "~";
-    },
-    lowercase: function() {
-      return "null";
-    },
-    uppercase: function() {
-      return "NULL";
-    },
-    camelcase: function() {
-      return "Null";
-    },
-    empty: function() {
-      return "";
-    }
-  },
-  defaultStyle: "lowercase"
-});
-function resolveYamlBoolean(data) {
-  if (data === null) return false;
-  var max = data.length;
-  return max === 4 && (data === "true" || data === "True" || data === "TRUE") || max === 5 && (data === "false" || data === "False" || data === "FALSE");
-}
-function constructYamlBoolean(data) {
-  return data === "true" || data === "True" || data === "TRUE";
-}
-function isBoolean(object) {
-  return Object.prototype.toString.call(object) === "[object Boolean]";
-}
-var bool = new type("tag:yaml.org,2002:bool", {
-  kind: "scalar",
-  resolve: resolveYamlBoolean,
-  construct: constructYamlBoolean,
-  predicate: isBoolean,
-  represent: {
-    lowercase: function(object) {
-      return object ? "true" : "false";
-    },
-    uppercase: function(object) {
-      return object ? "TRUE" : "FALSE";
-    },
-    camelcase: function(object) {
-      return object ? "True" : "False";
-    }
-  },
-  defaultStyle: "lowercase"
-});
-function isHexCode(c) {
-  return 48 <= c && c <= 57 || 65 <= c && c <= 70 || 97 <= c && c <= 102;
-}
-function isOctCode(c) {
-  return 48 <= c && c <= 55;
-}
-function isDecCode(c) {
-  return 48 <= c && c <= 57;
-}
-function resolveYamlInteger(data) {
-  if (data === null) return false;
-  var max = data.length, index = 0, hasDigits = false, ch;
-  if (!max) return false;
-  ch = data[index];
-  if (ch === "-" || ch === "+") {
-    ch = data[++index];
-  }
-  if (ch === "0") {
-    if (index + 1 === max) return true;
-    ch = data[++index];
-    if (ch === "b") {
-      index++;
-      for (; index < max; index++) {
-        ch = data[index];
-        if (ch === "_") continue;
-        if (ch !== "0" && ch !== "1") return false;
-        hasDigits = true;
-      }
-      return hasDigits && ch !== "_";
-    }
-    if (ch === "x") {
-      index++;
-      for (; index < max; index++) {
-        ch = data[index];
-        if (ch === "_") continue;
-        if (!isHexCode(data.charCodeAt(index))) return false;
-        hasDigits = true;
-      }
-      return hasDigits && ch !== "_";
-    }
-    if (ch === "o") {
-      index++;
-      for (; index < max; index++) {
-        ch = data[index];
-        if (ch === "_") continue;
-        if (!isOctCode(data.charCodeAt(index))) return false;
-        hasDigits = true;
-      }
-      return hasDigits && ch !== "_";
-    }
-  }
-  if (ch === "_") return false;
-  for (; index < max; index++) {
-    ch = data[index];
-    if (ch === "_") continue;
-    if (!isDecCode(data.charCodeAt(index))) {
-      return false;
-    }
-    hasDigits = true;
-  }
-  if (!hasDigits || ch === "_") return false;
-  return true;
-}
-function constructYamlInteger(data) {
-  var value = data, sign = 1, ch;
-  if (value.indexOf("_") !== -1) {
-    value = value.replace(/_/g, "");
-  }
-  ch = value[0];
-  if (ch === "-" || ch === "+") {
-    if (ch === "-") sign = -1;
-    value = value.slice(1);
-    ch = value[0];
-  }
-  if (value === "0") return 0;
-  if (ch === "0") {
-    if (value[1] === "b") return sign * parseInt(value.slice(2), 2);
-    if (value[1] === "x") return sign * parseInt(value.slice(2), 16);
-    if (value[1] === "o") return sign * parseInt(value.slice(2), 8);
-  }
-  return sign * parseInt(value, 10);
-}
-function isInteger(object) {
-  return Object.prototype.toString.call(object) === "[object Number]" && (object % 1 === 0 && !common.isNegativeZero(object));
-}
-var int = new type("tag:yaml.org,2002:int", {
-  kind: "scalar",
-  resolve: resolveYamlInteger,
-  construct: constructYamlInteger,
-  predicate: isInteger,
-  represent: {
-    binary: function(obj) {
-      return obj >= 0 ? "0b" + obj.toString(2) : "-0b" + obj.toString(2).slice(1);
-    },
-    octal: function(obj) {
-      return obj >= 0 ? "0o" + obj.toString(8) : "-0o" + obj.toString(8).slice(1);
-    },
-    decimal: function(obj) {
-      return obj.toString(10);
-    },
-    /* eslint-disable max-len */
-    hexadecimal: function(obj) {
-      return obj >= 0 ? "0x" + obj.toString(16).toUpperCase() : "-0x" + obj.toString(16).toUpperCase().slice(1);
-    }
-  },
-  defaultStyle: "decimal",
-  styleAliases: {
-    binary: [2, "bin"],
-    octal: [8, "oct"],
-    decimal: [10, "dec"],
-    hexadecimal: [16, "hex"]
-  }
-});
-var YAML_FLOAT_PATTERN = new RegExp(
-  // 2.5e4, 2.5 and integers
-  "^(?:[-+]?(?:[0-9][0-9_]*)(?:\\.[0-9_]*)?(?:[eE][-+]?[0-9]+)?|\\.[0-9_]+(?:[eE][-+]?[0-9]+)?|[-+]?\\.(?:inf|Inf|INF)|\\.(?:nan|NaN|NAN))$"
-);
-function resolveYamlFloat(data) {
-  if (data === null) return false;
-  if (!YAML_FLOAT_PATTERN.test(data) || // Quick hack to not allow integers end with `_`
-  // Probably should update regexp & check speed
-  data[data.length - 1] === "_") {
-    return false;
-  }
-  return true;
-}
-function constructYamlFloat(data) {
-  var value, sign;
-  value = data.replace(/_/g, "").toLowerCase();
-  sign = value[0] === "-" ? -1 : 1;
-  if ("+-".indexOf(value[0]) >= 0) {
-    value = value.slice(1);
-  }
-  if (value === ".inf") {
-    return sign === 1 ? Number.POSITIVE_INFINITY : Number.NEGATIVE_INFINITY;
-  } else if (value === ".nan") {
-    return NaN;
-  }
-  return sign * parseFloat(value, 10);
-}
-var SCIENTIFIC_WITHOUT_DOT = /^[-+]?[0-9]+e/;
-function representYamlFloat(object, style) {
-  var res;
-  if (isNaN(object)) {
-    switch (style) {
-      case "lowercase":
-        return ".nan";
-      case "uppercase":
-        return ".NAN";
-      case "camelcase":
-        return ".NaN";
-    }
-  } else if (Number.POSITIVE_INFINITY === object) {
-    switch (style) {
-      case "lowercase":
-        return ".inf";
-      case "uppercase":
-        return ".INF";
-      case "camelcase":
-        return ".Inf";
-    }
-  } else if (Number.NEGATIVE_INFINITY === object) {
-    switch (style) {
-      case "lowercase":
-        return "-.inf";
-      case "uppercase":
-        return "-.INF";
-      case "camelcase":
-        return "-.Inf";
-    }
-  } else if (common.isNegativeZero(object)) {
-    return "-0.0";
-  }
-  res = object.toString(10);
-  return SCIENTIFIC_WITHOUT_DOT.test(res) ? res.replace("e", ".e") : res;
-}
-function isFloat(object) {
-  return Object.prototype.toString.call(object) === "[object Number]" && (object % 1 !== 0 || common.isNegativeZero(object));
-}
-var float = new type("tag:yaml.org,2002:float", {
-  kind: "scalar",
-  resolve: resolveYamlFloat,
-  construct: constructYamlFloat,
-  predicate: isFloat,
-  represent: representYamlFloat,
-  defaultStyle: "lowercase"
-});
-var json = failsafe.extend({
-  implicit: [
-    _null,
-    bool,
-    int,
-    float
-  ]
-});
-var core = json;
-var YAML_DATE_REGEXP = new RegExp(
-  "^([0-9][0-9][0-9][0-9])-([0-9][0-9])-([0-9][0-9])$"
-);
-var YAML_TIMESTAMP_REGEXP = new RegExp(
-  "^([0-9][0-9][0-9][0-9])-([0-9][0-9]?)-([0-9][0-9]?)(?:[Tt]|[ \\t]+)([0-9][0-9]?):([0-9][0-9]):([0-9][0-9])(?:\\.([0-9]*))?(?:[ \\t]*(Z|([-+])([0-9][0-9]?)(?::([0-9][0-9]))?))?$"
-);
-function resolveYamlTimestamp(data) {
-  if (data === null) return false;
-  if (YAML_DATE_REGEXP.exec(data) !== null) return true;
-  if (YAML_TIMESTAMP_REGEXP.exec(data) !== null) return true;
-  return false;
-}
-function constructYamlTimestamp(data) {
-  var match, year, month, day, hour, minute, second, fraction = 0, delta = null, tz_hour, tz_minute, date;
-  match = YAML_DATE_REGEXP.exec(data);
-  if (match === null) match = YAML_TIMESTAMP_REGEXP.exec(data);
-  if (match === null) throw new Error("Date resolve error");
-  year = +match[1];
-  month = +match[2] - 1;
-  day = +match[3];
-  if (!match[4]) {
-    return new Date(Date.UTC(year, month, day));
-  }
-  hour = +match[4];
-  minute = +match[5];
-  second = +match[6];
-  if (match[7]) {
-    fraction = match[7].slice(0, 3);
-    while (fraction.length < 3) {
-      fraction += "0";
-    }
-    fraction = +fraction;
-  }
-  if (match[9]) {
-    tz_hour = +match[10];
-    tz_minute = +(match[11] || 0);
-    delta = (tz_hour * 60 + tz_minute) * 6e4;
-    if (match[9] === "-") delta = -delta;
-  }
-  date = new Date(Date.UTC(year, month, day, hour, minute, second, fraction));
-  if (delta) date.setTime(date.getTime() - delta);
-  return date;
-}
-function representYamlTimestamp(object) {
-  return object.toISOString();
-}
-var timestamp = new type("tag:yaml.org,2002:timestamp", {
-  kind: "scalar",
-  resolve: resolveYamlTimestamp,
-  construct: constructYamlTimestamp,
-  instanceOf: Date,
-  represent: representYamlTimestamp
-});
-function resolveYamlMerge(data) {
-  return data === "<<" || data === null;
-}
-var merge = new type("tag:yaml.org,2002:merge", {
-  kind: "scalar",
-  resolve: resolveYamlMerge
-});
-var BASE64_MAP = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=\n\r";
-function resolveYamlBinary(data) {
-  if (data === null) return false;
-  var code, idx, bitlen = 0, max = data.length, map2 = BASE64_MAP;
-  for (idx = 0; idx < max; idx++) {
-    code = map2.indexOf(data.charAt(idx));
-    if (code > 64) continue;
-    if (code < 0) return false;
-    bitlen += 6;
-  }
-  return bitlen % 8 === 0;
-}
-function constructYamlBinary(data) {
-  var idx, tailbits, input = data.replace(/[\r\n=]/g, ""), max = input.length, map2 = BASE64_MAP, bits = 0, result = [];
-  for (idx = 0; idx < max; idx++) {
-    if (idx % 4 === 0 && idx) {
-      result.push(bits >> 16 & 255);
-      result.push(bits >> 8 & 255);
-      result.push(bits & 255);
-    }
-    bits = bits << 6 | map2.indexOf(input.charAt(idx));
-  }
-  tailbits = max % 4 * 6;
-  if (tailbits === 0) {
-    result.push(bits >> 16 & 255);
-    result.push(bits >> 8 & 255);
-    result.push(bits & 255);
-  } else if (tailbits === 18) {
-    result.push(bits >> 10 & 255);
-    result.push(bits >> 2 & 255);
-  } else if (tailbits === 12) {
-    result.push(bits >> 4 & 255);
-  }
-  return new Uint8Array(result);
-}
-function representYamlBinary(object) {
-  var result = "", bits = 0, idx, tail, max = object.length, map2 = BASE64_MAP;
-  for (idx = 0; idx < max; idx++) {
-    if (idx % 3 === 0 && idx) {
-      result += map2[bits >> 18 & 63];
-      result += map2[bits >> 12 & 63];
-      result += map2[bits >> 6 & 63];
-      result += map2[bits & 63];
-    }
-    bits = (bits << 8) + object[idx];
-  }
-  tail = max % 3;
-  if (tail === 0) {
-    result += map2[bits >> 18 & 63];
-    result += map2[bits >> 12 & 63];
-    result += map2[bits >> 6 & 63];
-    result += map2[bits & 63];
-  } else if (tail === 2) {
-    result += map2[bits >> 10 & 63];
-    result += map2[bits >> 4 & 63];
-    result += map2[bits << 2 & 63];
-    result += map2[64];
-  } else if (tail === 1) {
-    result += map2[bits >> 2 & 63];
-    result += map2[bits << 4 & 63];
-    result += map2[64];
-    result += map2[64];
-  }
-  return result;
-}
-function isBinary(obj) {
-  return Object.prototype.toString.call(obj) === "[object Uint8Array]";
-}
-var binary = new type("tag:yaml.org,2002:binary", {
-  kind: "scalar",
-  resolve: resolveYamlBinary,
-  construct: constructYamlBinary,
-  predicate: isBinary,
-  represent: representYamlBinary
-});
-var _hasOwnProperty$3 = Object.prototype.hasOwnProperty;
-var _toString$2 = Object.prototype.toString;
-function resolveYamlOmap(data) {
-  if (data === null) return true;
-  var objectKeys = [], index, length, pair, pairKey, pairHasKey, object = data;
-  for (index = 0, length = object.length; index < length; index += 1) {
-    pair = object[index];
-    pairHasKey = false;
-    if (_toString$2.call(pair) !== "[object Object]") return false;
-    for (pairKey in pair) {
-      if (_hasOwnProperty$3.call(pair, pairKey)) {
-        if (!pairHasKey) pairHasKey = true;
-        else return false;
-      }
-    }
-    if (!pairHasKey) return false;
-    if (objectKeys.indexOf(pairKey) === -1) objectKeys.push(pairKey);
-    else return false;
-  }
-  return true;
-}
-function constructYamlOmap(data) {
-  return data !== null ? data : [];
-}
-var omap = new type("tag:yaml.org,2002:omap", {
-  kind: "sequence",
-  resolve: resolveYamlOmap,
-  construct: constructYamlOmap
-});
-var _toString$1 = Object.prototype.toString;
-function resolveYamlPairs(data) {
-  if (data === null) return true;
-  var index, length, pair, keys, result, object = data;
-  result = new Array(object.length);
-  for (index = 0, length = object.length; index < length; index += 1) {
-    pair = object[index];
-    if (_toString$1.call(pair) !== "[object Object]") return false;
-    keys = Object.keys(pair);
-    if (keys.length !== 1) return false;
-    result[index] = [keys[0], pair[keys[0]]];
-  }
-  return true;
-}
-function constructYamlPairs(data) {
-  if (data === null) return [];
-  var index, length, pair, keys, result, object = data;
-  result = new Array(object.length);
-  for (index = 0, length = object.length; index < length; index += 1) {
-    pair = object[index];
-    keys = Object.keys(pair);
-    result[index] = [keys[0], pair[keys[0]]];
-  }
-  return result;
-}
-var pairs = new type("tag:yaml.org,2002:pairs", {
-  kind: "sequence",
-  resolve: resolveYamlPairs,
-  construct: constructYamlPairs
-});
-var _hasOwnProperty$2 = Object.prototype.hasOwnProperty;
-function resolveYamlSet(data) {
-  if (data === null) return true;
-  var key, object = data;
-  for (key in object) {
-    if (_hasOwnProperty$2.call(object, key)) {
-      if (object[key] !== null) return false;
-    }
-  }
-  return true;
-}
-function constructYamlSet(data) {
-  return data !== null ? data : {};
-}
-var set = new type("tag:yaml.org,2002:set", {
-  kind: "mapping",
-  resolve: resolveYamlSet,
-  construct: constructYamlSet
-});
-var _default = core.extend({
-  implicit: [
-    timestamp,
-    merge
-  ],
-  explicit: [
-    binary,
-    omap,
-    pairs,
-    set
-  ]
-});
-var _hasOwnProperty$1 = Object.prototype.hasOwnProperty;
-var CONTEXT_FLOW_IN = 1;
-var CONTEXT_FLOW_OUT = 2;
-var CONTEXT_BLOCK_IN = 3;
-var CONTEXT_BLOCK_OUT = 4;
-var CHOMPING_CLIP = 1;
-var CHOMPING_STRIP = 2;
-var CHOMPING_KEEP = 3;
-var PATTERN_NON_PRINTABLE = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x84\x86-\x9F\uFFFE\uFFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF]/;
-var PATTERN_NON_ASCII_LINE_BREAKS = /[\x85\u2028\u2029]/;
-var PATTERN_FLOW_INDICATORS = /[,\[\]\{\}]/;
-var PATTERN_TAG_HANDLE = /^(?:!|!!|![a-z\-]+!)$/i;
-var PATTERN_TAG_URI = /^(?:!|[^,\[\]\{\}])(?:%[0-9a-f]{2}|[0-9a-z\-#;\/\?:@&=\+\$,_\.!~\*'\(\)\[\]])*$/i;
-function _class(obj) {
-  return Object.prototype.toString.call(obj);
-}
-function is_EOL(c) {
-  return c === 10 || c === 13;
-}
-function is_WHITE_SPACE(c) {
-  return c === 9 || c === 32;
-}
-function is_WS_OR_EOL(c) {
-  return c === 9 || c === 32 || c === 10 || c === 13;
-}
-function is_FLOW_INDICATOR(c) {
-  return c === 44 || c === 91 || c === 93 || c === 123 || c === 125;
-}
-function fromHexCode(c) {
-  var lc;
-  if (48 <= c && c <= 57) {
-    return c - 48;
-  }
-  lc = c | 32;
-  if (97 <= lc && lc <= 102) {
-    return lc - 97 + 10;
-  }
-  return -1;
-}
-function escapedHexLen(c) {
-  if (c === 120) {
-    return 2;
-  }
-  if (c === 117) {
-    return 4;
-  }
-  if (c === 85) {
-    return 8;
-  }
-  return 0;
-}
-function fromDecimalCode(c) {
-  if (48 <= c && c <= 57) {
-    return c - 48;
-  }
-  return -1;
-}
-function simpleEscapeSequence(c) {
-  return c === 48 ? "\0" : c === 97 ? "\x07" : c === 98 ? "\b" : c === 116 ? "	" : c === 9 ? "	" : c === 110 ? "\n" : c === 118 ? "\v" : c === 102 ? "\f" : c === 114 ? "\r" : c === 101 ? "\x1B" : c === 32 ? " " : c === 34 ? '"' : c === 47 ? "/" : c === 92 ? "\\" : c === 78 ? "\x85" : c === 95 ? "\xA0" : c === 76 ? "\u2028" : c === 80 ? "\u2029" : "";
-}
-function charFromCodepoint(c) {
-  if (c <= 65535) {
-    return String.fromCharCode(c);
-  }
-  return String.fromCharCode(
-    (c - 65536 >> 10) + 55296,
-    (c - 65536 & 1023) + 56320
-  );
-}
-function setProperty(object, key, value) {
-  if (key === "__proto__") {
-    Object.defineProperty(object, key, {
-      configurable: true,
-      enumerable: true,
-      writable: true,
-      value
-    });
-  } else {
-    object[key] = value;
-  }
-}
-var simpleEscapeCheck = new Array(256);
-var simpleEscapeMap = new Array(256);
-for (i = 0; i < 256; i++) {
-  simpleEscapeCheck[i] = simpleEscapeSequence(i) ? 1 : 0;
-  simpleEscapeMap[i] = simpleEscapeSequence(i);
-}
-var i;
-function State$1(input, options) {
-  this.input = input;
-  this.filename = options["filename"] || null;
-  this.schema = options["schema"] || _default;
-  this.onWarning = options["onWarning"] || null;
-  this.legacy = options["legacy"] || false;
-  this.json = options["json"] || false;
-  this.listener = options["listener"] || null;
-  this.implicitTypes = this.schema.compiledImplicit;
-  this.typeMap = this.schema.compiledTypeMap;
-  this.length = input.length;
-  this.position = 0;
-  this.line = 0;
-  this.lineStart = 0;
-  this.lineIndent = 0;
-  this.firstTabInLine = -1;
-  this.documents = [];
-}
-function generateError(state, message) {
-  var mark = {
-    name: state.filename,
-    buffer: state.input.slice(0, -1),
-    // omit trailing \0
-    position: state.position,
-    line: state.line,
-    column: state.position - state.lineStart
-  };
-  mark.snippet = snippet(mark);
-  return new exception(message, mark);
-}
-function throwError(state, message) {
-  throw generateError(state, message);
-}
-function throwWarning(state, message) {
-  if (state.onWarning) {
-    state.onWarning.call(null, generateError(state, message));
-  }
-}
-var directiveHandlers = {
-  YAML: function handleYamlDirective(state, name, args) {
-    var match, major, minor;
-    if (state.version !== null) {
-      throwError(state, "duplication of %YAML directive");
-    }
-    if (args.length !== 1) {
-      throwError(state, "YAML directive accepts exactly one argument");
-    }
-    match = /^([0-9]+)\.([0-9]+)$/.exec(args[0]);
-    if (match === null) {
-      throwError(state, "ill-formed argument of the YAML directive");
-    }
-    major = parseInt(match[1], 10);
-    minor = parseInt(match[2], 10);
-    if (major !== 1) {
-      throwError(state, "unacceptable YAML version of the document");
-    }
-    state.version = args[0];
-    state.checkLineBreaks = minor < 2;
-    if (minor !== 1 && minor !== 2) {
-      throwWarning(state, "unsupported YAML version of the document");
-    }
-  },
-  TAG: function handleTagDirective(state, name, args) {
-    var handle, prefix;
-    if (args.length !== 2) {
-      throwError(state, "TAG directive accepts exactly two arguments");
-    }
-    handle = args[0];
-    prefix = args[1];
-    if (!PATTERN_TAG_HANDLE.test(handle)) {
-      throwError(state, "ill-formed tag handle (first argument) of the TAG directive");
-    }
-    if (_hasOwnProperty$1.call(state.tagMap, handle)) {
-      throwError(state, 'there is a previously declared suffix for "' + handle + '" tag handle');
-    }
-    if (!PATTERN_TAG_URI.test(prefix)) {
-      throwError(state, "ill-formed tag prefix (second argument) of the TAG directive");
-    }
-    try {
-      prefix = decodeURIComponent(prefix);
-    } catch (err) {
-      throwError(state, "tag prefix is malformed: " + prefix);
-    }
-    state.tagMap[handle] = prefix;
-  }
-};
-function captureSegment(state, start, end, checkJson) {
-  var _position, _length, _character, _result;
-  if (start < end) {
-    _result = state.input.slice(start, end);
-    if (checkJson) {
-      for (_position = 0, _length = _result.length; _position < _length; _position += 1) {
-        _character = _result.charCodeAt(_position);
-        if (!(_character === 9 || 32 <= _character && _character <= 1114111)) {
-          throwError(state, "expected valid JSON character");
-        }
-      }
-    } else if (PATTERN_NON_PRINTABLE.test(_result)) {
-      throwError(state, "the stream contains non-printable characters");
-    }
-    state.result += _result;
-  }
-}
-function mergeMappings(state, destination, source, overridableKeys) {
-  var sourceKeys, key, index, quantity;
-  if (!common.isObject(source)) {
-    throwError(state, "cannot merge mappings; the provided source object is unacceptable");
-  }
-  sourceKeys = Object.keys(source);
-  for (index = 0, quantity = sourceKeys.length; index < quantity; index += 1) {
-    key = sourceKeys[index];
-    if (!_hasOwnProperty$1.call(destination, key)) {
-      setProperty(destination, key, source[key]);
-      overridableKeys[key] = true;
-    }
-  }
-}
-function storeMappingPair(state, _result, overridableKeys, keyTag, keyNode, valueNode, startLine, startLineStart, startPos) {
-  var index, quantity;
-  if (Array.isArray(keyNode)) {
-    keyNode = Array.prototype.slice.call(keyNode);
-    for (index = 0, quantity = keyNode.length; index < quantity; index += 1) {
-      if (Array.isArray(keyNode[index])) {
-        throwError(state, "nested arrays are not supported inside keys");
-      }
-      if (typeof keyNode === "object" && _class(keyNode[index]) === "[object Object]") {
-        keyNode[index] = "[object Object]";
-      }
-    }
-  }
-  if (typeof keyNode === "object" && _class(keyNode) === "[object Object]") {
-    keyNode = "[object Object]";
-  }
-  keyNode = String(keyNode);
-  if (_result === null) {
-    _result = {};
-  }
-  if (keyTag === "tag:yaml.org,2002:merge") {
-    if (Array.isArray(valueNode)) {
-      for (index = 0, quantity = valueNode.length; index < quantity; index += 1) {
-        mergeMappings(state, _result, valueNode[index], overridableKeys);
-      }
-    } else {
-      mergeMappings(state, _result, valueNode, overridableKeys);
-    }
-  } else {
-    if (!state.json && !_hasOwnProperty$1.call(overridableKeys, keyNode) && _hasOwnProperty$1.call(_result, keyNode)) {
-      state.line = startLine || state.line;
-      state.lineStart = startLineStart || state.lineStart;
-      state.position = startPos || state.position;
-      throwError(state, "duplicated mapping key");
-    }
-    setProperty(_result, keyNode, valueNode);
-    delete overridableKeys[keyNode];
-  }
-  return _result;
-}
-function readLineBreak(state) {
-  var ch;
-  ch = state.input.charCodeAt(state.position);
-  if (ch === 10) {
-    state.position++;
-  } else if (ch === 13) {
-    state.position++;
-    if (state.input.charCodeAt(state.position) === 10) {
-      state.position++;
-    }
-  } else {
-    throwError(state, "a line break is expected");
-  }
-  state.line += 1;
-  state.lineStart = state.position;
-  state.firstTabInLine = -1;
-}
-function skipSeparationSpace(state, allowComments, checkIndent) {
-  var lineBreaks = 0, ch = state.input.charCodeAt(state.position);
-  while (ch !== 0) {
-    while (is_WHITE_SPACE(ch)) {
-      if (ch === 9 && state.firstTabInLine === -1) {
-        state.firstTabInLine = state.position;
-      }
-      ch = state.input.charCodeAt(++state.position);
-    }
-    if (allowComments && ch === 35) {
-      do {
-        ch = state.input.charCodeAt(++state.position);
-      } while (ch !== 10 && ch !== 13 && ch !== 0);
-    }
-    if (is_EOL(ch)) {
-      readLineBreak(state);
-      ch = state.input.charCodeAt(state.position);
-      lineBreaks++;
-      state.lineIndent = 0;
-      while (ch === 32) {
-        state.lineIndent++;
-        ch = state.input.charCodeAt(++state.position);
-      }
-    } else {
-      break;
-    }
-  }
-  if (checkIndent !== -1 && lineBreaks !== 0 && state.lineIndent < checkIndent) {
-    throwWarning(state, "deficient indentation");
-  }
-  return lineBreaks;
-}
-function testDocumentSeparator(state) {
-  var _position = state.position, ch;
-  ch = state.input.charCodeAt(_position);
-  if ((ch === 45 || ch === 46) && ch === state.input.charCodeAt(_position + 1) && ch === state.input.charCodeAt(_position + 2)) {
-    _position += 3;
-    ch = state.input.charCodeAt(_position);
-    if (ch === 0 || is_WS_OR_EOL(ch)) {
-      return true;
-    }
-  }
-  return false;
-}
-function writeFoldedLines(state, count) {
-  if (count === 1) {
-    state.result += " ";
-  } else if (count > 1) {
-    state.result += common.repeat("\n", count - 1);
-  }
-}
-function readPlainScalar(state, nodeIndent, withinFlowCollection) {
-  var preceding, following, captureStart, captureEnd, hasPendingContent, _line, _lineStart, _lineIndent, _kind = state.kind, _result = state.result, ch;
-  ch = state.input.charCodeAt(state.position);
-  if (is_WS_OR_EOL(ch) || is_FLOW_INDICATOR(ch) || ch === 35 || ch === 38 || ch === 42 || ch === 33 || ch === 124 || ch === 62 || ch === 39 || ch === 34 || ch === 37 || ch === 64 || ch === 96) {
-    return false;
-  }
-  if (ch === 63 || ch === 45) {
-    following = state.input.charCodeAt(state.position + 1);
-    if (is_WS_OR_EOL(following) || withinFlowCollection && is_FLOW_INDICATOR(following)) {
-      return false;
-    }
-  }
-  state.kind = "scalar";
-  state.result = "";
-  captureStart = captureEnd = state.position;
-  hasPendingContent = false;
-  while (ch !== 0) {
-    if (ch === 58) {
-      following = state.input.charCodeAt(state.position + 1);
-      if (is_WS_OR_EOL(following) || withinFlowCollection && is_FLOW_INDICATOR(following)) {
-        break;
-      }
-    } else if (ch === 35) {
-      preceding = state.input.charCodeAt(state.position - 1);
-      if (is_WS_OR_EOL(preceding)) {
-        break;
-      }
-    } else if (state.position === state.lineStart && testDocumentSeparator(state) || withinFlowCollection && is_FLOW_INDICATOR(ch)) {
-      break;
-    } else if (is_EOL(ch)) {
-      _line = state.line;
-      _lineStart = state.lineStart;
-      _lineIndent = state.lineIndent;
-      skipSeparationSpace(state, false, -1);
-      if (state.lineIndent >= nodeIndent) {
-        hasPendingContent = true;
-        ch = state.input.charCodeAt(state.position);
-        continue;
-      } else {
-        state.position = captureEnd;
-        state.line = _line;
-        state.lineStart = _lineStart;
-        state.lineIndent = _lineIndent;
-        break;
-      }
-    }
-    if (hasPendingContent) {
-      captureSegment(state, captureStart, captureEnd, false);
-      writeFoldedLines(state, state.line - _line);
-      captureStart = captureEnd = state.position;
-      hasPendingContent = false;
-    }
-    if (!is_WHITE_SPACE(ch)) {
-      captureEnd = state.position + 1;
-    }
-    ch = state.input.charCodeAt(++state.position);
-  }
-  captureSegment(state, captureStart, captureEnd, false);
-  if (state.result) {
-    return true;
-  }
-  state.kind = _kind;
-  state.result = _result;
-  return false;
-}
-function readSingleQuotedScalar(state, nodeIndent) {
-  var ch, captureStart, captureEnd;
-  ch = state.input.charCodeAt(state.position);
-  if (ch !== 39) {
-    return false;
-  }
-  state.kind = "scalar";
-  state.result = "";
-  state.position++;
-  captureStart = captureEnd = state.position;
-  while ((ch = state.input.charCodeAt(state.position)) !== 0) {
-    if (ch === 39) {
-      captureSegment(state, captureStart, state.position, true);
-      ch = state.input.charCodeAt(++state.position);
-      if (ch === 39) {
-        captureStart = state.position;
-        state.position++;
-        captureEnd = state.position;
-      } else {
-        return true;
-      }
-    } else if (is_EOL(ch)) {
-      captureSegment(state, captureStart, captureEnd, true);
-      writeFoldedLines(state, skipSeparationSpace(state, false, nodeIndent));
-      captureStart = captureEnd = state.position;
-    } else if (state.position === state.lineStart && testDocumentSeparator(state)) {
-      throwError(state, "unexpected end of the document within a single quoted scalar");
-    } else {
-      state.position++;
-      captureEnd = state.position;
-    }
-  }
-  throwError(state, "unexpected end of the stream within a single quoted scalar");
-}
-function readDoubleQuotedScalar(state, nodeIndent) {
-  var captureStart, captureEnd, hexLength, hexResult, tmp, ch;
-  ch = state.input.charCodeAt(state.position);
-  if (ch !== 34) {
-    return false;
-  }
-  state.kind = "scalar";
-  state.result = "";
-  state.position++;
-  captureStart = captureEnd = state.position;
-  while ((ch = state.input.charCodeAt(state.position)) !== 0) {
-    if (ch === 34) {
-      captureSegment(state, captureStart, state.position, true);
-      state.position++;
-      return true;
-    } else if (ch === 92) {
-      captureSegment(state, captureStart, state.position, true);
-      ch = state.input.charCodeAt(++state.position);
-      if (is_EOL(ch)) {
-        skipSeparationSpace(state, false, nodeIndent);
-      } else if (ch < 256 && simpleEscapeCheck[ch]) {
-        state.result += simpleEscapeMap[ch];
-        state.position++;
-      } else if ((tmp = escapedHexLen(ch)) > 0) {
-        hexLength = tmp;
-        hexResult = 0;
-        for (; hexLength > 0; hexLength--) {
-          ch = state.input.charCodeAt(++state.position);
-          if ((tmp = fromHexCode(ch)) >= 0) {
-            hexResult = (hexResult << 4) + tmp;
-          } else {
-            throwError(state, "expected hexadecimal character");
-          }
-        }
-        state.result += charFromCodepoint(hexResult);
-        state.position++;
-      } else {
-        throwError(state, "unknown escape sequence");
-      }
-      captureStart = captureEnd = state.position;
-    } else if (is_EOL(ch)) {
-      captureSegment(state, captureStart, captureEnd, true);
-      writeFoldedLines(state, skipSeparationSpace(state, false, nodeIndent));
-      captureStart = captureEnd = state.position;
-    } else if (state.position === state.lineStart && testDocumentSeparator(state)) {
-      throwError(state, "unexpected end of the document within a double quoted scalar");
-    } else {
-      state.position++;
-      captureEnd = state.position;
-    }
-  }
-  throwError(state, "unexpected end of the stream within a double quoted scalar");
-}
-function readFlowCollection(state, nodeIndent) {
-  var readNext = true, _line, _lineStart, _pos, _tag = state.tag, _result, _anchor = state.anchor, following, terminator, isPair, isExplicitPair, isMapping, overridableKeys = /* @__PURE__ */ Object.create(null), keyNode, keyTag, valueNode, ch;
-  ch = state.input.charCodeAt(state.position);
-  if (ch === 91) {
-    terminator = 93;
-    isMapping = false;
-    _result = [];
-  } else if (ch === 123) {
-    terminator = 125;
-    isMapping = true;
-    _result = {};
-  } else {
-    return false;
-  }
-  if (state.anchor !== null) {
-    state.anchorMap[state.anchor] = _result;
-  }
-  ch = state.input.charCodeAt(++state.position);
-  while (ch !== 0) {
-    skipSeparationSpace(state, true, nodeIndent);
-    ch = state.input.charCodeAt(state.position);
-    if (ch === terminator) {
-      state.position++;
-      state.tag = _tag;
-      state.anchor = _anchor;
-      state.kind = isMapping ? "mapping" : "sequence";
-      state.result = _result;
-      return true;
-    } else if (!readNext) {
-      throwError(state, "missed comma between flow collection entries");
-    } else if (ch === 44) {
-      throwError(state, "expected the node content, but found ','");
-    }
-    keyTag = keyNode = valueNode = null;
-    isPair = isExplicitPair = false;
-    if (ch === 63) {
-      following = state.input.charCodeAt(state.position + 1);
-      if (is_WS_OR_EOL(following)) {
-        isPair = isExplicitPair = true;
-        state.position++;
-        skipSeparationSpace(state, true, nodeIndent);
-      }
-    }
-    _line = state.line;
-    _lineStart = state.lineStart;
-    _pos = state.position;
-    composeNode(state, nodeIndent, CONTEXT_FLOW_IN, false, true);
-    keyTag = state.tag;
-    keyNode = state.result;
-    skipSeparationSpace(state, true, nodeIndent);
-    ch = state.input.charCodeAt(state.position);
-    if ((isExplicitPair || state.line === _line) && ch === 58) {
-      isPair = true;
-      ch = state.input.charCodeAt(++state.position);
-      skipSeparationSpace(state, true, nodeIndent);
-      composeNode(state, nodeIndent, CONTEXT_FLOW_IN, false, true);
-      valueNode = state.result;
-    }
-    if (isMapping) {
-      storeMappingPair(state, _result, overridableKeys, keyTag, keyNode, valueNode, _line, _lineStart, _pos);
-    } else if (isPair) {
-      _result.push(storeMappingPair(state, null, overridableKeys, keyTag, keyNode, valueNode, _line, _lineStart, _pos));
-    } else {
-      _result.push(keyNode);
-    }
-    skipSeparationSpace(state, true, nodeIndent);
-    ch = state.input.charCodeAt(state.position);
-    if (ch === 44) {
-      readNext = true;
-      ch = state.input.charCodeAt(++state.position);
-    } else {
-      readNext = false;
-    }
-  }
-  throwError(state, "unexpected end of the stream within a flow collection");
-}
-function readBlockScalar(state, nodeIndent) {
-  var captureStart, folding, chomping = CHOMPING_CLIP, didReadContent = false, detectedIndent = false, textIndent = nodeIndent, emptyLines = 0, atMoreIndented = false, tmp, ch;
-  ch = state.input.charCodeAt(state.position);
-  if (ch === 124) {
-    folding = false;
-  } else if (ch === 62) {
-    folding = true;
-  } else {
-    return false;
-  }
-  state.kind = "scalar";
-  state.result = "";
-  while (ch !== 0) {
-    ch = state.input.charCodeAt(++state.position);
-    if (ch === 43 || ch === 45) {
-      if (CHOMPING_CLIP === chomping) {
-        chomping = ch === 43 ? CHOMPING_KEEP : CHOMPING_STRIP;
-      } else {
-        throwError(state, "repeat of a chomping mode identifier");
-      }
-    } else if ((tmp = fromDecimalCode(ch)) >= 0) {
-      if (tmp === 0) {
-        throwError(state, "bad explicit indentation width of a block scalar; it cannot be less than one");
-      } else if (!detectedIndent) {
-        textIndent = nodeIndent + tmp - 1;
-        detectedIndent = true;
-      } else {
-        throwError(state, "repeat of an indentation width identifier");
-      }
-    } else {
-      break;
-    }
-  }
-  if (is_WHITE_SPACE(ch)) {
-    do {
-      ch = state.input.charCodeAt(++state.position);
-    } while (is_WHITE_SPACE(ch));
-    if (ch === 35) {
-      do {
-        ch = state.input.charCodeAt(++state.position);
-      } while (!is_EOL(ch) && ch !== 0);
-    }
-  }
-  while (ch !== 0) {
-    readLineBreak(state);
-    state.lineIndent = 0;
-    ch = state.input.charCodeAt(state.position);
-    while ((!detectedIndent || state.lineIndent < textIndent) && ch === 32) {
-      state.lineIndent++;
-      ch = state.input.charCodeAt(++state.position);
-    }
-    if (!detectedIndent && state.lineIndent > textIndent) {
-      textIndent = state.lineIndent;
-    }
-    if (is_EOL(ch)) {
-      emptyLines++;
-      continue;
-    }
-    if (state.lineIndent < textIndent) {
-      if (chomping === CHOMPING_KEEP) {
-        state.result += common.repeat("\n", didReadContent ? 1 + emptyLines : emptyLines);
-      } else if (chomping === CHOMPING_CLIP) {
-        if (didReadContent) {
-          state.result += "\n";
-        }
-      }
-      break;
-    }
-    if (folding) {
-      if (is_WHITE_SPACE(ch)) {
-        atMoreIndented = true;
-        state.result += common.repeat("\n", didReadContent ? 1 + emptyLines : emptyLines);
-      } else if (atMoreIndented) {
-        atMoreIndented = false;
-        state.result += common.repeat("\n", emptyLines + 1);
-      } else if (emptyLines === 0) {
-        if (didReadContent) {
-          state.result += " ";
-        }
-      } else {
-        state.result += common.repeat("\n", emptyLines);
-      }
-    } else {
-      state.result += common.repeat("\n", didReadContent ? 1 + emptyLines : emptyLines);
-    }
-    didReadContent = true;
-    detectedIndent = true;
-    emptyLines = 0;
-    captureStart = state.position;
-    while (!is_EOL(ch) && ch !== 0) {
-      ch = state.input.charCodeAt(++state.position);
-    }
-    captureSegment(state, captureStart, state.position, false);
-  }
-  return true;
-}
-function readBlockSequence(state, nodeIndent) {
-  var _line, _tag = state.tag, _anchor = state.anchor, _result = [], following, detected = false, ch;
-  if (state.firstTabInLine !== -1) return false;
-  if (state.anchor !== null) {
-    state.anchorMap[state.anchor] = _result;
-  }
-  ch = state.input.charCodeAt(state.position);
-  while (ch !== 0) {
-    if (state.firstTabInLine !== -1) {
-      state.position = state.firstTabInLine;
-      throwError(state, "tab characters must not be used in indentation");
-    }
-    if (ch !== 45) {
-      break;
-    }
-    following = state.input.charCodeAt(state.position + 1);
-    if (!is_WS_OR_EOL(following)) {
-      break;
-    }
-    detected = true;
-    state.position++;
-    if (skipSeparationSpace(state, true, -1)) {
-      if (state.lineIndent <= nodeIndent) {
-        _result.push(null);
-        ch = state.input.charCodeAt(state.position);
-        continue;
-      }
-    }
-    _line = state.line;
-    composeNode(state, nodeIndent, CONTEXT_BLOCK_IN, false, true);
-    _result.push(state.result);
-    skipSeparationSpace(state, true, -1);
-    ch = state.input.charCodeAt(state.position);
-    if ((state.line === _line || state.lineIndent > nodeIndent) && ch !== 0) {
-      throwError(state, "bad indentation of a sequence entry");
-    } else if (state.lineIndent < nodeIndent) {
-      break;
-    }
-  }
-  if (detected) {
-    state.tag = _tag;
-    state.anchor = _anchor;
-    state.kind = "sequence";
-    state.result = _result;
-    return true;
-  }
-  return false;
-}
-function readBlockMapping(state, nodeIndent, flowIndent) {
-  var following, allowCompact, _line, _keyLine, _keyLineStart, _keyPos, _tag = state.tag, _anchor = state.anchor, _result = {}, overridableKeys = /* @__PURE__ */ Object.create(null), keyTag = null, keyNode = null, valueNode = null, atExplicitKey = false, detected = false, ch;
-  if (state.firstTabInLine !== -1) return false;
-  if (state.anchor !== null) {
-    state.anchorMap[state.anchor] = _result;
-  }
-  ch = state.input.charCodeAt(state.position);
-  while (ch !== 0) {
-    if (!atExplicitKey && state.firstTabInLine !== -1) {
-      state.position = state.firstTabInLine;
-      throwError(state, "tab characters must not be used in indentation");
-    }
-    following = state.input.charCodeAt(state.position + 1);
-    _line = state.line;
-    if ((ch === 63 || ch === 58) && is_WS_OR_EOL(following)) {
-      if (ch === 63) {
-        if (atExplicitKey) {
-          storeMappingPair(state, _result, overridableKeys, keyTag, keyNode, null, _keyLine, _keyLineStart, _keyPos);
-          keyTag = keyNode = valueNode = null;
-        }
-        detected = true;
-        atExplicitKey = true;
-        allowCompact = true;
-      } else if (atExplicitKey) {
-        atExplicitKey = false;
-        allowCompact = true;
-      } else {
-        throwError(state, "incomplete explicit mapping pair; a key node is missed; or followed by a non-tabulated empty line");
-      }
-      state.position += 1;
-      ch = following;
-    } else {
-      _keyLine = state.line;
-      _keyLineStart = state.lineStart;
-      _keyPos = state.position;
-      if (!composeNode(state, flowIndent, CONTEXT_FLOW_OUT, false, true)) {
-        break;
-      }
-      if (state.line === _line) {
-        ch = state.input.charCodeAt(state.position);
-        while (is_WHITE_SPACE(ch)) {
-          ch = state.input.charCodeAt(++state.position);
-        }
-        if (ch === 58) {
-          ch = state.input.charCodeAt(++state.position);
-          if (!is_WS_OR_EOL(ch)) {
-            throwError(state, "a whitespace character is expected after the key-value separator within a block mapping");
-          }
-          if (atExplicitKey) {
-            storeMappingPair(state, _result, overridableKeys, keyTag, keyNode, null, _keyLine, _keyLineStart, _keyPos);
-            keyTag = keyNode = valueNode = null;
-          }
-          detected = true;
-          atExplicitKey = false;
-          allowCompact = false;
-          keyTag = state.tag;
-          keyNode = state.result;
-        } else if (detected) {
-          throwError(state, "can not read an implicit mapping pair; a colon is missed");
-        } else {
-          state.tag = _tag;
-          state.anchor = _anchor;
-          return true;
-        }
-      } else if (detected) {
-        throwError(state, "can not read a block mapping entry; a multiline key may not be an implicit key");
-      } else {
-        state.tag = _tag;
-        state.anchor = _anchor;
-        return true;
-      }
-    }
-    if (state.line === _line || state.lineIndent > nodeIndent) {
-      if (atExplicitKey) {
-        _keyLine = state.line;
-        _keyLineStart = state.lineStart;
-        _keyPos = state.position;
-      }
-      if (composeNode(state, nodeIndent, CONTEXT_BLOCK_OUT, true, allowCompact)) {
-        if (atExplicitKey) {
-          keyNode = state.result;
-        } else {
-          valueNode = state.result;
-        }
-      }
-      if (!atExplicitKey) {
-        storeMappingPair(state, _result, overridableKeys, keyTag, keyNode, valueNode, _keyLine, _keyLineStart, _keyPos);
-        keyTag = keyNode = valueNode = null;
-      }
-      skipSeparationSpace(state, true, -1);
-      ch = state.input.charCodeAt(state.position);
-    }
-    if ((state.line === _line || state.lineIndent > nodeIndent) && ch !== 0) {
-      throwError(state, "bad indentation of a mapping entry");
-    } else if (state.lineIndent < nodeIndent) {
-      break;
-    }
-  }
-  if (atExplicitKey) {
-    storeMappingPair(state, _result, overridableKeys, keyTag, keyNode, null, _keyLine, _keyLineStart, _keyPos);
-  }
-  if (detected) {
-    state.tag = _tag;
-    state.anchor = _anchor;
-    state.kind = "mapping";
-    state.result = _result;
-  }
-  return detected;
-}
-function readTagProperty(state) {
-  var _position, isVerbatim = false, isNamed = false, tagHandle, tagName, ch;
-  ch = state.input.charCodeAt(state.position);
-  if (ch !== 33) return false;
-  if (state.tag !== null) {
-    throwError(state, "duplication of a tag property");
-  }
-  ch = state.input.charCodeAt(++state.position);
-  if (ch === 60) {
-    isVerbatim = true;
-    ch = state.input.charCodeAt(++state.position);
-  } else if (ch === 33) {
-    isNamed = true;
-    tagHandle = "!!";
-    ch = state.input.charCodeAt(++state.position);
-  } else {
-    tagHandle = "!";
-  }
-  _position = state.position;
-  if (isVerbatim) {
-    do {
-      ch = state.input.charCodeAt(++state.position);
-    } while (ch !== 0 && ch !== 62);
-    if (state.position < state.length) {
-      tagName = state.input.slice(_position, state.position);
-      ch = state.input.charCodeAt(++state.position);
-    } else {
-      throwError(state, "unexpected end of the stream within a verbatim tag");
-    }
-  } else {
-    while (ch !== 0 && !is_WS_OR_EOL(ch)) {
-      if (ch === 33) {
-        if (!isNamed) {
-          tagHandle = state.input.slice(_position - 1, state.position + 1);
-          if (!PATTERN_TAG_HANDLE.test(tagHandle)) {
-            throwError(state, "named tag handle cannot contain such characters");
-          }
-          isNamed = true;
-          _position = state.position + 1;
-        } else {
-          throwError(state, "tag suffix cannot contain exclamation marks");
-        }
-      }
-      ch = state.input.charCodeAt(++state.position);
-    }
-    tagName = state.input.slice(_position, state.position);
-    if (PATTERN_FLOW_INDICATORS.test(tagName)) {
-      throwError(state, "tag suffix cannot contain flow indicator characters");
-    }
-  }
-  if (tagName && !PATTERN_TAG_URI.test(tagName)) {
-    throwError(state, "tag name cannot contain such characters: " + tagName);
-  }
-  try {
-    tagName = decodeURIComponent(tagName);
-  } catch (err) {
-    throwError(state, "tag name is malformed: " + tagName);
-  }
-  if (isVerbatim) {
-    state.tag = tagName;
-  } else if (_hasOwnProperty$1.call(state.tagMap, tagHandle)) {
-    state.tag = state.tagMap[tagHandle] + tagName;
-  } else if (tagHandle === "!") {
-    state.tag = "!" + tagName;
-  } else if (tagHandle === "!!") {
-    state.tag = "tag:yaml.org,2002:" + tagName;
-  } else {
-    throwError(state, 'undeclared tag handle "' + tagHandle + '"');
-  }
-  return true;
-}
-function readAnchorProperty(state) {
-  var _position, ch;
-  ch = state.input.charCodeAt(state.position);
-  if (ch !== 38) return false;
-  if (state.anchor !== null) {
-    throwError(state, "duplication of an anchor property");
-  }
-  ch = state.input.charCodeAt(++state.position);
-  _position = state.position;
-  while (ch !== 0 && !is_WS_OR_EOL(ch) && !is_FLOW_INDICATOR(ch)) {
-    ch = state.input.charCodeAt(++state.position);
-  }
-  if (state.position === _position) {
-    throwError(state, "name of an anchor node must contain at least one character");
-  }
-  state.anchor = state.input.slice(_position, state.position);
-  return true;
-}
-function readAlias(state) {
-  var _position, alias, ch;
-  ch = state.input.charCodeAt(state.position);
-  if (ch !== 42) return false;
-  ch = state.input.charCodeAt(++state.position);
-  _position = state.position;
-  while (ch !== 0 && !is_WS_OR_EOL(ch) && !is_FLOW_INDICATOR(ch)) {
-    ch = state.input.charCodeAt(++state.position);
-  }
-  if (state.position === _position) {
-    throwError(state, "name of an alias node must contain at least one character");
-  }
-  alias = state.input.slice(_position, state.position);
-  if (!_hasOwnProperty$1.call(state.anchorMap, alias)) {
-    throwError(state, 'unidentified alias "' + alias + '"');
-  }
-  state.result = state.anchorMap[alias];
-  skipSeparationSpace(state, true, -1);
-  return true;
-}
-function composeNode(state, parentIndent, nodeContext, allowToSeek, allowCompact) {
-  var allowBlockStyles, allowBlockScalars, allowBlockCollections, indentStatus = 1, atNewLine = false, hasContent = false, typeIndex, typeQuantity, typeList, type2, flowIndent, blockIndent;
-  if (state.listener !== null) {
-    state.listener("open", state);
-  }
-  state.tag = null;
-  state.anchor = null;
-  state.kind = null;
-  state.result = null;
-  allowBlockStyles = allowBlockScalars = allowBlockCollections = CONTEXT_BLOCK_OUT === nodeContext || CONTEXT_BLOCK_IN === nodeContext;
-  if (allowToSeek) {
-    if (skipSeparationSpace(state, true, -1)) {
-      atNewLine = true;
-      if (state.lineIndent > parentIndent) {
-        indentStatus = 1;
-      } else if (state.lineIndent === parentIndent) {
-        indentStatus = 0;
-      } else if (state.lineIndent < parentIndent) {
-        indentStatus = -1;
-      }
-    }
-  }
-  if (indentStatus === 1) {
-    while (readTagProperty(state) || readAnchorProperty(state)) {
-      if (skipSeparationSpace(state, true, -1)) {
-        atNewLine = true;
-        allowBlockCollections = allowBlockStyles;
-        if (state.lineIndent > parentIndent) {
-          indentStatus = 1;
-        } else if (state.lineIndent === parentIndent) {
-          indentStatus = 0;
-        } else if (state.lineIndent < parentIndent) {
-          indentStatus = -1;
-        }
-      } else {
-        allowBlockCollections = false;
-      }
-    }
-  }
-  if (allowBlockCollections) {
-    allowBlockCollections = atNewLine || allowCompact;
-  }
-  if (indentStatus === 1 || CONTEXT_BLOCK_OUT === nodeContext) {
-    if (CONTEXT_FLOW_IN === nodeContext || CONTEXT_FLOW_OUT === nodeContext) {
-      flowIndent = parentIndent;
-    } else {
-      flowIndent = parentIndent + 1;
-    }
-    blockIndent = state.position - state.lineStart;
-    if (indentStatus === 1) {
-      if (allowBlockCollections && (readBlockSequence(state, blockIndent) || readBlockMapping(state, blockIndent, flowIndent)) || readFlowCollection(state, flowIndent)) {
-        hasContent = true;
-      } else {
-        if (allowBlockScalars && readBlockScalar(state, flowIndent) || readSingleQuotedScalar(state, flowIndent) || readDoubleQuotedScalar(state, flowIndent)) {
-          hasContent = true;
-        } else if (readAlias(state)) {
-          hasContent = true;
-          if (state.tag !== null || state.anchor !== null) {
-            throwError(state, "alias node should not have any properties");
-          }
-        } else if (readPlainScalar(state, flowIndent, CONTEXT_FLOW_IN === nodeContext)) {
-          hasContent = true;
-          if (state.tag === null) {
-            state.tag = "?";
-          }
-        }
-        if (state.anchor !== null) {
-          state.anchorMap[state.anchor] = state.result;
-        }
-      }
-    } else if (indentStatus === 0) {
-      hasContent = allowBlockCollections && readBlockSequence(state, blockIndent);
-    }
-  }
-  if (state.tag === null) {
-    if (state.anchor !== null) {
-      state.anchorMap[state.anchor] = state.result;
-    }
-  } else if (state.tag === "?") {
-    if (state.result !== null && state.kind !== "scalar") {
-      throwError(state, 'unacceptable node kind for !<?> tag; it should be "scalar", not "' + state.kind + '"');
-    }
-    for (typeIndex = 0, typeQuantity = state.implicitTypes.length; typeIndex < typeQuantity; typeIndex += 1) {
-      type2 = state.implicitTypes[typeIndex];
-      if (type2.resolve(state.result)) {
-        state.result = type2.construct(state.result);
-        state.tag = type2.tag;
-        if (state.anchor !== null) {
-          state.anchorMap[state.anchor] = state.result;
-        }
-        break;
-      }
-    }
-  } else if (state.tag !== "!") {
-    if (_hasOwnProperty$1.call(state.typeMap[state.kind || "fallback"], state.tag)) {
-      type2 = state.typeMap[state.kind || "fallback"][state.tag];
-    } else {
-      type2 = null;
-      typeList = state.typeMap.multi[state.kind || "fallback"];
-      for (typeIndex = 0, typeQuantity = typeList.length; typeIndex < typeQuantity; typeIndex += 1) {
-        if (state.tag.slice(0, typeList[typeIndex].tag.length) === typeList[typeIndex].tag) {
-          type2 = typeList[typeIndex];
-          break;
-        }
-      }
-    }
-    if (!type2) {
-      throwError(state, "unknown tag !<" + state.tag + ">");
-    }
-    if (state.result !== null && type2.kind !== state.kind) {
-      throwError(state, "unacceptable node kind for !<" + state.tag + '> tag; it should be "' + type2.kind + '", not "' + state.kind + '"');
-    }
-    if (!type2.resolve(state.result, state.tag)) {
-      throwError(state, "cannot resolve a node with !<" + state.tag + "> explicit tag");
-    } else {
-      state.result = type2.construct(state.result, state.tag);
-      if (state.anchor !== null) {
-        state.anchorMap[state.anchor] = state.result;
-      }
-    }
-  }
-  if (state.listener !== null) {
-    state.listener("close", state);
-  }
-  return state.tag !== null || state.anchor !== null || hasContent;
-}
-function readDocument(state) {
-  var documentStart = state.position, _position, directiveName, directiveArgs, hasDirectives = false, ch;
-  state.version = null;
-  state.checkLineBreaks = state.legacy;
-  state.tagMap = /* @__PURE__ */ Object.create(null);
-  state.anchorMap = /* @__PURE__ */ Object.create(null);
-  while ((ch = state.input.charCodeAt(state.position)) !== 0) {
-    skipSeparationSpace(state, true, -1);
-    ch = state.input.charCodeAt(state.position);
-    if (state.lineIndent > 0 || ch !== 37) {
-      break;
-    }
-    hasDirectives = true;
-    ch = state.input.charCodeAt(++state.position);
-    _position = state.position;
-    while (ch !== 0 && !is_WS_OR_EOL(ch)) {
-      ch = state.input.charCodeAt(++state.position);
-    }
-    directiveName = state.input.slice(_position, state.position);
-    directiveArgs = [];
-    if (directiveName.length < 1) {
-      throwError(state, "directive name must not be less than one character in length");
-    }
-    while (ch !== 0) {
-      while (is_WHITE_SPACE(ch)) {
-        ch = state.input.charCodeAt(++state.position);
-      }
-      if (ch === 35) {
-        do {
-          ch = state.input.charCodeAt(++state.position);
-        } while (ch !== 0 && !is_EOL(ch));
-        break;
-      }
-      if (is_EOL(ch)) break;
-      _position = state.position;
-      while (ch !== 0 && !is_WS_OR_EOL(ch)) {
-        ch = state.input.charCodeAt(++state.position);
-      }
-      directiveArgs.push(state.input.slice(_position, state.position));
-    }
-    if (ch !== 0) readLineBreak(state);
-    if (_hasOwnProperty$1.call(directiveHandlers, directiveName)) {
-      directiveHandlers[directiveName](state, directiveName, directiveArgs);
-    } else {
-      throwWarning(state, 'unknown document directive "' + directiveName + '"');
-    }
-  }
-  skipSeparationSpace(state, true, -1);
-  if (state.lineIndent === 0 && state.input.charCodeAt(state.position) === 45 && state.input.charCodeAt(state.position + 1) === 45 && state.input.charCodeAt(state.position + 2) === 45) {
-    state.position += 3;
-    skipSeparationSpace(state, true, -1);
-  } else if (hasDirectives) {
-    throwError(state, "directives end mark is expected");
-  }
-  composeNode(state, state.lineIndent - 1, CONTEXT_BLOCK_OUT, false, true);
-  skipSeparationSpace(state, true, -1);
-  if (state.checkLineBreaks && PATTERN_NON_ASCII_LINE_BREAKS.test(state.input.slice(documentStart, state.position))) {
-    throwWarning(state, "non-ASCII line breaks are interpreted as content");
-  }
-  state.documents.push(state.result);
-  if (state.position === state.lineStart && testDocumentSeparator(state)) {
-    if (state.input.charCodeAt(state.position) === 46) {
-      state.position += 3;
-      skipSeparationSpace(state, true, -1);
-    }
-    return;
-  }
-  if (state.position < state.length - 1) {
-    throwError(state, "end of the stream or a document separator is expected");
-  } else {
-    return;
-  }
-}
-function loadDocuments(input, options) {
-  input = String(input);
-  options = options || {};
-  if (input.length !== 0) {
-    if (input.charCodeAt(input.length - 1) !== 10 && input.charCodeAt(input.length - 1) !== 13) {
-      input += "\n";
-    }
-    if (input.charCodeAt(0) === 65279) {
-      input = input.slice(1);
-    }
-  }
-  var state = new State$1(input, options);
-  var nullpos = input.indexOf("\0");
-  if (nullpos !== -1) {
-    state.position = nullpos;
-    throwError(state, "null byte is not allowed in input");
-  }
-  state.input += "\0";
-  while (state.input.charCodeAt(state.position) === 32) {
-    state.lineIndent += 1;
-    state.position += 1;
-  }
-  while (state.position < state.length - 1) {
-    readDocument(state);
-  }
-  return state.documents;
-}
-function loadAll$1(input, iterator, options) {
-  if (iterator !== null && typeof iterator === "object" && typeof options === "undefined") {
-    options = iterator;
-    iterator = null;
-  }
-  var documents = loadDocuments(input, options);
-  if (typeof iterator !== "function") {
-    return documents;
-  }
-  for (var index = 0, length = documents.length; index < length; index += 1) {
-    iterator(documents[index]);
-  }
-}
-function load$1(input, options) {
-  var documents = loadDocuments(input, options);
-  if (documents.length === 0) {
-    return void 0;
-  } else if (documents.length === 1) {
-    return documents[0];
-  }
-  throw new exception("expected a single document in the stream, but found more");
-}
-var loadAll_1 = loadAll$1;
-var load_1 = load$1;
-var loader = {
-  loadAll: loadAll_1,
-  load: load_1
-};
-var _toString = Object.prototype.toString;
-var _hasOwnProperty = Object.prototype.hasOwnProperty;
-var CHAR_BOM = 65279;
-var CHAR_TAB = 9;
-var CHAR_LINE_FEED = 10;
-var CHAR_CARRIAGE_RETURN = 13;
-var CHAR_SPACE = 32;
-var CHAR_EXCLAMATION = 33;
-var CHAR_DOUBLE_QUOTE = 34;
-var CHAR_SHARP = 35;
-var CHAR_PERCENT = 37;
-var CHAR_AMPERSAND = 38;
-var CHAR_SINGLE_QUOTE = 39;
-var CHAR_ASTERISK = 42;
-var CHAR_COMMA = 44;
-var CHAR_MINUS = 45;
-var CHAR_COLON = 58;
-var CHAR_EQUALS = 61;
-var CHAR_GREATER_THAN = 62;
-var CHAR_QUESTION = 63;
-var CHAR_COMMERCIAL_AT = 64;
-var CHAR_LEFT_SQUARE_BRACKET = 91;
-var CHAR_RIGHT_SQUARE_BRACKET = 93;
-var CHAR_GRAVE_ACCENT = 96;
-var CHAR_LEFT_CURLY_BRACKET = 123;
-var CHAR_VERTICAL_LINE = 124;
-var CHAR_RIGHT_CURLY_BRACKET = 125;
-var ESCAPE_SEQUENCES = {};
-ESCAPE_SEQUENCES[0] = "\\0";
-ESCAPE_SEQUENCES[7] = "\\a";
-ESCAPE_SEQUENCES[8] = "\\b";
-ESCAPE_SEQUENCES[9] = "\\t";
-ESCAPE_SEQUENCES[10] = "\\n";
-ESCAPE_SEQUENCES[11] = "\\v";
-ESCAPE_SEQUENCES[12] = "\\f";
-ESCAPE_SEQUENCES[13] = "\\r";
-ESCAPE_SEQUENCES[27] = "\\e";
-ESCAPE_SEQUENCES[34] = '\\"';
-ESCAPE_SEQUENCES[92] = "\\\\";
-ESCAPE_SEQUENCES[133] = "\\N";
-ESCAPE_SEQUENCES[160] = "\\_";
-ESCAPE_SEQUENCES[8232] = "\\L";
-ESCAPE_SEQUENCES[8233] = "\\P";
-var DEPRECATED_BOOLEANS_SYNTAX = [
-  "y",
-  "Y",
-  "yes",
-  "Yes",
-  "YES",
-  "on",
-  "On",
-  "ON",
-  "n",
-  "N",
-  "no",
-  "No",
-  "NO",
-  "off",
-  "Off",
-  "OFF"
-];
-var DEPRECATED_BASE60_SYNTAX = /^[-+]?[0-9_]+(?::[0-9_]+)+(?:\.[0-9_]*)?$/;
-function compileStyleMap(schema2, map2) {
-  var result, keys, index, length, tag, style, type2;
-  if (map2 === null) return {};
-  result = {};
-  keys = Object.keys(map2);
-  for (index = 0, length = keys.length; index < length; index += 1) {
-    tag = keys[index];
-    style = String(map2[tag]);
-    if (tag.slice(0, 2) === "!!") {
-      tag = "tag:yaml.org,2002:" + tag.slice(2);
-    }
-    type2 = schema2.compiledTypeMap["fallback"][tag];
-    if (type2 && _hasOwnProperty.call(type2.styleAliases, style)) {
-      style = type2.styleAliases[style];
-    }
-    result[tag] = style;
-  }
-  return result;
-}
-function encodeHex(character) {
-  var string, handle, length;
-  string = character.toString(16).toUpperCase();
-  if (character <= 255) {
-    handle = "x";
-    length = 2;
-  } else if (character <= 65535) {
-    handle = "u";
-    length = 4;
-  } else if (character <= 4294967295) {
-    handle = "U";
-    length = 8;
-  } else {
-    throw new exception("code point within a string may not be greater than 0xFFFFFFFF");
-  }
-  return "\\" + handle + common.repeat("0", length - string.length) + string;
-}
-var QUOTING_TYPE_SINGLE = 1;
-var QUOTING_TYPE_DOUBLE = 2;
-function State(options) {
-  this.schema = options["schema"] || _default;
-  this.indent = Math.max(1, options["indent"] || 2);
-  this.noArrayIndent = options["noArrayIndent"] || false;
-  this.skipInvalid = options["skipInvalid"] || false;
-  this.flowLevel = common.isNothing(options["flowLevel"]) ? -1 : options["flowLevel"];
-  this.styleMap = compileStyleMap(this.schema, options["styles"] || null);
-  this.sortKeys = options["sortKeys"] || false;
-  this.lineWidth = options["lineWidth"] || 80;
-  this.noRefs = options["noRefs"] || false;
-  this.noCompatMode = options["noCompatMode"] || false;
-  this.condenseFlow = options["condenseFlow"] || false;
-  this.quotingType = options["quotingType"] === '"' ? QUOTING_TYPE_DOUBLE : QUOTING_TYPE_SINGLE;
-  this.forceQuotes = options["forceQuotes"] || false;
-  this.replacer = typeof options["replacer"] === "function" ? options["replacer"] : null;
-  this.implicitTypes = this.schema.compiledImplicit;
-  this.explicitTypes = this.schema.compiledExplicit;
-  this.tag = null;
-  this.result = "";
-  this.duplicates = [];
-  this.usedDuplicates = null;
-}
-function indentString(string, spaces) {
-  var ind = common.repeat(" ", spaces), position = 0, next = -1, result = "", line, length = string.length;
-  while (position < length) {
-    next = string.indexOf("\n", position);
-    if (next === -1) {
-      line = string.slice(position);
-      position = length;
-    } else {
-      line = string.slice(position, next + 1);
-      position = next + 1;
-    }
-    if (line.length && line !== "\n") result += ind;
-    result += line;
-  }
-  return result;
-}
-function generateNextLine(state, level) {
-  return "\n" + common.repeat(" ", state.indent * level);
-}
-function testImplicitResolving(state, str2) {
-  var index, length, type2;
-  for (index = 0, length = state.implicitTypes.length; index < length; index += 1) {
-    type2 = state.implicitTypes[index];
-    if (type2.resolve(str2)) {
-      return true;
-    }
-  }
-  return false;
-}
-function isWhitespace(c) {
-  return c === CHAR_SPACE || c === CHAR_TAB;
-}
-function isPrintable(c) {
-  return 32 <= c && c <= 126 || 161 <= c && c <= 55295 && c !== 8232 && c !== 8233 || 57344 <= c && c <= 65533 && c !== CHAR_BOM || 65536 <= c && c <= 1114111;
-}
-function isNsCharOrWhitespace(c) {
-  return isPrintable(c) && c !== CHAR_BOM && c !== CHAR_CARRIAGE_RETURN && c !== CHAR_LINE_FEED;
-}
-function isPlainSafe(c, prev, inblock) {
-  var cIsNsCharOrWhitespace = isNsCharOrWhitespace(c);
-  var cIsNsChar = cIsNsCharOrWhitespace && !isWhitespace(c);
-  return (
-    // ns-plain-safe
-    (inblock ? (
-      // c = flow-in
-      cIsNsCharOrWhitespace
-    ) : cIsNsCharOrWhitespace && c !== CHAR_COMMA && c !== CHAR_LEFT_SQUARE_BRACKET && c !== CHAR_RIGHT_SQUARE_BRACKET && c !== CHAR_LEFT_CURLY_BRACKET && c !== CHAR_RIGHT_CURLY_BRACKET) && c !== CHAR_SHARP && !(prev === CHAR_COLON && !cIsNsChar) || isNsCharOrWhitespace(prev) && !isWhitespace(prev) && c === CHAR_SHARP || prev === CHAR_COLON && cIsNsChar
-  );
-}
-function isPlainSafeFirst(c) {
-  return isPrintable(c) && c !== CHAR_BOM && !isWhitespace(c) && c !== CHAR_MINUS && c !== CHAR_QUESTION && c !== CHAR_COLON && c !== CHAR_COMMA && c !== CHAR_LEFT_SQUARE_BRACKET && c !== CHAR_RIGHT_SQUARE_BRACKET && c !== CHAR_LEFT_CURLY_BRACKET && c !== CHAR_RIGHT_CURLY_BRACKET && c !== CHAR_SHARP && c !== CHAR_AMPERSAND && c !== CHAR_ASTERISK && c !== CHAR_EXCLAMATION && c !== CHAR_VERTICAL_LINE && c !== CHAR_EQUALS && c !== CHAR_GREATER_THAN && c !== CHAR_SINGLE_QUOTE && c !== CHAR_DOUBLE_QUOTE && c !== CHAR_PERCENT && c !== CHAR_COMMERCIAL_AT && c !== CHAR_GRAVE_ACCENT;
-}
-function isPlainSafeLast(c) {
-  return !isWhitespace(c) && c !== CHAR_COLON;
-}
-function codePointAt(string, pos) {
-  var first = string.charCodeAt(pos), second;
-  if (first >= 55296 && first <= 56319 && pos + 1 < string.length) {
-    second = string.charCodeAt(pos + 1);
-    if (second >= 56320 && second <= 57343) {
-      return (first - 55296) * 1024 + second - 56320 + 65536;
-    }
-  }
-  return first;
-}
-function needIndentIndicator(string) {
-  var leadingSpaceRe = /^\n* /;
-  return leadingSpaceRe.test(string);
-}
-var STYLE_PLAIN = 1;
-var STYLE_SINGLE = 2;
-var STYLE_LITERAL = 3;
-var STYLE_FOLDED = 4;
-var STYLE_DOUBLE = 5;
-function chooseScalarStyle(string, singleLineOnly, indentPerLevel, lineWidth, testAmbiguousType, quotingType, forceQuotes, inblock) {
-  var i;
-  var char = 0;
-  var prevChar = null;
-  var hasLineBreak = false;
-  var hasFoldableLine = false;
-  var shouldTrackWidth = lineWidth !== -1;
-  var previousLineBreak = -1;
-  var plain = isPlainSafeFirst(codePointAt(string, 0)) && isPlainSafeLast(codePointAt(string, string.length - 1));
-  if (singleLineOnly || forceQuotes) {
-    for (i = 0; i < string.length; char >= 65536 ? i += 2 : i++) {
-      char = codePointAt(string, i);
-      if (!isPrintable(char)) {
-        return STYLE_DOUBLE;
-      }
-      plain = plain && isPlainSafe(char, prevChar, inblock);
-      prevChar = char;
-    }
-  } else {
-    for (i = 0; i < string.length; char >= 65536 ? i += 2 : i++) {
-      char = codePointAt(string, i);
-      if (char === CHAR_LINE_FEED) {
-        hasLineBreak = true;
-        if (shouldTrackWidth) {
-          hasFoldableLine = hasFoldableLine || // Foldable line = too long, and not more-indented.
-          i - previousLineBreak - 1 > lineWidth && string[previousLineBreak + 1] !== " ";
-          previousLineBreak = i;
-        }
-      } else if (!isPrintable(char)) {
-        return STYLE_DOUBLE;
-      }
-      plain = plain && isPlainSafe(char, prevChar, inblock);
-      prevChar = char;
-    }
-    hasFoldableLine = hasFoldableLine || shouldTrackWidth && (i - previousLineBreak - 1 > lineWidth && string[previousLineBreak + 1] !== " ");
-  }
-  if (!hasLineBreak && !hasFoldableLine) {
-    if (plain && !forceQuotes && !testAmbiguousType(string)) {
-      return STYLE_PLAIN;
-    }
-    return quotingType === QUOTING_TYPE_DOUBLE ? STYLE_DOUBLE : STYLE_SINGLE;
-  }
-  if (indentPerLevel > 9 && needIndentIndicator(string)) {
-    return STYLE_DOUBLE;
-  }
-  if (!forceQuotes) {
-    return hasFoldableLine ? STYLE_FOLDED : STYLE_LITERAL;
-  }
-  return quotingType === QUOTING_TYPE_DOUBLE ? STYLE_DOUBLE : STYLE_SINGLE;
-}
-function writeScalar(state, string, level, iskey, inblock) {
-  state.dump = (function() {
-    if (string.length === 0) {
-      return state.quotingType === QUOTING_TYPE_DOUBLE ? '""' : "''";
-    }
-    if (!state.noCompatMode) {
-      if (DEPRECATED_BOOLEANS_SYNTAX.indexOf(string) !== -1 || DEPRECATED_BASE60_SYNTAX.test(string)) {
-        return state.quotingType === QUOTING_TYPE_DOUBLE ? '"' + string + '"' : "'" + string + "'";
-      }
-    }
-    var indent = state.indent * Math.max(1, level);
-    var lineWidth = state.lineWidth === -1 ? -1 : Math.max(Math.min(state.lineWidth, 40), state.lineWidth - indent);
-    var singleLineOnly = iskey || state.flowLevel > -1 && level >= state.flowLevel;
-    function testAmbiguity(string2) {
-      return testImplicitResolving(state, string2);
-    }
-    switch (chooseScalarStyle(
-      string,
-      singleLineOnly,
-      state.indent,
-      lineWidth,
-      testAmbiguity,
-      state.quotingType,
-      state.forceQuotes && !iskey,
-      inblock
-    )) {
-      case STYLE_PLAIN:
-        return string;
-      case STYLE_SINGLE:
-        return "'" + string.replace(/'/g, "''") + "'";
-      case STYLE_LITERAL:
-        return "|" + blockHeader(string, state.indent) + dropEndingNewline(indentString(string, indent));
-      case STYLE_FOLDED:
-        return ">" + blockHeader(string, state.indent) + dropEndingNewline(indentString(foldString(string, lineWidth), indent));
-      case STYLE_DOUBLE:
-        return '"' + escapeString(string) + '"';
-      default:
-        throw new exception("impossible error: invalid scalar style");
-    }
-  })();
-}
-function blockHeader(string, indentPerLevel) {
-  var indentIndicator = needIndentIndicator(string) ? String(indentPerLevel) : "";
-  var clip = string[string.length - 1] === "\n";
-  var keep = clip && (string[string.length - 2] === "\n" || string === "\n");
-  var chomp = keep ? "+" : clip ? "" : "-";
-  return indentIndicator + chomp + "\n";
-}
-function dropEndingNewline(string) {
-  return string[string.length - 1] === "\n" ? string.slice(0, -1) : string;
-}
-function foldString(string, width) {
-  var lineRe = /(\n+)([^\n]*)/g;
-  var result = (function() {
-    var nextLF = string.indexOf("\n");
-    nextLF = nextLF !== -1 ? nextLF : string.length;
-    lineRe.lastIndex = nextLF;
-    return foldLine(string.slice(0, nextLF), width);
-  })();
-  var prevMoreIndented = string[0] === "\n" || string[0] === " ";
-  var moreIndented;
-  var match;
-  while (match = lineRe.exec(string)) {
-    var prefix = match[1], line = match[2];
-    moreIndented = line[0] === " ";
-    result += prefix + (!prevMoreIndented && !moreIndented && line !== "" ? "\n" : "") + foldLine(line, width);
-    prevMoreIndented = moreIndented;
-  }
-  return result;
-}
-function foldLine(line, width) {
-  if (line === "" || line[0] === " ") return line;
-  var breakRe = / [^ ]/g;
-  var match;
-  var start = 0, end, curr = 0, next = 0;
-  var result = "";
-  while (match = breakRe.exec(line)) {
-    next = match.index;
-    if (next - start > width) {
-      end = curr > start ? curr : next;
-      result += "\n" + line.slice(start, end);
-      start = end + 1;
-    }
-    curr = next;
-  }
-  result += "\n";
-  if (line.length - start > width && curr > start) {
-    result += line.slice(start, curr) + "\n" + line.slice(curr + 1);
-  } else {
-    result += line.slice(start);
-  }
-  return result.slice(1);
-}
-function escapeString(string) {
-  var result = "";
-  var char = 0;
-  var escapeSeq;
-  for (var i = 0; i < string.length; char >= 65536 ? i += 2 : i++) {
-    char = codePointAt(string, i);
-    escapeSeq = ESCAPE_SEQUENCES[char];
-    if (!escapeSeq && isPrintable(char)) {
-      result += string[i];
-      if (char >= 65536) result += string[i + 1];
-    } else {
-      result += escapeSeq || encodeHex(char);
-    }
-  }
-  return result;
-}
-function writeFlowSequence(state, level, object) {
-  var _result = "", _tag = state.tag, index, length, value;
-  for (index = 0, length = object.length; index < length; index += 1) {
-    value = object[index];
-    if (state.replacer) {
-      value = state.replacer.call(object, String(index), value);
-    }
-    if (writeNode(state, level, value, false, false) || typeof value === "undefined" && writeNode(state, level, null, false, false)) {
-      if (_result !== "") _result += "," + (!state.condenseFlow ? " " : "");
-      _result += state.dump;
-    }
-  }
-  state.tag = _tag;
-  state.dump = "[" + _result + "]";
-}
-function writeBlockSequence(state, level, object, compact) {
-  var _result = "", _tag = state.tag, index, length, value;
-  for (index = 0, length = object.length; index < length; index += 1) {
-    value = object[index];
-    if (state.replacer) {
-      value = state.replacer.call(object, String(index), value);
-    }
-    if (writeNode(state, level + 1, value, true, true, false, true) || typeof value === "undefined" && writeNode(state, level + 1, null, true, true, false, true)) {
-      if (!compact || _result !== "") {
-        _result += generateNextLine(state, level);
-      }
-      if (state.dump && CHAR_LINE_FEED === state.dump.charCodeAt(0)) {
-        _result += "-";
-      } else {
-        _result += "- ";
-      }
-      _result += state.dump;
-    }
-  }
-  state.tag = _tag;
-  state.dump = _result || "[]";
-}
-function writeFlowMapping(state, level, object) {
-  var _result = "", _tag = state.tag, objectKeyList = Object.keys(object), index, length, objectKey, objectValue, pairBuffer;
-  for (index = 0, length = objectKeyList.length; index < length; index += 1) {
-    pairBuffer = "";
-    if (_result !== "") pairBuffer += ", ";
-    if (state.condenseFlow) pairBuffer += '"';
-    objectKey = objectKeyList[index];
-    objectValue = object[objectKey];
-    if (state.replacer) {
-      objectValue = state.replacer.call(object, objectKey, objectValue);
-    }
-    if (!writeNode(state, level, objectKey, false, false)) {
-      continue;
-    }
-    if (state.dump.length > 1024) pairBuffer += "? ";
-    pairBuffer += state.dump + (state.condenseFlow ? '"' : "") + ":" + (state.condenseFlow ? "" : " ");
-    if (!writeNode(state, level, objectValue, false, false)) {
-      continue;
-    }
-    pairBuffer += state.dump;
-    _result += pairBuffer;
-  }
-  state.tag = _tag;
-  state.dump = "{" + _result + "}";
-}
-function writeBlockMapping(state, level, object, compact) {
-  var _result = "", _tag = state.tag, objectKeyList = Object.keys(object), index, length, objectKey, objectValue, explicitPair, pairBuffer;
-  if (state.sortKeys === true) {
-    objectKeyList.sort();
-  } else if (typeof state.sortKeys === "function") {
-    objectKeyList.sort(state.sortKeys);
-  } else if (state.sortKeys) {
-    throw new exception("sortKeys must be a boolean or a function");
-  }
-  for (index = 0, length = objectKeyList.length; index < length; index += 1) {
-    pairBuffer = "";
-    if (!compact || _result !== "") {
-      pairBuffer += generateNextLine(state, level);
-    }
-    objectKey = objectKeyList[index];
-    objectValue = object[objectKey];
-    if (state.replacer) {
-      objectValue = state.replacer.call(object, objectKey, objectValue);
-    }
-    if (!writeNode(state, level + 1, objectKey, true, true, true)) {
-      continue;
-    }
-    explicitPair = state.tag !== null && state.tag !== "?" || state.dump && state.dump.length > 1024;
-    if (explicitPair) {
-      if (state.dump && CHAR_LINE_FEED === state.dump.charCodeAt(0)) {
-        pairBuffer += "?";
-      } else {
-        pairBuffer += "? ";
-      }
-    }
-    pairBuffer += state.dump;
-    if (explicitPair) {
-      pairBuffer += generateNextLine(state, level);
-    }
-    if (!writeNode(state, level + 1, objectValue, true, explicitPair)) {
-      continue;
-    }
-    if (state.dump && CHAR_LINE_FEED === state.dump.charCodeAt(0)) {
-      pairBuffer += ":";
-    } else {
-      pairBuffer += ": ";
-    }
-    pairBuffer += state.dump;
-    _result += pairBuffer;
-  }
-  state.tag = _tag;
-  state.dump = _result || "{}";
-}
-function detectType(state, object, explicit) {
-  var _result, typeList, index, length, type2, style;
-  typeList = explicit ? state.explicitTypes : state.implicitTypes;
-  for (index = 0, length = typeList.length; index < length; index += 1) {
-    type2 = typeList[index];
-    if ((type2.instanceOf || type2.predicate) && (!type2.instanceOf || typeof object === "object" && object instanceof type2.instanceOf) && (!type2.predicate || type2.predicate(object))) {
-      if (explicit) {
-        if (type2.multi && type2.representName) {
-          state.tag = type2.representName(object);
-        } else {
-          state.tag = type2.tag;
-        }
-      } else {
-        state.tag = "?";
-      }
-      if (type2.represent) {
-        style = state.styleMap[type2.tag] || type2.defaultStyle;
-        if (_toString.call(type2.represent) === "[object Function]") {
-          _result = type2.represent(object, style);
-        } else if (_hasOwnProperty.call(type2.represent, style)) {
-          _result = type2.represent[style](object, style);
-        } else {
-          throw new exception("!<" + type2.tag + '> tag resolver accepts not "' + style + '" style');
-        }
-        state.dump = _result;
-      }
-      return true;
-    }
-  }
-  return false;
-}
-function writeNode(state, level, object, block, compact, iskey, isblockseq) {
-  state.tag = null;
-  state.dump = object;
-  if (!detectType(state, object, false)) {
-    detectType(state, object, true);
-  }
-  var type2 = _toString.call(state.dump);
-  var inblock = block;
-  var tagStr;
-  if (block) {
-    block = state.flowLevel < 0 || state.flowLevel > level;
-  }
-  var objectOrArray = type2 === "[object Object]" || type2 === "[object Array]", duplicateIndex, duplicate;
-  if (objectOrArray) {
-    duplicateIndex = state.duplicates.indexOf(object);
-    duplicate = duplicateIndex !== -1;
-  }
-  if (state.tag !== null && state.tag !== "?" || duplicate || state.indent !== 2 && level > 0) {
-    compact = false;
-  }
-  if (duplicate && state.usedDuplicates[duplicateIndex]) {
-    state.dump = "*ref_" + duplicateIndex;
-  } else {
-    if (objectOrArray && duplicate && !state.usedDuplicates[duplicateIndex]) {
-      state.usedDuplicates[duplicateIndex] = true;
-    }
-    if (type2 === "[object Object]") {
-      if (block && Object.keys(state.dump).length !== 0) {
-        writeBlockMapping(state, level, state.dump, compact);
-        if (duplicate) {
-          state.dump = "&ref_" + duplicateIndex + state.dump;
-        }
-      } else {
-        writeFlowMapping(state, level, state.dump);
-        if (duplicate) {
-          state.dump = "&ref_" + duplicateIndex + " " + state.dump;
-        }
-      }
-    } else if (type2 === "[object Array]") {
-      if (block && state.dump.length !== 0) {
-        if (state.noArrayIndent && !isblockseq && level > 0) {
-          writeBlockSequence(state, level - 1, state.dump, compact);
-        } else {
-          writeBlockSequence(state, level, state.dump, compact);
-        }
-        if (duplicate) {
-          state.dump = "&ref_" + duplicateIndex + state.dump;
-        }
-      } else {
-        writeFlowSequence(state, level, state.dump);
-        if (duplicate) {
-          state.dump = "&ref_" + duplicateIndex + " " + state.dump;
-        }
-      }
-    } else if (type2 === "[object String]") {
-      if (state.tag !== "?") {
-        writeScalar(state, state.dump, level, iskey, inblock);
-      }
-    } else if (type2 === "[object Undefined]") {
-      return false;
-    } else {
-      if (state.skipInvalid) return false;
-      throw new exception("unacceptable kind of an object to dump " + type2);
-    }
-    if (state.tag !== null && state.tag !== "?") {
-      tagStr = encodeURI(
-        state.tag[0] === "!" ? state.tag.slice(1) : state.tag
-      ).replace(/!/g, "%21");
-      if (state.tag[0] === "!") {
-        tagStr = "!" + tagStr;
-      } else if (tagStr.slice(0, 18) === "tag:yaml.org,2002:") {
-        tagStr = "!!" + tagStr.slice(18);
-      } else {
-        tagStr = "!<" + tagStr + ">";
-      }
-      state.dump = tagStr + " " + state.dump;
-    }
-  }
-  return true;
-}
-function getDuplicateReferences(object, state) {
-  var objects = [], duplicatesIndexes = [], index, length;
-  inspectNode(object, objects, duplicatesIndexes);
-  for (index = 0, length = duplicatesIndexes.length; index < length; index += 1) {
-    state.duplicates.push(objects[duplicatesIndexes[index]]);
-  }
-  state.usedDuplicates = new Array(length);
-}
-function inspectNode(object, objects, duplicatesIndexes) {
-  var objectKeyList, index, length;
-  if (object !== null && typeof object === "object") {
-    index = objects.indexOf(object);
-    if (index !== -1) {
-      if (duplicatesIndexes.indexOf(index) === -1) {
-        duplicatesIndexes.push(index);
-      }
-    } else {
-      objects.push(object);
-      if (Array.isArray(object)) {
-        for (index = 0, length = object.length; index < length; index += 1) {
-          inspectNode(object[index], objects, duplicatesIndexes);
-        }
-      } else {
-        objectKeyList = Object.keys(object);
-        for (index = 0, length = objectKeyList.length; index < length; index += 1) {
-          inspectNode(object[objectKeyList[index]], objects, duplicatesIndexes);
-        }
-      }
-    }
-  }
-}
-function dump$1(input, options) {
-  options = options || {};
-  var state = new State(options);
-  if (!state.noRefs) getDuplicateReferences(input, state);
-  var value = input;
-  if (state.replacer) {
-    value = state.replacer.call({ "": value }, "", value);
-  }
-  if (writeNode(state, 0, value, true, true)) return state.dump + "\n";
-  return "";
-}
-var dump_1 = dump$1;
-var dumper = {
-  dump: dump_1
-};
-function renamed(from, to) {
-  return function() {
-    throw new Error("Function yaml." + from + " is removed in js-yaml 4. Use yaml." + to + " instead, which is now safe by default.");
-  };
-}
-var Type = type;
-var Schema = schema;
-var FAILSAFE_SCHEMA = failsafe;
-var JSON_SCHEMA = json;
-var CORE_SCHEMA = core;
-var DEFAULT_SCHEMA = _default;
-var load = loader.load;
-var loadAll = loader.loadAll;
-var dump = dumper.dump;
-var YAMLException = exception;
-var types = {
-  binary,
-  float,
-  map,
-  null: _null,
-  pairs,
-  set,
-  timestamp,
-  bool,
-  int,
-  merge,
-  omap,
-  seq,
-  str
-};
-var safeLoad = renamed("safeLoad", "load");
-var safeLoadAll = renamed("safeLoadAll", "loadAll");
-var safeDump = renamed("safeDump", "dump");
-var jsYaml = {
-  Type,
-  Schema,
-  FAILSAFE_SCHEMA,
-  JSON_SCHEMA,
-  CORE_SCHEMA,
-  DEFAULT_SCHEMA,
-  load,
-  loadAll,
-  dump,
-  YAMLException,
-  types,
-  safeLoad,
-  safeLoadAll,
-  safeDump
-};
-
-// ../cli/dist/src/config/yaml-tags.js
-function createTagType(tagName) {
-  return new jsYaml.Type(`!${tagName}`, {
-    kind: "mapping",
-    construct(data) {
-      return { tag: tagName, config: data ?? {} };
-    },
-    instanceOf: Object,
-    represent(value) {
-      const tv = value;
-      return tv.config;
-    }
-  });
-}
-function createBareTagType(tagName) {
-  return new jsYaml.Type(`!${tagName}`, {
-    kind: "scalar",
-    construct() {
-      return { tag: tagName, config: {} };
-    },
-    instanceOf: Object,
-    represent() {
-      return "";
-    }
-  });
-}
-var TAG_NAMES = ["secret", "gcp", "aws", "age", "sops"];
-var mappingTypes = TAG_NAMES.map((name) => createTagType(name));
-var bareTypes = TAG_NAMES.map((name) => createBareTagType(name));
-var KEYSHELF_SCHEMA = jsYaml.DEFAULT_SCHEMA.extend([...bareTypes, ...mappingTypes]);
-function isTaggedValue(value) {
-  return typeof value === "object" && value !== null && "tag" in value && "config" in value && typeof value.tag === "string";
-}
-
-// ../cli/dist/src/utils/paths.js
-function flattenKeys(obj, prefix = "") {
-  const result = {};
-  for (const [key, value] of Object.entries(obj)) {
-    const path = prefix ? `${prefix}/${key}` : key;
-    if (typeof value === "object" && value !== null && !Array.isArray(value) && !("tag" in value && "config" in value)) {
-      Object.assign(result, flattenKeys(value, path));
-    } else {
-      result[path] = value;
-    }
-  }
-  return result;
-}
-
-// ../cli/dist/src/config/environment.js
-function parseEnvironment(content) {
-  const raw = jsYaml.load(content, { schema: KEYSHELF_SCHEMA });
-  if (!raw || typeof raw !== "object") {
-    return { overrides: {} };
-  }
-  const doc = raw;
-  const defaultProvider = parseProviderBlock(doc["default-provider"]);
-  const keysBlock = doc.keys;
-  if (keysBlock != null && typeof keysBlock !== "object") {
-    throw new Error('Environment file "keys:" must be a mapping');
-  }
-  const source = keysBlock ?? {};
-  const flat = flattenKeys(source);
-  const overrides = {};
-  for (const [path, value] of Object.entries(flat)) {
-    if (value != null) {
-      overrides[path] = value;
-    }
-  }
-  return { defaultProvider, overrides };
-}
-function parseProviderBlock(raw) {
-  if (!raw || typeof raw !== "object") return void 0;
-  const block = raw;
-  const name = block.name;
-  if (typeof name !== "string") return void 0;
-  const options = {};
-  for (const [key, value] of Object.entries(block)) {
-    if (key !== "name") {
-      options[key] = value;
-    }
-  }
-  return { name, options };
-}
-
-// ../cli/dist/src/config/schema.js
-function parseSchema(content) {
-  const raw = jsYaml.load(content, { schema: KEYSHELF_SCHEMA });
-  if (!raw || typeof raw !== "object") {
-    throw new Error('keyshelf.yaml must contain a "keys:" block defining your keys');
-  }
-  const doc = raw;
-  if (!("keys" in doc) || doc.keys == null || typeof doc.keys !== "object") {
-    throw new Error('keyshelf.yaml must contain a "keys:" block defining your keys');
-  }
-  const provider = parseProviderBlock(doc["default-provider"]);
-  let name;
-  if ("name" in doc && doc.name !== void 0) {
-    if (typeof doc.name !== "string" || doc.name === "") {
-      throw new Error('keyshelf.yaml "name" must be a non-empty string');
-    }
-    if (!/^[a-zA-Z0-9_-]+$/.test(doc.name)) {
-      throw new Error(
-        'keyshelf.yaml "name" must contain only letters, digits, hyphens, and underscores'
-      );
-    }
-    name = doc.name;
-  }
-  const flat = flattenKeys(doc.keys);
-  const definitions = [];
-  for (const [path, value] of Object.entries(flat)) {
-    if (isTaggedValue(value)) {
-      definitions.push({
-        path,
-        isSecret: true,
-        optional: value.tag === "secret" && value.config.optional === true
-      });
-    } else {
-      if (value != null && typeof value === "object") {
-        throw new Error(
-          `Unexpected object value at "${path}" in schema. Use nested keys or a tag instead.`
-        );
-      }
-      definitions.push({
-        path,
-        isSecret: false,
-        optional: false,
-        defaultValue: value == null ? void 0 : String(value)
-      });
-    }
-  }
-  return { keys: definitions, config: { name, provider } };
-}
 
 // ../cli/dist/src/config/app-mapping.js
 var TEMPLATE_RE = /\$\{([^}]+)\}/g;
 function isTemplateMapping(m) {
   return "template" in m;
-}
-function resolveTemplate(template, resolvedMap) {
-  const missing = [];
-  const value = template.replace(TEMPLATE_RE, (_, keyPath) => {
-    const trimmed = keyPath.trim();
-    const resolved = resolvedMap.get(trimmed);
-    if (resolved === void 0) {
-      missing.push(trimmed);
-      return "";
-    }
-    return resolved;
-  });
-  return { value, missing };
 }
 function parseAppMapping(content) {
   const mappings = [];
@@ -2800,144 +34,709 @@ function parseAppMapping(content) {
   }
   return mappings;
 }
-var SCHEMA_FILE = "keyshelf.yaml";
-var ENV_DIR = ".keyshelf";
+var PATH_SEGMENT_RE = /^[A-Za-z_][A-Za-z0-9_-]*$/;
+var TEMPLATE_RE2 = /(?<!\$)\$\{([^}]+)\}/g;
+var CONFIG_NAME_RE = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
+var configScalarSchema = z.union([z.string(), z.number(), z.boolean()]);
+var ageProviderSchema = z.object({
+  __kind: z.literal("provider:age"),
+  name: z.literal("age"),
+  options: z.object({
+    identityFile: z.string().min(1),
+    secretsDir: z.string().min(1)
+  }).strict()
+}).strict();
+var gcpProviderSchema = z.object({
+  __kind: z.literal("provider:gcp"),
+  name: z.literal("gcp"),
+  options: z.object({
+    project: z.string().min(1)
+  }).strict()
+}).strict();
+var sopsProviderSchema = z.object({
+  __kind: z.literal("provider:sops"),
+  name: z.literal("sops"),
+  options: z.object({
+    identityFile: z.string().min(1),
+    secretsFile: z.string().min(1)
+  }).strict()
+}).strict();
+var providerRefSchema = z.discriminatedUnion("__kind", [
+  ageProviderSchema,
+  gcpProviderSchema,
+  sopsProviderSchema
+]);
+var baseRecordSchema = {
+  group: z.string().optional(),
+  optional: z.boolean().optional(),
+  description: z.string().optional()
+};
+var configRecordSchema = z.object({
+  __kind: z.literal("config"),
+  ...baseRecordSchema,
+  value: configScalarSchema.optional(),
+  default: configScalarSchema.optional(),
+  values: z.record(z.string(), configScalarSchema).optional()
+}).strict();
+var secretRecordSchema = z.object({
+  __kind: z.literal("secret"),
+  ...baseRecordSchema,
+  value: providerRefSchema.optional(),
+  default: providerRefSchema.optional(),
+  values: z.record(z.string(), providerRefSchema).optional()
+}).strict();
+var keyNodeSchema = z.lazy(
+  () => z.union([
+    configScalarSchema,
+    configRecordSchema,
+    secretRecordSchema,
+    z.record(z.string(), keyNodeSchema).refine((value) => Object.keys(value).length > 0, {
+      message: "key namespaces must not be empty"
+    }).refine((value) => !Object.hasOwn(value, "__kind"), {
+      message: "factory objects with __kind must match their declared schema"
+    })
+  ])
+);
+var keyshelfConfigSchema = z.object({
+  __kind: z.literal("keyshelf:config"),
+  name: z.string().min(1).refine((value) => CONFIG_NAME_RE.test(value), {
+    message: "name must match /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/ (lowercase, digits, dashes; no leading or trailing dash)"
+  }),
+  envs: z.array(z.string().min(1)).nonempty(),
+  groups: z.array(z.string().min(1)).optional(),
+  keys: z.record(z.string(), keyNodeSchema).refine((value) => Object.keys(value).length > 0, {
+    message: "keys must contain at least one entry"
+  })
+}).strict();
+function normalizeConfig(input) {
+  const parsed = keyshelfConfigSchema.parse(input);
+  const errors = [];
+  checkUnique("envs", parsed.envs, errors);
+  const groups2 = [...parsed.groups ?? []];
+  checkUnique("groups", groups2, errors);
+  const flattened = flattenKeyTree(parsed.keys, errors);
+  const paths = new Set(flattened.map((record) => record.path));
+  validatePathConflicts(flattened, errors);
+  validateRecords(flattened, parsed.envs, groups2, errors);
+  validateTemplateReferences(flattened, paths, errors);
+  if (errors.length > 0) {
+    throw new Error(
+      `Invalid keyshelf.config.ts:
+${errors.map((error) => `- ${error}`).join("\n")}`
+    );
+  }
+  return {
+    name: parsed.name,
+    envs: [...parsed.envs],
+    groups: groups2,
+    keys: flattened
+  };
+}
+function validateAppMappingReferences(mappings, flattenedKeys) {
+  const paths = new Set(flattenedKeys.map((record) => record.path));
+  const errors = [];
+  for (const mapping of mappings) {
+    const references = isTemplateMapping(mapping) ? mapping.keyPaths : [mapping.keyPath];
+    for (const reference of references) {
+      if (!paths.has(reference)) {
+        errors.push(`${mapping.envVar}: references unknown key "${reference}"`);
+      }
+    }
+  }
+  if (errors.length > 0) {
+    throw new Error(`Invalid .env.keyshelf:
+${errors.map((error) => `- ${error}`).join("\n")}`);
+  }
+}
+function validateRecords(records, envs, groups2, errors) {
+  const envSet = new Set(envs);
+  const groupSet = new Set(groups2);
+  for (const record of records) {
+    validateRecordGroup(record, groups2, groupSet, errors);
+    validateRecordValues(record, envSet, errors);
+    validateSecretValue(record, errors);
+  }
+}
+function validateRecordGroup(record, groups2, groupSet, errors) {
+  if (record.group === void 0 || groupSet.has(record.group)) return;
+  const suffix = groups2.length === 0 ? " because no groups are declared" : "";
+  errors.push(`${record.path}: group "${record.group}" is not declared${suffix}`);
+}
+function validateRecordValues(record, envSet, errors) {
+  for (const envName2 of Object.keys(record.values ?? {})) {
+    if (!envSet.has(envName2)) {
+      errors.push(`${record.path}: values contains undeclared env "${envName2}"`);
+    }
+  }
+}
+function validateSecretValue(record, errors) {
+  if (record.kind !== "secret") return;
+  const hasValues = record.values !== void 0 && Object.keys(record.values).length > 0;
+  if (record.value === void 0 && !hasValues) {
+    errors.push(`${record.path}: secret requires value, default, or at least one values entry`);
+  }
+}
+function flattenKeyTree(tree, errors, prefix = []) {
+  const records = [];
+  for (const [rawKey, value] of Object.entries(tree)) {
+    const fullParts = [...prefix, ...rawKey.split("/")];
+    const path = fullParts.join("/");
+    validatePathParts(fullParts, errors);
+    records.push(...flattenKeyNode(value, path, fullParts, errors));
+  }
+  return records;
+}
+function flattenKeyNode(value, path, fullParts, errors) {
+  if (isConfigRecord(value)) return [normalizeConfigRecord(path, value, errors)];
+  if (isSecretRecord(value)) return [normalizeSecretRecord(path, value, errors)];
+  const scalar = configScalarSchema.safeParse(value);
+  if (scalar.success) return [normalizeScalarRecord(path, scalar.data)];
+  return flattenKeyTree(value, errors, fullParts);
+}
+function normalizeConfigRecord(path, input, errors) {
+  return {
+    path,
+    kind: "config",
+    group: input.group,
+    optional: input.optional ?? false,
+    description: input.description,
+    value: resolveBinding(path, input.value, input.default, errors),
+    values: copyDefinedRecord(input.values)
+  };
+}
+function normalizeSecretRecord(path, input, errors) {
+  return {
+    path,
+    kind: "secret",
+    group: input.group,
+    optional: input.optional ?? false,
+    description: input.description,
+    value: resolveBinding(path, input.value, input.default, errors),
+    values: copyDefinedRecord(input.values)
+  };
+}
+function resolveBinding(path, value, fallback, errors) {
+  if (value !== void 0 && fallback !== void 0) {
+    errors.push(`${path}: value and default are mutually exclusive`);
+  }
+  return value ?? fallback;
+}
+function normalizeScalarRecord(path, value) {
+  return {
+    path,
+    kind: "config",
+    optional: false,
+    value
+  };
+}
+function validatePathParts(parts, errors) {
+  for (const part of parts) {
+    if (!PATH_SEGMENT_RE.test(part)) {
+      errors.push(`${parts.join("/")}: invalid path segment "${part}"`);
+    }
+  }
+}
+function validatePathConflicts(records, errors) {
+  const sorted = [...records].sort((a, b) => a.path.localeCompare(b.path));
+  const seen = /* @__PURE__ */ new Set();
+  for (const record of sorted) {
+    if (seen.has(record.path)) {
+      errors.push(`${record.path}: duplicate flattened path`);
+      continue;
+    }
+    seen.add(record.path);
+    const segments = record.path.split("/");
+    for (let index = 1; index < segments.length; index += 1) {
+      const prefix = segments.slice(0, index).join("/");
+      if (seen.has(prefix)) {
+        errors.push(`${record.path}: conflicts with leaf path "${prefix}"`);
+      }
+    }
+  }
+}
+function validateTemplateReferences(records, paths, errors) {
+  const graph = buildTemplateGraph(records, paths, errors);
+  validateTemplateGraph(graph, errors);
+}
+function buildTemplateGraph(records, paths, errors) {
+  const graph = /* @__PURE__ */ new Map();
+  for (const record of records) {
+    if (record.kind !== "config") continue;
+    graph.set(record.path, validateTemplateRecord(record, paths, errors));
+  }
+  return graph;
+}
+function validateTemplateRecord(record, paths, errors) {
+  const references = getTemplateReferences(record);
+  for (const reference of references) {
+    if (!paths.has(reference)) {
+      errors.push(`${record.path}: template references unknown key "${reference}"`);
+    }
+  }
+  return references.filter((reference) => paths.has(reference));
+}
+function getTemplateReferences(record) {
+  return [
+    ...extractTemplateReferences(record.value),
+    ...Object.values(record.values ?? {}).flatMap((value) => extractTemplateReferences(value))
+  ];
+}
+function validateTemplateGraph(graph, errors) {
+  const state = {
+    visiting: /* @__PURE__ */ new Set(),
+    visited: /* @__PURE__ */ new Set(),
+    stack: []
+  };
+  for (const path of graph.keys()) {
+    visitTemplatePath(path, graph, state, errors);
+  }
+}
+function visitTemplatePath(path, graph, state, errors) {
+  if (state.visited.has(path)) return;
+  if (state.visiting.has(path)) {
+    reportTemplateCycle(path, state.stack, errors);
+    return;
+  }
+  state.visiting.add(path);
+  state.stack.push(path);
+  for (const dependency of graph.get(path) ?? []) {
+    visitTemplatePath(dependency, graph, state, errors);
+  }
+  state.stack.pop();
+  state.visiting.delete(path);
+  state.visited.add(path);
+}
+function reportTemplateCycle(path, stack, errors) {
+  const cycleStart = stack.indexOf(path);
+  const cycle = [...stack.slice(cycleStart), path].join(" -> ");
+  errors.push(`template cycle detected: ${cycle}`);
+}
+function extractTemplateReferences(value) {
+  if (typeof value !== "string") return [];
+  const references = [];
+  TEMPLATE_RE2.lastIndex = 0;
+  for (const match of value.matchAll(TEMPLATE_RE2)) {
+    references.push(match[1].trim());
+  }
+  return references;
+}
+function checkUnique(label, values, errors) {
+  const seen = /* @__PURE__ */ new Set();
+  for (const value of values) {
+    if (seen.has(value)) {
+      errors.push(`${label}: duplicate "${value}"`);
+    }
+    seen.add(value);
+  }
+}
+function copyDefinedRecord(values) {
+  if (values === void 0) return void 0;
+  const copy = {};
+  for (const [key, value] of Object.entries(values)) {
+    if (value !== void 0) {
+      copy[key] = value;
+    }
+  }
+  return copy;
+}
+function isConfigRecord(value) {
+  return getKind(value) === "config";
+}
+function isSecretRecord(value) {
+  return getKind(value) === "secret";
+}
+function getKind(value) {
+  if (value == null) return void 0;
+  if (typeof value !== "object") return void 0;
+  if (Array.isArray(value)) return void 0;
+  return value.__kind;
+}
+
+// ../cli/dist/src/v5/config/loader.js
+var CONFIG_FILE = "keyshelf.config.ts";
 var APP_MAPPING_FILE = ".env.keyshelf";
-function findRootDir(from) {
+var cachedJiti;
+function getJiti() {
+  if (cachedJiti === void 0) {
+    const override = process.env.KEYSHELF_CONFIG_MODULE_PATH;
+    const configModulePath = override !== void 0 ? resolve(override) : fileURLToPath(new URL("./index.js", import.meta.url));
+    cachedJiti = createJiti(import.meta.url, {
+      alias: {
+        "keyshelf/config": configModulePath
+      }
+    });
+  }
+  return cachedJiti;
+}
+function findV5RootDir(from) {
   let dir = resolve(from);
   while (true) {
-    if (existsSync(join(dir, SCHEMA_FILE))) {
+    if (existsSync(join(dir, CONFIG_FILE))) {
       return dir;
     }
     const parent = dirname(dir);
     if (parent === dir) {
-      throw new Error(`Could not find ${SCHEMA_FILE} in ${from} or any parent directory`);
+      throw new Error(`Could not find ${CONFIG_FILE} in ${from} or any parent directory`);
     }
     dir = parent;
   }
 }
-async function loadConfig(appDir, envName, options) {
-  const rootDir = findRootDir(appDir);
-  const schemaPath = join(rootDir, SCHEMA_FILE);
-  const schemaContent = await readFile(schemaPath, "utf-8");
-  const parsed = parseSchema(schemaContent);
-  const schema2 = parsed.keys;
-  const envPath = join(rootDir, ENV_DIR, `${envName}.yaml`);
-  let env2;
+async function loadV5Config(appDir, options = {}) {
+  const explicitConfigPath = options.configPath === void 0 ? void 0 : resolve(options.configPath);
+  const rootDir = explicitConfigPath === void 0 ? findV5RootDir(appDir) : dirname(explicitConfigPath);
+  const configPath = explicitConfigPath ?? join(rootDir, CONFIG_FILE);
+  const started = performance.now();
+  const rawConfig = await importConfig(configPath);
+  const config = normalizeConfig(rawConfig);
+  const loadTimeMs = performance.now() - started;
+  const mappingPath = options.mappingFile ? resolve(options.mappingFile) : join(resolve(appDir), APP_MAPPING_FILE);
+  const appMapping = await loadAppMapping(mappingPath, options.mappingFile !== void 0);
+  validateAppMappingReferences(appMapping, config.keys);
+  return {
+    rootDir,
+    configPath,
+    config,
+    appMapping,
+    loadTimeMs
+  };
+}
+async function importConfig(configPath) {
+  return await getJiti().import(configPath, { default: true });
+}
+async function loadAppMapping(mappingPath, required) {
   try {
-    const envContent = await readFile(envPath, "utf-8");
-    env2 = parseEnvironment(envContent);
+    return parseAppMapping(await readFile(mappingPath, "utf-8"));
   } catch (err) {
     if (err.code === "ENOENT") {
-      throw new Error(`Environment file not found: ${envPath}`, {
-        cause: err
-      });
-    }
-    throw err;
-  }
-  const mappingPath = options?.mappingFile ? resolve(options.mappingFile) : join(appDir, APP_MAPPING_FILE);
-  let appMapping;
-  try {
-    const mappingContent = await readFile(mappingPath, "utf-8");
-    appMapping = parseAppMapping(mappingContent);
-  } catch (err) {
-    if (err.code === "ENOENT") {
-      if (options?.mappingFile) {
+      if (required) {
         throw new Error(`App mapping file not found: ${mappingPath}`, {
           cause: err
         });
       }
-      appMapping = [];
-    } else {
-      throw err;
+      return [];
     }
+    throw err;
   }
-  const globalProvider = parsed.config.provider;
-  if (globalProvider && !env2.defaultProvider) {
-    env2 = { ...env2, defaultProvider: globalProvider };
-  } else if (globalProvider && env2.defaultProvider) {
-    const envProvider = env2.defaultProvider;
-    env2 = {
-      ...env2,
-      defaultProvider: {
-        name: envProvider.name,
-        options: {
-          ...globalProvider.name === envProvider.name ? globalProvider.options : {},
-          ...envProvider.options
-        }
-      }
-    };
-  }
-  return { rootDir, name: parsed.config.name, schema: schema2, env: env2, appMapping };
 }
 
-// ../cli/dist/src/resolver/index.js
-async function resolve2(options) {
-  const { schema: schema2, env: env2, envName, rootDir, registry, keyshelfName } = options;
-  const entries = await Promise.all(
-    schema2.map(async (key) => {
-      const value = await resolveKey(key, env2, envName, rootDir, registry, keyshelfName);
-      return value !== void 0 ? { path: key.path, value } : null;
-    })
+// ../cli/dist/src/v5/resolver/format.js
+function formatSkipCause(cause) {
+  switch (cause.type) {
+    case "group-filter":
+      return `is filtered out by --group=${cause.activeGroups.join(",")}`;
+    case "path-filter":
+      return `is filtered out by --filter=${cause.activePrefixes.join(",")}`;
+    case "optional-no-value":
+      return "is optional and has no value";
+    case "optional-not-found":
+      return "is optional and was not found in its provider";
+    case "template-ref-unavailable":
+      return `is unavailable: referenced key '${cause.reference}' ${formatSkipCause(cause.referenceCause)}`;
+  }
+}
+
+// ../cli/dist/src/v5/resolver/index.js
+var TEMPLATE_RE3 = /(?<!\$)\$\{([^}]+)\}/g;
+var ESCAPED_TEMPLATE_RE = /\$\$\{/g;
+async function validate(options) {
+  const topLevelErrors = [];
+  const envError = checkValidEnv(options);
+  if (envError !== void 0) topLevelErrors.push(envError);
+  const groupCheck = checkGroupFilter(options.config, options.groups);
+  topLevelErrors.push(...groupCheck.errors);
+  if (topLevelErrors.length > 0) {
+    return { topLevelErrors, keyErrors: [] };
+  }
+  const selected = selectRecords(options.config, options.groups, options.filters);
+  const envRequiredError = checkEnvProvidedWhenRequired(selected, options.envName);
+  if (envRequiredError !== void 0) {
+    return { topLevelErrors: [envRequiredError], keyErrors: [] };
+  }
+  const resolution = await resolveWithStatus(options);
+  const keyErrors = resolution.statuses.filter((status) => {
+    return status.status === "error";
+  }).map((status) => ({
+    path: status.path,
+    message: status.message,
+    error: status.error
+  }));
+  return { topLevelErrors: [], keyErrors };
+}
+async function resolveWithStatus(options) {
+  assertValidEnv(options);
+  const selected = selectRecords(options.config, options.groups, options.filters);
+  assertEnvProvidedWhenRequired(selected, options.envName);
+  const selectedByPath = new Map(
+    selected.filter((entry) => entry.selected).map((entry) => [entry.record.path, entry.record])
   );
-  return entries.filter((e) => e !== null);
-}
-async function resolveKey(key, env2, envName, rootDir, registry, keyshelfName) {
-  const override = env2.overrides[key.path];
-  if (override !== void 0 && !isTaggedValue(override)) {
-    return String(override);
-  }
-  if (override !== void 0 && isTaggedValue(override)) {
-    try {
-      return await resolveViaProvider(
-        key.path,
-        override,
-        env2,
-        envName,
-        rootDir,
-        registry,
-        keyshelfName
-      );
-    } catch (err) {
-      if (key.optional) return void 0;
-      throw err;
+  const statusByPath = /* @__PURE__ */ new Map();
+  const resolving = /* @__PURE__ */ new Set();
+  for (const entry of selected) {
+    if (!entry.selected && entry.cause !== void 0) {
+      statusByPath.set(entry.record.path, {
+        path: entry.record.path,
+        status: "filtered",
+        cause: entry.cause
+      });
     }
   }
-  if (key.isSecret && env2.defaultProvider) {
-    const provider = registry.get(env2.defaultProvider.name);
-    const ctx = {
-      keyPath: key.path,
-      envName,
-      rootDir,
-      keyshelfName,
-      config: { ...env2.defaultProvider.options }
+  async function resolveRecord(path) {
+    const existing = statusByPath.get(path);
+    if (existing !== void 0) return existing;
+    const record = selectedByPath.get(path);
+    if (record === void 0) {
+      return toErrorStatus(path, new Error(`unknown key reference "${path}"`));
+    }
+    if (resolving.has(path)) {
+      return toErrorStatus(path, new Error(`template cycle detected while resolving "${path}"`));
+    }
+    resolving.add(path);
+    const status = await resolveSelectedRecord(record, options, resolveRecord);
+    resolving.delete(path);
+    statusByPath.set(path, status);
+    return status;
+  }
+  for (const entry of selected) {
+    if (entry.selected) {
+      await resolveRecord(entry.record.path);
+    }
+  }
+  const statuses = selected.map((entry) => statusByPath.get(entry.record.path)).filter(isDefined);
+  const resolved = statuses.filter((status) => {
+    return status.status === "resolved";
+  }).map((status) => ({ path: status.path, value: status.value }));
+  return { statuses, resolved, statusByPath };
+}
+function renderAppMapping(mappings, resolution) {
+  const resolvedMap = new Map(resolution.resolved.map((key) => [key.path, key.value]));
+  return mappings.map((mapping) => {
+    if (isTemplateMapping(mapping)) {
+      for (const keyPath of mapping.keyPaths) {
+        if (!resolvedMap.has(keyPath)) {
+          return skippedEnvVar(mapping.envVar, mapping, keyPath, resolution);
+        }
+      }
+      return {
+        envVar: mapping.envVar,
+        status: "rendered",
+        value: renderTemplate(mapping.template, resolvedMap),
+        mapping
+      };
+    }
+    const value = resolvedMap.get(mapping.keyPath);
+    if (value === void 0) {
+      return skippedEnvVar(mapping.envVar, mapping, mapping.keyPath, resolution);
+    }
+    return {
+      envVar: mapping.envVar,
+      status: "rendered",
+      value,
+      mapping
     };
-    try {
-      return await provider.resolve(ctx);
-    } catch (err) {
-      if (key.optional) return void 0;
-      throw err;
+  });
+}
+function selectRecords(config, groups2, filters2) {
+  const groupSet = normalizeGroupFilter(config, groups2);
+  const activeGroups = [...groupSet];
+  const pathPrefixes = normalizePathFilters(filters2);
+  return config.keys.map((record) => {
+    if (isExcludedByGroup(record, groupSet)) {
+      return {
+        record,
+        selected: false,
+        cause: { type: "group-filter", activeGroups }
+      };
+    }
+    if (isExcludedByPath(record, pathPrefixes)) {
+      return {
+        record,
+        selected: false,
+        cause: { type: "path-filter", activePrefixes: pathPrefixes }
+      };
+    }
+    return { record, selected: true };
+  });
+}
+function normalizeGroupFilter(config, groups2) {
+  const { errors, groupSet } = checkGroupFilter(config, groups2);
+  if (errors.length > 0) throw new Error(errors[0].message);
+  return groupSet;
+}
+function checkGroupFilter(config, groups2) {
+  const groupNames = [...new Set(groups2 ?? [])];
+  if (groupNames.length === 0) return { errors: [], groupSet: /* @__PURE__ */ new Set() };
+  if (config.groups.length === 0) {
+    return {
+      errors: [{ message: "--group cannot be used because this config declares no groups" }],
+      groupSet: /* @__PURE__ */ new Set()
+    };
+  }
+  const declaredGroups = new Set(config.groups);
+  const errors = [];
+  for (const group of groupNames) {
+    if (!declaredGroups.has(group)) {
+      errors.push({ message: `Unknown group "${group}"` });
     }
   }
-  if (!key.isSecret && key.defaultValue !== void 0) {
-    return key.defaultValue;
-  }
-  if (key.optional) {
-    return void 0;
-  }
-  throw new Error(`No value for required key "${key.path}"`);
+  return { errors, groupSet: new Set(groupNames.filter((g) => declaredGroups.has(g))) };
 }
-async function resolveViaProvider(keyPath, tagged, env2, envName, rootDir, registry, keyshelfName) {
-  const provider = registry.get(tagged.tag);
-  const baseConfig = env2.defaultProvider?.name === tagged.tag ? { ...env2.defaultProvider.options } : {};
-  const ctx = {
-    keyPath,
-    envName,
-    rootDir,
-    keyshelfName,
-    config: { ...baseConfig, ...tagged.config }
+function normalizePathFilters(filters2) {
+  return [...new Set(filters2 ?? [])].filter((filter) => filter.length > 0);
+}
+function isExcludedByGroup(record, groupSet) {
+  if (groupSet.size === 0) return false;
+  if (record.group === void 0) return false;
+  return !groupSet.has(record.group);
+}
+function isExcludedByPath(record, prefixes) {
+  if (prefixes.length === 0) return false;
+  return !prefixes.some((prefix) => matchesPathPrefix(record.path, prefix));
+}
+function matchesPathPrefix(path, prefix) {
+  return path === prefix || path.startsWith(`${prefix}/`);
+}
+function assertValidEnv(options) {
+  const error = checkValidEnv(options);
+  if (error !== void 0) throw new Error(error.message);
+}
+function checkValidEnv(options) {
+  if (options.envName === void 0) return void 0;
+  if (options.config.envs.includes(options.envName)) return void 0;
+  return { message: `Unknown env "${options.envName}"` };
+}
+function assertEnvProvidedWhenRequired(selected, envName2) {
+  const error = checkEnvProvidedWhenRequired(selected, envName2);
+  if (error !== void 0) throw new Error(error.message);
+}
+function checkEnvProvidedWhenRequired(selected, envName2) {
+  if (envName2 !== void 0) return void 0;
+  const envScopedRecord = selected.filter((entry) => entry.selected).map((entry) => entry.record).find((record) => hasValuesWithoutFallback(record));
+  if (envScopedRecord === void 0) return void 0;
+  return {
+    message: `--env is required because selected key "${envScopedRecord.path}" has env-specific values and no fallback`
   };
-  return provider.resolve(ctx);
+}
+function hasValuesWithoutFallback(record) {
+  return record.value === void 0 && Object.keys(record.values ?? {}).length > 0;
+}
+async function resolveSelectedRecord(record, options, resolveRecord) {
+  const binding = getActiveBinding(record, options.envName);
+  if (binding === void 0) {
+    if (record.optional) {
+      return {
+        path: record.path,
+        status: "skipped",
+        cause: { type: "optional-no-value" }
+      };
+    }
+    return toErrorStatus(record.path, new Error(`No value for required key "${record.path}"`));
+  }
+  try {
+    const value = record.kind === "secret" ? await resolveProvider(record.path, binding, options) : await resolveConfigBinding(record.path, binding, resolveRecord);
+    return { path: record.path, status: "resolved", value };
+  } catch (err) {
+    if (err instanceof FilteredTemplateReferenceError) {
+      return {
+        path: record.path,
+        status: "skipped",
+        cause: {
+          type: "template-ref-unavailable",
+          reference: err.reference,
+          referenceCause: err.referenceCause
+        }
+      };
+    }
+    if (record.optional && isNotFoundError(err)) {
+      return {
+        path: record.path,
+        status: "skipped",
+        cause: { type: "optional-not-found" }
+      };
+    }
+    return toErrorStatus(record.path, err);
+  }
+}
+function getActiveBinding(record, envName2) {
+  if (envName2 !== void 0 && record.values !== void 0 && Object.hasOwn(record.values, envName2)) {
+    return record.values[envName2];
+  }
+  return record.value;
+}
+async function resolveProvider(keyPath, providerRef, options) {
+  const provider = options.registry.get(providerRef.name);
+  return provider.resolve({
+    keyPath,
+    envName: options.envName,
+    rootDir: options.rootDir,
+    config: { ...providerRef.options },
+    keyshelfName: options.config.name
+  });
+}
+async function resolveConfigBinding(path, binding, resolveRecord) {
+  if (typeof binding !== "string") return String(binding);
+  return interpolateConfigTemplate(path, binding, resolveRecord);
+}
+async function interpolateConfigTemplate(path, template, resolveRecord) {
+  const replacements = /* @__PURE__ */ new Map();
+  TEMPLATE_RE3.lastIndex = 0;
+  for (const match of template.matchAll(TEMPLATE_RE3)) {
+    const reference = match[1].trim();
+    const status = await resolveRecord(reference);
+    if (status.status === "resolved") {
+      replacements.set(reference, status.value);
+      continue;
+    }
+    if (status.status === "filtered" || status.status === "skipped") {
+      throw new FilteredTemplateReferenceError(path, reference, status.cause);
+    }
+    throw new Error(`referenced key "${reference}" could not be resolved: ${status.message}`);
+  }
+  TEMPLATE_RE3.lastIndex = 0;
+  return template.replace(TEMPLATE_RE3, (_, keyPath) => replacements.get(keyPath.trim()) ?? "").replace(ESCAPED_TEMPLATE_RE, "${");
+}
+function renderTemplate(template, resolvedMap) {
+  TEMPLATE_RE3.lastIndex = 0;
+  return template.replace(TEMPLATE_RE3, (_, keyPath) => resolvedMap.get(keyPath.trim()) ?? "").replace(ESCAPED_TEMPLATE_RE, "${");
+}
+function skippedEnvVar(envVar, mapping, keyPath, resolution) {
+  const status = resolution.statusByPath.get(keyPath);
+  return {
+    envVar,
+    status: "skipped",
+    keyPath,
+    cause: statusToSkipCause(status),
+    mapping
+  };
+}
+function statusToSkipCause(status) {
+  if (status?.status === "filtered" || status?.status === "skipped") return status.cause;
+  return { type: "optional-no-value" };
+}
+var FilteredTemplateReferenceError = class extends Error {
+  constructor(keyPath, reference, referenceCause) {
+    super(`referenced key "${reference}" is unavailable for "${keyPath}"`);
+    this.keyPath = keyPath;
+    this.reference = reference;
+    this.referenceCause = referenceCause;
+  }
+  keyPath;
+  reference;
+  referenceCause;
+};
+function toErrorStatus(path, err) {
+  return {
+    path,
+    status: "error",
+    message: err instanceof Error ? err.message : String(err),
+    error: err instanceof Error ? err : void 0
+  };
+}
+function isNotFoundError(err) {
+  const message = err instanceof Error ? err.message : String(err);
+  return /(^|[^a-z])not[ _-]?found([^a-z]|$)|NOT_FOUND/.test(message);
+}
+function isDefined(value) {
+  return value !== void 0;
 }
 
 // ../cli/dist/src/providers/registry.js
@@ -3108,10 +907,10 @@ function hexToBytes(hex) {
   }
   return array;
 }
-function utf8ToBytes(str2) {
-  if (typeof str2 !== "string")
+function utf8ToBytes(str) {
+  if (typeof str !== "string")
     throw new TypeError("string expected");
-  return new Uint8Array(new TextEncoder().encode(str2));
+  return new Uint8Array(new TextEncoder().encode(str));
 }
 function kdfInputToBytes(data, errorTitle = "") {
   if (typeof data === "string")
@@ -3764,13 +1563,13 @@ function genBech32(encoding) {
     const sum = bechChecksum(lowered, words, ENCODING_CONST);
     return `${lowered}1${BECH_ALPHABET.encode(words)}${sum}`;
   }
-  function decode(str2, limit = 90) {
-    astr("bech32.decode input", str2);
-    const slen = str2.length;
+  function decode(str, limit = 90) {
+    astr("bech32.decode input", str);
+    const slen = str.length;
     if (slen < 8 || limit !== false && slen > limit)
-      throw new TypeError(`invalid string length: ${slen} (${str2}). Expected (8..${limit})`);
-    const lowered = str2.toLowerCase();
-    if (str2 !== lowered && str2 !== str2.toUpperCase())
+      throw new TypeError(`invalid string length: ${slen} (${str}). Expected (8..${limit})`);
+    const lowered = str.toLowerCase();
+    if (str !== lowered && str !== str.toUpperCase())
       throw new Error(`String must be lowercase or uppercase`);
     const sepIndex = lowered.lastIndexOf("1");
     if (sepIndex === 0 || sepIndex === -1)
@@ -3782,12 +1581,12 @@ function genBech32(encoding) {
     const words = BECH_ALPHABET.decode(data).slice(0, -6);
     const sum = bechChecksum(prefix, words, ENCODING_CONST);
     if (!data.endsWith(sum))
-      throw new Error(`Invalid checksum in ${str2}: expected "${sum}"`);
+      throw new Error(`Invalid checksum in ${str}: expected "${sum}"`);
     return { prefix, words };
   }
   const decodeUnsafe = unsafeWrapper(decode);
-  function decodeToBytes(str2) {
-    const { prefix, words } = decode(str2, false);
+  function decodeToBytes(str) {
+    const { prefix, words } = decode(str, false);
     return {
       prefix,
       words,
@@ -4164,7 +1963,7 @@ function copyBytes(bytes) {
 }
 
 // ../../node_modules/@noble/ciphers/_arx.js
-var encodeStr = (str2) => Uint8Array.from(str2.split(""), (c) => c.charCodeAt(0));
+var encodeStr = (str) => Uint8Array.from(str.split(""), (c) => c.charCodeAt(0));
 var sigma16_32 = /* @__PURE__ */ (() => swap32IfBE2(u322(encodeStr("expand 16-byte k"))))();
 var sigma32_32 = /* @__PURE__ */ (() => swap32IfBE2(u322(encodeStr("expand 32-byte k"))))();
 function rotl2(a, b) {
@@ -4174,7 +1973,7 @@ var BLOCK_LEN = 64;
 var BLOCK_LEN32 = 16;
 var MAX_COUNTER = /* @__PURE__ */ (() => 2 ** 32 - 1)();
 var U32_EMPTY = /* @__PURE__ */ Uint32Array.of();
-function runCipher(core2, sigma, key, nonce, data, output, counter, rounds) {
+function runCipher(core, sigma, key, nonce, data, output, counter, rounds) {
   const len = data.length;
   const block = new Uint8Array(BLOCK_LEN);
   const b32 = u322(block);
@@ -4183,7 +1982,7 @@ function runCipher(core2, sigma, key, nonce, data, output, counter, rounds) {
   const o32 = isAligned ? u322(output) : U32_EMPTY;
   if (!isLE2) {
     for (let pos = 0; pos < len; counter++) {
-      core2(sigma, key, nonce, b32, counter, rounds);
+      core(sigma, key, nonce, b32, counter, rounds);
       swap32IfBE2(b32);
       if (counter >= MAX_COUNTER)
         throw new Error("arx: counter overflow");
@@ -4197,7 +1996,7 @@ function runCipher(core2, sigma, key, nonce, data, output, counter, rounds) {
     return;
   }
   for (let pos = 0; pos < len; counter++) {
-    core2(sigma, key, nonce, b32, counter, rounds);
+    core(sigma, key, nonce, b32, counter, rounds);
     if (counter >= MAX_COUNTER)
       throw new Error("arx: counter overflow");
     const take = Math.min(BLOCK_LEN, len - pos);
@@ -4219,9 +2018,9 @@ function runCipher(core2, sigma, key, nonce, data, output, counter, rounds) {
     pos += take;
   }
 }
-function createCipher(core2, opts2) {
+function createCipher(core, opts2) {
   const { allowShortKeys, extendNonceFn, counterLength, counterRight, rounds } = checkOpts2({ allowShortKeys: false, counterLength: 8, counterRight: false, rounds: 20 }, opts2);
-  if (typeof core2 !== "function")
+  if (typeof core !== "function")
     throw new Error("core must be a function");
   anumber3(counterLength);
   anumber3(rounds);
@@ -4282,7 +2081,7 @@ function createCipher(core2, opts2) {
     }
     const n32 = swap32IfBE2(u322(nonce));
     try {
-      runCipher(core2, sigma, k32, n32, data, output, counter, rounds);
+      runCipher(core, sigma, k32, n32, data, output, counter, rounds);
       return output;
     } finally {
       clean2(...toClean);
@@ -4975,13 +2774,13 @@ function validateObject(object, fields = {}, optFields = {}) {
   iter(optFields, true);
 }
 function memoized(fn) {
-  const map2 = /* @__PURE__ */ new WeakMap();
+  const map = /* @__PURE__ */ new WeakMap();
   return (arg, ...args) => {
-    const val = map2.get(arg);
+    const val = map.get(arg);
     if (val !== void 0)
       return val;
     const computed = fn(arg, ...args);
-    map2.set(arg, computed);
+    map.set(arg, computed);
     return computed;
   };
 }
@@ -5153,9 +2952,9 @@ function validateField(field) {
     BYTES: "number",
     BITS: "number"
   };
-  const opts2 = FIELD_FIELDS.reduce((map2, val) => {
-    map2[val] = "function";
-    return map2;
+  const opts2 = FIELD_FIELDS.reduce((map, val) => {
+    map[val] = "function";
+    return map;
   }, initial);
   validateObject(field, opts2);
   return field;
@@ -5576,11 +3375,11 @@ function createField(order, field, isLE4) {
     return Field(order, { isLE: isLE4 });
   }
 }
-function createCurveFields(type2, CURVE, curveOpts = {}, FpFnLE) {
+function createCurveFields(type, CURVE, curveOpts = {}, FpFnLE) {
   if (FpFnLE === void 0)
-    FpFnLE = type2 === "edwards";
+    FpFnLE = type === "edwards";
   if (!CURVE || typeof CURVE !== "object")
-    throw new Error(`expected valid ${type2} CURVE object`);
+    throw new Error(`expected valid ${type} CURVE object`);
   for (const p of ["p", "n", "h"]) {
     const val = CURVE[p];
     if (!(typeof val === "bigint" && val > _0n3))
@@ -5617,9 +3416,9 @@ function validateOpts(curve) {
 }
 function montgomery(curveDef) {
   const CURVE = validateOpts(curveDef);
-  const { P, type: type2, adjustScalarBytes: adjustScalarBytes3, powPminus2, randomBytes: rand } = CURVE;
-  const is25519 = type2 === "x25519";
-  if (!is25519 && type2 !== "x448")
+  const { P, type, adjustScalarBytes: adjustScalarBytes3, powPminus2, randomBytes: rand } = CURVE;
+  const is25519 = type === "x25519";
+  if (!is25519 && type !== "x448")
     throw new Error("invalid type");
   const randomBytes_ = rand || randomBytes3;
   const montgomeryBits = is25519 ? 255 : 448;
@@ -5912,7 +3711,7 @@ var DER = {
     }
   },
   toSig(bytes) {
-    const { Err: E, _int: int2, _tlv: tlv } = DER;
+    const { Err: E, _int: int, _tlv: tlv } = DER;
     const data = abytes3(bytes, void 0, "signature");
     const { v: seqBytes, l: seqLeftBytes } = tlv.decode(48, data);
     if (seqLeftBytes.length)
@@ -5921,14 +3720,14 @@ var DER = {
     const { v: sBytes, l: sLeftBytes } = tlv.decode(2, rLeftBytes);
     if (sLeftBytes.length)
       throw new E("invalid signature: left bytes after parsing");
-    return { r: int2.decode(rBytes), s: int2.decode(sBytes) };
+    return { r: int.decode(rBytes), s: int.decode(sBytes) };
   },
   hexFromSig(sig) {
-    const { _tlv: tlv, _int: int2 } = DER;
-    const rs = tlv.encode(2, int2.encode(sig.r));
-    const ss = tlv.encode(2, int2.encode(sig.s));
-    const seq2 = rs + ss;
-    return tlv.encode(48, seq2);
+    const { _tlv: tlv, _int: int } = DER;
+    const rs = tlv.encode(2, int.encode(sig.r));
+    const ss = tlv.encode(2, int.encode(sig.s));
+    const seq = rs + ss;
+    return tlv.encode(48, seq);
   }
 };
 var _0n5 = BigInt(0);
@@ -7805,10 +5604,10 @@ function BaseCaseMultiply(a0, a1, b0, b1, zeta) {
 }
 function MultiplyNTTs(f, g) {
   for (let i = 0; i < N / 2; i++) {
-    let z = nttZetas[64 + (i >> 1)];
+    let z2 = nttZetas[64 + (i >> 1)];
     if (i & 1)
-      z = -z;
-    const { c0, c1 } = BaseCaseMultiply(f[2 * i + 0], f[2 * i + 1], g[2 * i + 0], g[2 * i + 1], z);
+      z2 = -z2;
+    const { c0, c1 } = BaseCaseMultiply(f[2 * i + 0], f[2 * i + 1], g[2 * i + 0], g[2 * i + 1], z2);
     f[2 * i + 0] = c0;
     f[2 * i + 1] = c1;
   }
@@ -7991,13 +5790,13 @@ function createKyber(opts2) {
       const test = HASH256(secretKey.subarray(k768 / 2, start));
       if (!equalBytes2(test, secretKey.subarray(start, start + 32)))
         throw new Error("invalid secretKey: hash check failed");
-      const [sk, publicKey, publicKeyHash, z] = secretCoder.decode(secretKey);
+      const [sk, publicKey, publicKeyHash, z2] = secretCoder.decode(secretKey);
       const msg = KPKE.decrypt(cipherText, sk);
       const kr = HASH512.create().update(msg).update(publicKeyHash).digest();
       const Khat = kr.subarray(0, 32);
       const cipherText2 = KPKE.encrypt(publicKey, msg, kr.subarray(32, 64));
       const isValid = equalBytes2(cipherText, cipherText2);
-      const Kbar = KDF.create({ dkLen: 32 }).update(z).update(cipherText).digest();
+      const Kbar = KDF.create({ dkLen: 32 }).update(z2).update(cipherText).digest();
       cleanBytes(msg, cipherText2, !isValid ? Khat : Kbar);
       return isValid ? Khat : Kbar;
     }
@@ -8578,9 +6377,9 @@ function validateField2(field) {
     BYTES: "number",
     BITS: "number"
   };
-  const opts2 = FIELD_FIELDS2.reduce((map2, val) => {
-    map2[val] = "function";
-    return map2;
+  const opts2 = FIELD_FIELDS2.reduce((map, val) => {
+    map[val] = "function";
+    return map;
   }, initial);
   validateObject2(field, opts2);
   asafenumber(field.BYTES, "BYTES");
@@ -9021,11 +6820,11 @@ function createField2(order, field, isLE4) {
     return Field2(order, { isLE: isLE4 });
   }
 }
-function createCurveFields2(type2, CURVE, curveOpts = {}, FpFnLE) {
+function createCurveFields2(type, CURVE, curveOpts = {}, FpFnLE) {
   if (FpFnLE === void 0)
-    FpFnLE = type2 === "edwards";
+    FpFnLE = type === "edwards";
   if (!CURVE || typeof CURVE !== "object")
-    throw new Error(`expected valid ${type2} CURVE object`);
+    throw new Error(`expected valid ${type} CURVE object`);
   for (const p of ["p", "n", "h"]) {
     const val = CURVE[p];
     if (!(typeof val === "bigint" && val > _0n9))
@@ -9033,7 +6832,7 @@ function createCurveFields2(type2, CURVE, curveOpts = {}, FpFnLE) {
   }
   const Fp2 = createField2(CURVE.p, curveOpts.Fp, FpFnLE);
   const Fn2 = createField2(CURVE.n, curveOpts.Fn, FpFnLE);
-  const _b = type2 === "weierstrass" ? "b" : "d";
+  const _b = type === "weierstrass" ? "b" : "d";
   const params = ["Gx", "Gy", "a", _b];
   for (const p of params) {
     if (!Fp2.isValid(CURVE[p]))
@@ -9180,7 +6979,7 @@ var DER2 = {
     }
   },
   toSig(bytes) {
-    const { Err: E, _int: int2, _tlv: tlv } = DER2;
+    const { Err: E, _int: int, _tlv: tlv } = DER2;
     const data = abytes4(bytes, void 0, "signature");
     const { v: seqBytes, l: seqLeftBytes } = tlv.decode(48, data);
     if (seqLeftBytes.length)
@@ -9189,14 +6988,14 @@ var DER2 = {
     const { v: sBytes, l: sLeftBytes } = tlv.decode(2, rLeftBytes);
     if (sLeftBytes.length)
       throw new E("invalid signature: left bytes after parsing");
-    return { r: int2.decode(rBytes), s: int2.decode(sBytes) };
+    return { r: int.decode(rBytes), s: int.decode(sBytes) };
   },
   hexFromSig(sig) {
-    const { _tlv: tlv, _int: int2 } = DER2;
-    const rs = tlv.encode(2, int2.encode(sig.r));
-    const ss = tlv.encode(2, int2.encode(sig.s));
-    const seq2 = rs + ss;
-    return tlv.encode(48, seq2);
+    const { _tlv: tlv, _int: int } = DER2;
+    const rs = tlv.encode(2, int.encode(sig.r));
+    const ss = tlv.encode(2, int.encode(sig.s));
+    const seq = rs + ss;
+    return tlv.encode(48, seq);
   }
 };
 Object.freeze(DER2._tlv);
@@ -10346,9 +8145,9 @@ function validateOpts2(curve) {
 }
 function montgomery2(curveDef) {
   const CURVE = validateOpts2(curveDef);
-  const { P, type: type2, adjustScalarBytes: adjustScalarBytes3, powPminus2, randomBytes: rand } = CURVE;
-  const is25519 = type2 === "x25519";
-  if (!is25519 && type2 !== "x448")
+  const { P, type, adjustScalarBytes: adjustScalarBytes3, powPminus2, randomBytes: rand } = CURVE;
+  const is25519 = type === "x25519";
+  if (!is25519 && type !== "x448")
     throw new Error("invalid type");
   const randomBytes_ = rand === void 0 ? randomBytes5 : rand;
   const montgomeryBits = is25519 ? 255 : 448;
@@ -11759,20 +9558,26 @@ var SopsProvider = class {
   }
 };
 
-// scripts/emit-env.mjs
-var env = process.env.KEYSHELF_ENV;
+// scripts/emit-env-v5.mjs
+var envName = process.env.KEYSHELF_ENV || void 0;
 var mapsRaw = process.env.KEYSHELF_MAPS || "";
+var groupsRaw = process.env.KEYSHELF_GROUPS || "";
+var filtersRaw = process.env.KEYSHELF_FILTERS || "";
 var cwd = process.env.KEYSHELF_CWD || process.cwd();
 var githubEnv = process.env.GITHUB_ENV;
-var BUNDLED_PROVIDERS = /* @__PURE__ */ new Set(["plaintext", "age", "sops"]);
-if (!env) fail("KEYSHELF_ENV is required");
 if (!githubEnv) fail("GITHUB_ENV is not set; this script must run inside GitHub Actions");
 var maps = mapsRaw.split("\n").map((s) => s.trim()).filter(Boolean);
 if (maps.length === 0) fail("'map' input is empty");
+var groups = splitList(groupsRaw);
+var filters = splitList(filtersRaw);
+var registry = new ProviderRegistry();
+registry.register(new PlaintextProvider());
+registry.register(new AgeProvider());
+registry.register(new SopsProvider());
 for (const mapFile of maps) {
   let vars;
   try {
-    vars = await resolveMap(cwd, env, mapFile);
+    vars = await resolveMap(cwd, envName, mapFile);
   } catch (err) {
     fail(`Failed to resolve map "${mapFile}": ${err.message}`);
   }
@@ -11784,47 +9589,44 @@ for (const mapFile of maps) {
     appendEnv(v.envVar, v.value);
   }
 }
-async function resolveMap(appDir, envName, mapFile) {
-  const config = await loadConfig(appDir, envName, { mappingFile: mapFile });
-  const providerName = config.env.defaultProvider?.name;
-  if (providerName && !BUNDLED_PROVIDERS.has(providerName)) {
-    fail(
-      `Provider "${providerName}" is not bundled into the keyshelf action. Bundled providers: ${[...BUNDLED_PROVIDERS].join(", ")}. See https://github.com/pantoninho/keyshelf/issues/73 for status.`
-    );
+async function resolveMap(appDir, envName2, mapFile) {
+  const loaded = await loadV5Config(appDir, { mappingFile: mapFile });
+  const resolveOpts = {
+    config: loaded.config,
+    envName: envName2,
+    rootDir: loaded.rootDir,
+    registry,
+    groups,
+    filters
+  };
+  const validation = await validate(resolveOpts);
+  if (validation.topLevelErrors.length > 0) {
+    fail(validation.topLevelErrors.map((e) => e.message).join("; "));
   }
-  const registry = new ProviderRegistry();
-  registry.register(new PlaintextProvider());
-  registry.register(new AgeProvider());
-  registry.register(new SopsProvider());
-  const resolved = await resolve2({
-    schema: config.schema,
-    env: config.env,
-    envName,
-    rootDir: config.rootDir,
-    registry
-  });
-  const resolvedMap = new Map(resolved.map((r) => [r.path, r.value]));
-  const schemaByPath = new Map(config.schema.map((k) => [k.path, k]));
+  if (validation.keyErrors.length > 0) {
+    const lines = validation.keyErrors.map((e) => `  - ${e.path}: ${e.message}`).join("\n");
+    fail(`Validation errors:
+${lines}`);
+  }
+  const resolution = await resolveWithStatus(resolveOpts);
+  const rendered = renderAppMapping(loaded.appMapping, resolution);
+  const recordByPath = new Map(loaded.config.keys.map((k) => [k.path, k]));
   const vars = [];
-  for (const mapping of config.appMapping) {
-    if (isTemplateMapping(mapping)) {
-      const { value, missing } = resolveTemplate(mapping.template, resolvedMap);
-      for (const m of missing) {
-        process.stderr.write(
-          `warning: ${mapping.envVar} references "${m}" which is not defined in schema
+  for (const result of rendered) {
+    if (result.status === "skipped") {
+      process.stderr.write(
+        `keyshelf: skipping ${result.envVar} \u2014 referenced key '${result.keyPath}' ${formatSkipCause(result.cause)}
 `
-        );
-      }
-      const secret = mapping.keyPaths.some((p) => schemaByPath.get(p)?.isSecret === true);
-      vars.push({ envVar: mapping.envVar, value, secret });
-    } else {
-      const value = resolvedMap.get(mapping.keyPath);
-      if (value === void 0) continue;
-      const secret = schemaByPath.get(mapping.keyPath)?.isSecret === true;
-      vars.push({ envVar: mapping.envVar, value, secret });
+      );
+      continue;
     }
+    const secret = "template" in result.mapping ? result.mapping.keyPaths.some((p) => recordByPath.get(p)?.kind === "secret") : recordByPath.get(result.mapping.keyPath)?.kind === "secret";
+    vars.push({ envVar: result.envVar, value: result.value, secret });
   }
   return vars;
+}
+function splitList(raw) {
+  return raw.split(/[\n,]/).map((s) => s.trim()).filter(Boolean);
 }
 function appendEnv(name, value) {
   const delim = `EOF_${randomBytes$1(8).toString("hex")}`;
@@ -11842,9 +9644,6 @@ function fail(msg) {
   process.exit(1);
 }
 /*! Bundled license information:
-
-js-yaml/dist/js-yaml.mjs:
-  (*! js-yaml 4.1.1 https://github.com/nodeca/js-yaml @license MIT *)
 
 @scure/base/index.js:
   (*! scure-base - MIT License (c) 2022 Paul Miller (paulmillr.com) *)

--- a/packages/action/dist/keyshelf-config.mjs
+++ b/packages/action/dist/keyshelf-config.mjs
@@ -1,0 +1,443 @@
+import { existsSync } from 'fs';
+import { readFile } from 'fs/promises';
+import { resolve, join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { performance } from 'perf_hooks';
+import { createJiti } from 'jiti';
+import { z } from 'zod';
+
+// ../cli/dist/src/v5/config/factories.js
+function defineConfig(input) {
+  return { __kind: "keyshelf:config", ...input };
+}
+function config(input) {
+  return { __kind: "config", ...input };
+}
+function secret(input) {
+  return { __kind: "secret", ...input };
+}
+function age(options) {
+  return { __kind: "provider:age", name: "age", options };
+}
+function gcp(options) {
+  return { __kind: "provider:gcp", name: "gcp", options };
+}
+function sops(options) {
+  return { __kind: "provider:sops", name: "sops", options };
+}
+
+// ../cli/dist/src/config/app-mapping.js
+var TEMPLATE_RE = /\$\{([^}]+)\}/g;
+function isTemplateMapping(m) {
+  return "template" in m;
+}
+function parseAppMapping(content) {
+  const mappings = [];
+  for (const raw of content.split("\n")) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eqIndex = line.indexOf("=");
+    if (eqIndex === -1) continue;
+    const envVar = line.slice(0, eqIndex).trim();
+    const value = line.slice(eqIndex + 1).trim();
+    if (!envVar || !value) continue;
+    if (TEMPLATE_RE.test(value)) {
+      TEMPLATE_RE.lastIndex = 0;
+      const keyPaths = [...value.matchAll(TEMPLATE_RE)].map((m) => m[1].trim());
+      mappings.push({ envVar, template: value, keyPaths });
+    } else {
+      mappings.push({ envVar, keyPath: value });
+    }
+  }
+  return mappings;
+}
+var PATH_SEGMENT_RE = /^[A-Za-z_][A-Za-z0-9_-]*$/;
+var TEMPLATE_RE2 = /(?<!\$)\$\{([^}]+)\}/g;
+var CONFIG_NAME_RE = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
+var configScalarSchema = z.union([z.string(), z.number(), z.boolean()]);
+var ageProviderSchema = z.object({
+  __kind: z.literal("provider:age"),
+  name: z.literal("age"),
+  options: z.object({
+    identityFile: z.string().min(1),
+    secretsDir: z.string().min(1)
+  }).strict()
+}).strict();
+var gcpProviderSchema = z.object({
+  __kind: z.literal("provider:gcp"),
+  name: z.literal("gcp"),
+  options: z.object({
+    project: z.string().min(1)
+  }).strict()
+}).strict();
+var sopsProviderSchema = z.object({
+  __kind: z.literal("provider:sops"),
+  name: z.literal("sops"),
+  options: z.object({
+    identityFile: z.string().min(1),
+    secretsFile: z.string().min(1)
+  }).strict()
+}).strict();
+var providerRefSchema = z.discriminatedUnion("__kind", [
+  ageProviderSchema,
+  gcpProviderSchema,
+  sopsProviderSchema
+]);
+var baseRecordSchema = {
+  group: z.string().optional(),
+  optional: z.boolean().optional(),
+  description: z.string().optional()
+};
+var configRecordSchema = z.object({
+  __kind: z.literal("config"),
+  ...baseRecordSchema,
+  value: configScalarSchema.optional(),
+  default: configScalarSchema.optional(),
+  values: z.record(z.string(), configScalarSchema).optional()
+}).strict();
+var secretRecordSchema = z.object({
+  __kind: z.literal("secret"),
+  ...baseRecordSchema,
+  value: providerRefSchema.optional(),
+  default: providerRefSchema.optional(),
+  values: z.record(z.string(), providerRefSchema).optional()
+}).strict();
+var keyNodeSchema = z.lazy(
+  () => z.union([
+    configScalarSchema,
+    configRecordSchema,
+    secretRecordSchema,
+    z.record(z.string(), keyNodeSchema).refine((value) => Object.keys(value).length > 0, {
+      message: "key namespaces must not be empty"
+    }).refine((value) => !Object.hasOwn(value, "__kind"), {
+      message: "factory objects with __kind must match their declared schema"
+    })
+  ])
+);
+var keyshelfConfigSchema = z.object({
+  __kind: z.literal("keyshelf:config"),
+  name: z.string().min(1).refine((value) => CONFIG_NAME_RE.test(value), {
+    message: "name must match /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/ (lowercase, digits, dashes; no leading or trailing dash)"
+  }),
+  envs: z.array(z.string().min(1)).nonempty(),
+  groups: z.array(z.string().min(1)).optional(),
+  keys: z.record(z.string(), keyNodeSchema).refine((value) => Object.keys(value).length > 0, {
+    message: "keys must contain at least one entry"
+  })
+}).strict();
+function normalizeConfig(input) {
+  const parsed = keyshelfConfigSchema.parse(input);
+  const errors = [];
+  checkUnique("envs", parsed.envs, errors);
+  const groups = [...parsed.groups ?? []];
+  checkUnique("groups", groups, errors);
+  const flattened = flattenKeyTree(parsed.keys, errors);
+  const paths = new Set(flattened.map((record) => record.path));
+  validatePathConflicts(flattened, errors);
+  validateRecords(flattened, parsed.envs, groups, errors);
+  validateTemplateReferences(flattened, paths, errors);
+  if (errors.length > 0) {
+    throw new Error(
+      `Invalid keyshelf.config.ts:
+${errors.map((error) => `- ${error}`).join("\n")}`
+    );
+  }
+  return {
+    name: parsed.name,
+    envs: [...parsed.envs],
+    groups,
+    keys: flattened
+  };
+}
+function validateAppMappingReferences(mappings, flattenedKeys) {
+  const paths = new Set(flattenedKeys.map((record) => record.path));
+  const errors = [];
+  for (const mapping of mappings) {
+    const references = isTemplateMapping(mapping) ? mapping.keyPaths : [mapping.keyPath];
+    for (const reference of references) {
+      if (!paths.has(reference)) {
+        errors.push(`${mapping.envVar}: references unknown key "${reference}"`);
+      }
+    }
+  }
+  if (errors.length > 0) {
+    throw new Error(`Invalid .env.keyshelf:
+${errors.map((error) => `- ${error}`).join("\n")}`);
+  }
+}
+function validateRecords(records, envs, groups, errors) {
+  const envSet = new Set(envs);
+  const groupSet = new Set(groups);
+  for (const record of records) {
+    validateRecordGroup(record, groups, groupSet, errors);
+    validateRecordValues(record, envSet, errors);
+    validateSecretValue(record, errors);
+  }
+}
+function validateRecordGroup(record, groups, groupSet, errors) {
+  if (record.group === void 0 || groupSet.has(record.group)) return;
+  const suffix = groups.length === 0 ? " because no groups are declared" : "";
+  errors.push(`${record.path}: group "${record.group}" is not declared${suffix}`);
+}
+function validateRecordValues(record, envSet, errors) {
+  for (const envName of Object.keys(record.values ?? {})) {
+    if (!envSet.has(envName)) {
+      errors.push(`${record.path}: values contains undeclared env "${envName}"`);
+    }
+  }
+}
+function validateSecretValue(record, errors) {
+  if (record.kind !== "secret") return;
+  const hasValues = record.values !== void 0 && Object.keys(record.values).length > 0;
+  if (record.value === void 0 && !hasValues) {
+    errors.push(`${record.path}: secret requires value, default, or at least one values entry`);
+  }
+}
+function flattenKeyTree(tree, errors, prefix = []) {
+  const records = [];
+  for (const [rawKey, value] of Object.entries(tree)) {
+    const fullParts = [...prefix, ...rawKey.split("/")];
+    const path = fullParts.join("/");
+    validatePathParts(fullParts, errors);
+    records.push(...flattenKeyNode(value, path, fullParts, errors));
+  }
+  return records;
+}
+function flattenKeyNode(value, path, fullParts, errors) {
+  if (isConfigRecord(value)) return [normalizeConfigRecord(path, value, errors)];
+  if (isSecretRecord(value)) return [normalizeSecretRecord(path, value, errors)];
+  const scalar = configScalarSchema.safeParse(value);
+  if (scalar.success) return [normalizeScalarRecord(path, scalar.data)];
+  return flattenKeyTree(value, errors, fullParts);
+}
+function normalizeConfigRecord(path, input, errors) {
+  return {
+    path,
+    kind: "config",
+    group: input.group,
+    optional: input.optional ?? false,
+    description: input.description,
+    value: resolveBinding(path, input.value, input.default, errors),
+    values: copyDefinedRecord(input.values)
+  };
+}
+function normalizeSecretRecord(path, input, errors) {
+  return {
+    path,
+    kind: "secret",
+    group: input.group,
+    optional: input.optional ?? false,
+    description: input.description,
+    value: resolveBinding(path, input.value, input.default, errors),
+    values: copyDefinedRecord(input.values)
+  };
+}
+function resolveBinding(path, value, fallback, errors) {
+  if (value !== void 0 && fallback !== void 0) {
+    errors.push(`${path}: value and default are mutually exclusive`);
+  }
+  return value ?? fallback;
+}
+function normalizeScalarRecord(path, value) {
+  return {
+    path,
+    kind: "config",
+    optional: false,
+    value
+  };
+}
+function validatePathParts(parts, errors) {
+  for (const part of parts) {
+    if (!PATH_SEGMENT_RE.test(part)) {
+      errors.push(`${parts.join("/")}: invalid path segment "${part}"`);
+    }
+  }
+}
+function validatePathConflicts(records, errors) {
+  const sorted = [...records].sort((a, b) => a.path.localeCompare(b.path));
+  const seen = /* @__PURE__ */ new Set();
+  for (const record of sorted) {
+    if (seen.has(record.path)) {
+      errors.push(`${record.path}: duplicate flattened path`);
+      continue;
+    }
+    seen.add(record.path);
+    const segments = record.path.split("/");
+    for (let index = 1; index < segments.length; index += 1) {
+      const prefix = segments.slice(0, index).join("/");
+      if (seen.has(prefix)) {
+        errors.push(`${record.path}: conflicts with leaf path "${prefix}"`);
+      }
+    }
+  }
+}
+function validateTemplateReferences(records, paths, errors) {
+  const graph = buildTemplateGraph(records, paths, errors);
+  validateTemplateGraph(graph, errors);
+}
+function buildTemplateGraph(records, paths, errors) {
+  const graph = /* @__PURE__ */ new Map();
+  for (const record of records) {
+    if (record.kind !== "config") continue;
+    graph.set(record.path, validateTemplateRecord(record, paths, errors));
+  }
+  return graph;
+}
+function validateTemplateRecord(record, paths, errors) {
+  const references = getTemplateReferences(record);
+  for (const reference of references) {
+    if (!paths.has(reference)) {
+      errors.push(`${record.path}: template references unknown key "${reference}"`);
+    }
+  }
+  return references.filter((reference) => paths.has(reference));
+}
+function getTemplateReferences(record) {
+  return [
+    ...extractTemplateReferences(record.value),
+    ...Object.values(record.values ?? {}).flatMap((value) => extractTemplateReferences(value))
+  ];
+}
+function validateTemplateGraph(graph, errors) {
+  const state = {
+    visiting: /* @__PURE__ */ new Set(),
+    visited: /* @__PURE__ */ new Set(),
+    stack: []
+  };
+  for (const path of graph.keys()) {
+    visitTemplatePath(path, graph, state, errors);
+  }
+}
+function visitTemplatePath(path, graph, state, errors) {
+  if (state.visited.has(path)) return;
+  if (state.visiting.has(path)) {
+    reportTemplateCycle(path, state.stack, errors);
+    return;
+  }
+  state.visiting.add(path);
+  state.stack.push(path);
+  for (const dependency of graph.get(path) ?? []) {
+    visitTemplatePath(dependency, graph, state, errors);
+  }
+  state.stack.pop();
+  state.visiting.delete(path);
+  state.visited.add(path);
+}
+function reportTemplateCycle(path, stack, errors) {
+  const cycleStart = stack.indexOf(path);
+  const cycle = [...stack.slice(cycleStart), path].join(" -> ");
+  errors.push(`template cycle detected: ${cycle}`);
+}
+function extractTemplateReferences(value) {
+  if (typeof value !== "string") return [];
+  const references = [];
+  TEMPLATE_RE2.lastIndex = 0;
+  for (const match of value.matchAll(TEMPLATE_RE2)) {
+    references.push(match[1].trim());
+  }
+  return references;
+}
+function checkUnique(label, values, errors) {
+  const seen = /* @__PURE__ */ new Set();
+  for (const value of values) {
+    if (seen.has(value)) {
+      errors.push(`${label}: duplicate "${value}"`);
+    }
+    seen.add(value);
+  }
+}
+function copyDefinedRecord(values) {
+  if (values === void 0) return void 0;
+  const copy = {};
+  for (const [key, value] of Object.entries(values)) {
+    if (value !== void 0) {
+      copy[key] = value;
+    }
+  }
+  return copy;
+}
+function isConfigRecord(value) {
+  return getKind(value) === "config";
+}
+function isSecretRecord(value) {
+  return getKind(value) === "secret";
+}
+function isProviderRef(value) {
+  const kind = getKind(value);
+  return typeof kind === "string" && kind.startsWith("provider:");
+}
+function getKind(value) {
+  if (value == null) return void 0;
+  if (typeof value !== "object") return void 0;
+  if (Array.isArray(value)) return void 0;
+  return value.__kind;
+}
+
+// ../cli/dist/src/v5/config/loader.js
+var CONFIG_FILE = "keyshelf.config.ts";
+var APP_MAPPING_FILE = ".env.keyshelf";
+var cachedJiti;
+function getJiti() {
+  if (cachedJiti === void 0) {
+    const override = process.env.KEYSHELF_CONFIG_MODULE_PATH;
+    const configModulePath = override !== void 0 ? resolve(override) : fileURLToPath(new URL("./index.js", import.meta.url));
+    cachedJiti = createJiti(import.meta.url, {
+      alias: {
+        "keyshelf/config": configModulePath
+      }
+    });
+  }
+  return cachedJiti;
+}
+function findV5RootDir(from) {
+  let dir = resolve(from);
+  while (true) {
+    if (existsSync(join(dir, CONFIG_FILE))) {
+      return dir;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) {
+      throw new Error(`Could not find ${CONFIG_FILE} in ${from} or any parent directory`);
+    }
+    dir = parent;
+  }
+}
+async function loadV5Config(appDir, options = {}) {
+  const explicitConfigPath = options.configPath === void 0 ? void 0 : resolve(options.configPath);
+  const rootDir = explicitConfigPath === void 0 ? findV5RootDir(appDir) : dirname(explicitConfigPath);
+  const configPath = explicitConfigPath ?? join(rootDir, CONFIG_FILE);
+  const started = performance.now();
+  const rawConfig = await importConfig(configPath);
+  const config2 = normalizeConfig(rawConfig);
+  const loadTimeMs = performance.now() - started;
+  const mappingPath = options.mappingFile ? resolve(options.mappingFile) : join(resolve(appDir), APP_MAPPING_FILE);
+  const appMapping = await loadAppMapping(mappingPath, options.mappingFile !== void 0);
+  validateAppMappingReferences(appMapping, config2.keys);
+  return {
+    rootDir,
+    configPath,
+    config: config2,
+    appMapping,
+    loadTimeMs
+  };
+}
+async function importConfig(configPath) {
+  return await getJiti().import(configPath, { default: true });
+}
+async function loadAppMapping(mappingPath, required) {
+  try {
+    return parseAppMapping(await readFile(mappingPath, "utf-8"));
+  } catch (err) {
+    if (err.code === "ENOENT") {
+      if (required) {
+        throw new Error(`App mapping file not found: ${mappingPath}`, {
+          cause: err
+        });
+      }
+      return [];
+    }
+    throw err;
+  }
+}
+
+export { age, config, defineConfig, findV5RootDir, gcp, isProviderRef, keyshelfConfigSchema, loadV5Config, normalizeConfig, providerRefSchema, secret, sops, validateAppMappingReferences };

--- a/packages/action/dist/write-identity-v5.mjs
+++ b/packages/action/dist/write-identity-v5.mjs
@@ -1,0 +1,470 @@
+#!/usr/bin/env node
+import { mkdir, writeFile, chmod, readFile } from 'fs/promises';
+import { dirname, join, isAbsolute, resolve } from 'path';
+import { homedir } from 'os';
+import { existsSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { performance } from 'perf_hooks';
+import { createJiti } from 'jiti';
+import { z } from 'zod';
+
+// ../cli/dist/src/config/app-mapping.js
+var TEMPLATE_RE = /\$\{([^}]+)\}/g;
+function isTemplateMapping(m) {
+  return "template" in m;
+}
+function parseAppMapping(content) {
+  const mappings = [];
+  for (const raw of content.split("\n")) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eqIndex = line.indexOf("=");
+    if (eqIndex === -1) continue;
+    const envVar = line.slice(0, eqIndex).trim();
+    const value = line.slice(eqIndex + 1).trim();
+    if (!envVar || !value) continue;
+    if (TEMPLATE_RE.test(value)) {
+      TEMPLATE_RE.lastIndex = 0;
+      const keyPaths = [...value.matchAll(TEMPLATE_RE)].map((m) => m[1].trim());
+      mappings.push({ envVar, template: value, keyPaths });
+    } else {
+      mappings.push({ envVar, keyPath: value });
+    }
+  }
+  return mappings;
+}
+var PATH_SEGMENT_RE = /^[A-Za-z_][A-Za-z0-9_-]*$/;
+var TEMPLATE_RE2 = /(?<!\$)\$\{([^}]+)\}/g;
+var CONFIG_NAME_RE = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
+var configScalarSchema = z.union([z.string(), z.number(), z.boolean()]);
+var ageProviderSchema = z.object({
+  __kind: z.literal("provider:age"),
+  name: z.literal("age"),
+  options: z.object({
+    identityFile: z.string().min(1),
+    secretsDir: z.string().min(1)
+  }).strict()
+}).strict();
+var gcpProviderSchema = z.object({
+  __kind: z.literal("provider:gcp"),
+  name: z.literal("gcp"),
+  options: z.object({
+    project: z.string().min(1)
+  }).strict()
+}).strict();
+var sopsProviderSchema = z.object({
+  __kind: z.literal("provider:sops"),
+  name: z.literal("sops"),
+  options: z.object({
+    identityFile: z.string().min(1),
+    secretsFile: z.string().min(1)
+  }).strict()
+}).strict();
+var providerRefSchema = z.discriminatedUnion("__kind", [
+  ageProviderSchema,
+  gcpProviderSchema,
+  sopsProviderSchema
+]);
+var baseRecordSchema = {
+  group: z.string().optional(),
+  optional: z.boolean().optional(),
+  description: z.string().optional()
+};
+var configRecordSchema = z.object({
+  __kind: z.literal("config"),
+  ...baseRecordSchema,
+  value: configScalarSchema.optional(),
+  default: configScalarSchema.optional(),
+  values: z.record(z.string(), configScalarSchema).optional()
+}).strict();
+var secretRecordSchema = z.object({
+  __kind: z.literal("secret"),
+  ...baseRecordSchema,
+  value: providerRefSchema.optional(),
+  default: providerRefSchema.optional(),
+  values: z.record(z.string(), providerRefSchema).optional()
+}).strict();
+var keyNodeSchema = z.lazy(
+  () => z.union([
+    configScalarSchema,
+    configRecordSchema,
+    secretRecordSchema,
+    z.record(z.string(), keyNodeSchema).refine((value) => Object.keys(value).length > 0, {
+      message: "key namespaces must not be empty"
+    }).refine((value) => !Object.hasOwn(value, "__kind"), {
+      message: "factory objects with __kind must match their declared schema"
+    })
+  ])
+);
+var keyshelfConfigSchema = z.object({
+  __kind: z.literal("keyshelf:config"),
+  name: z.string().min(1).refine((value) => CONFIG_NAME_RE.test(value), {
+    message: "name must match /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/ (lowercase, digits, dashes; no leading or trailing dash)"
+  }),
+  envs: z.array(z.string().min(1)).nonempty(),
+  groups: z.array(z.string().min(1)).optional(),
+  keys: z.record(z.string(), keyNodeSchema).refine((value) => Object.keys(value).length > 0, {
+    message: "keys must contain at least one entry"
+  })
+}).strict();
+function normalizeConfig(input) {
+  const parsed = keyshelfConfigSchema.parse(input);
+  const errors = [];
+  checkUnique("envs", parsed.envs, errors);
+  const groups = [...parsed.groups ?? []];
+  checkUnique("groups", groups, errors);
+  const flattened = flattenKeyTree(parsed.keys, errors);
+  const paths = new Set(flattened.map((record) => record.path));
+  validatePathConflicts(flattened, errors);
+  validateRecords(flattened, parsed.envs, groups, errors);
+  validateTemplateReferences(flattened, paths, errors);
+  if (errors.length > 0) {
+    throw new Error(
+      `Invalid keyshelf.config.ts:
+${errors.map((error) => `- ${error}`).join("\n")}`
+    );
+  }
+  return {
+    name: parsed.name,
+    envs: [...parsed.envs],
+    groups,
+    keys: flattened
+  };
+}
+function validateAppMappingReferences(mappings, flattenedKeys) {
+  const paths = new Set(flattenedKeys.map((record) => record.path));
+  const errors = [];
+  for (const mapping of mappings) {
+    const references = isTemplateMapping(mapping) ? mapping.keyPaths : [mapping.keyPath];
+    for (const reference of references) {
+      if (!paths.has(reference)) {
+        errors.push(`${mapping.envVar}: references unknown key "${reference}"`);
+      }
+    }
+  }
+  if (errors.length > 0) {
+    throw new Error(`Invalid .env.keyshelf:
+${errors.map((error) => `- ${error}`).join("\n")}`);
+  }
+}
+function validateRecords(records, envs, groups, errors) {
+  const envSet = new Set(envs);
+  const groupSet = new Set(groups);
+  for (const record of records) {
+    validateRecordGroup(record, groups, groupSet, errors);
+    validateRecordValues(record, envSet, errors);
+    validateSecretValue(record, errors);
+  }
+}
+function validateRecordGroup(record, groups, groupSet, errors) {
+  if (record.group === void 0 || groupSet.has(record.group)) return;
+  const suffix = groups.length === 0 ? " because no groups are declared" : "";
+  errors.push(`${record.path}: group "${record.group}" is not declared${suffix}`);
+}
+function validateRecordValues(record, envSet, errors) {
+  for (const envName of Object.keys(record.values ?? {})) {
+    if (!envSet.has(envName)) {
+      errors.push(`${record.path}: values contains undeclared env "${envName}"`);
+    }
+  }
+}
+function validateSecretValue(record, errors) {
+  if (record.kind !== "secret") return;
+  const hasValues = record.values !== void 0 && Object.keys(record.values).length > 0;
+  if (record.value === void 0 && !hasValues) {
+    errors.push(`${record.path}: secret requires value, default, or at least one values entry`);
+  }
+}
+function flattenKeyTree(tree, errors, prefix = []) {
+  const records = [];
+  for (const [rawKey, value] of Object.entries(tree)) {
+    const fullParts = [...prefix, ...rawKey.split("/")];
+    const path = fullParts.join("/");
+    validatePathParts(fullParts, errors);
+    records.push(...flattenKeyNode(value, path, fullParts, errors));
+  }
+  return records;
+}
+function flattenKeyNode(value, path, fullParts, errors) {
+  if (isConfigRecord(value)) return [normalizeConfigRecord(path, value, errors)];
+  if (isSecretRecord(value)) return [normalizeSecretRecord(path, value, errors)];
+  const scalar = configScalarSchema.safeParse(value);
+  if (scalar.success) return [normalizeScalarRecord(path, scalar.data)];
+  return flattenKeyTree(value, errors, fullParts);
+}
+function normalizeConfigRecord(path, input, errors) {
+  return {
+    path,
+    kind: "config",
+    group: input.group,
+    optional: input.optional ?? false,
+    description: input.description,
+    value: resolveBinding(path, input.value, input.default, errors),
+    values: copyDefinedRecord(input.values)
+  };
+}
+function normalizeSecretRecord(path, input, errors) {
+  return {
+    path,
+    kind: "secret",
+    group: input.group,
+    optional: input.optional ?? false,
+    description: input.description,
+    value: resolveBinding(path, input.value, input.default, errors),
+    values: copyDefinedRecord(input.values)
+  };
+}
+function resolveBinding(path, value, fallback, errors) {
+  if (value !== void 0 && fallback !== void 0) {
+    errors.push(`${path}: value and default are mutually exclusive`);
+  }
+  return value ?? fallback;
+}
+function normalizeScalarRecord(path, value) {
+  return {
+    path,
+    kind: "config",
+    optional: false,
+    value
+  };
+}
+function validatePathParts(parts, errors) {
+  for (const part of parts) {
+    if (!PATH_SEGMENT_RE.test(part)) {
+      errors.push(`${parts.join("/")}: invalid path segment "${part}"`);
+    }
+  }
+}
+function validatePathConflicts(records, errors) {
+  const sorted = [...records].sort((a, b) => a.path.localeCompare(b.path));
+  const seen = /* @__PURE__ */ new Set();
+  for (const record of sorted) {
+    if (seen.has(record.path)) {
+      errors.push(`${record.path}: duplicate flattened path`);
+      continue;
+    }
+    seen.add(record.path);
+    const segments = record.path.split("/");
+    for (let index = 1; index < segments.length; index += 1) {
+      const prefix = segments.slice(0, index).join("/");
+      if (seen.has(prefix)) {
+        errors.push(`${record.path}: conflicts with leaf path "${prefix}"`);
+      }
+    }
+  }
+}
+function validateTemplateReferences(records, paths, errors) {
+  const graph = buildTemplateGraph(records, paths, errors);
+  validateTemplateGraph(graph, errors);
+}
+function buildTemplateGraph(records, paths, errors) {
+  const graph = /* @__PURE__ */ new Map();
+  for (const record of records) {
+    if (record.kind !== "config") continue;
+    graph.set(record.path, validateTemplateRecord(record, paths, errors));
+  }
+  return graph;
+}
+function validateTemplateRecord(record, paths, errors) {
+  const references = getTemplateReferences(record);
+  for (const reference of references) {
+    if (!paths.has(reference)) {
+      errors.push(`${record.path}: template references unknown key "${reference}"`);
+    }
+  }
+  return references.filter((reference) => paths.has(reference));
+}
+function getTemplateReferences(record) {
+  return [
+    ...extractTemplateReferences(record.value),
+    ...Object.values(record.values ?? {}).flatMap((value) => extractTemplateReferences(value))
+  ];
+}
+function validateTemplateGraph(graph, errors) {
+  const state = {
+    visiting: /* @__PURE__ */ new Set(),
+    visited: /* @__PURE__ */ new Set(),
+    stack: []
+  };
+  for (const path of graph.keys()) {
+    visitTemplatePath(path, graph, state, errors);
+  }
+}
+function visitTemplatePath(path, graph, state, errors) {
+  if (state.visited.has(path)) return;
+  if (state.visiting.has(path)) {
+    reportTemplateCycle(path, state.stack, errors);
+    return;
+  }
+  state.visiting.add(path);
+  state.stack.push(path);
+  for (const dependency of graph.get(path) ?? []) {
+    visitTemplatePath(dependency, graph, state, errors);
+  }
+  state.stack.pop();
+  state.visiting.delete(path);
+  state.visited.add(path);
+}
+function reportTemplateCycle(path, stack, errors) {
+  const cycleStart = stack.indexOf(path);
+  const cycle = [...stack.slice(cycleStart), path].join(" -> ");
+  errors.push(`template cycle detected: ${cycle}`);
+}
+function extractTemplateReferences(value) {
+  if (typeof value !== "string") return [];
+  const references = [];
+  TEMPLATE_RE2.lastIndex = 0;
+  for (const match of value.matchAll(TEMPLATE_RE2)) {
+    references.push(match[1].trim());
+  }
+  return references;
+}
+function checkUnique(label, values, errors) {
+  const seen = /* @__PURE__ */ new Set();
+  for (const value of values) {
+    if (seen.has(value)) {
+      errors.push(`${label}: duplicate "${value}"`);
+    }
+    seen.add(value);
+  }
+}
+function copyDefinedRecord(values) {
+  if (values === void 0) return void 0;
+  const copy = {};
+  for (const [key, value] of Object.entries(values)) {
+    if (value !== void 0) {
+      copy[key] = value;
+    }
+  }
+  return copy;
+}
+function isConfigRecord(value) {
+  return getKind(value) === "config";
+}
+function isSecretRecord(value) {
+  return getKind(value) === "secret";
+}
+function getKind(value) {
+  if (value == null) return void 0;
+  if (typeof value !== "object") return void 0;
+  if (Array.isArray(value)) return void 0;
+  return value.__kind;
+}
+
+// ../cli/dist/src/v5/config/loader.js
+var CONFIG_FILE = "keyshelf.config.ts";
+var APP_MAPPING_FILE = ".env.keyshelf";
+var cachedJiti;
+function getJiti() {
+  if (cachedJiti === void 0) {
+    const override = process.env.KEYSHELF_CONFIG_MODULE_PATH;
+    const configModulePath = override !== void 0 ? resolve(override) : fileURLToPath(new URL("./index.js", import.meta.url));
+    cachedJiti = createJiti(import.meta.url, {
+      alias: {
+        "keyshelf/config": configModulePath
+      }
+    });
+  }
+  return cachedJiti;
+}
+function findV5RootDir(from) {
+  let dir = resolve(from);
+  while (true) {
+    if (existsSync(join(dir, CONFIG_FILE))) {
+      return dir;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) {
+      throw new Error(`Could not find ${CONFIG_FILE} in ${from} or any parent directory`);
+    }
+    dir = parent;
+  }
+}
+async function loadV5Config(appDir, options = {}) {
+  const explicitConfigPath = options.configPath === void 0 ? void 0 : resolve(options.configPath);
+  const rootDir = explicitConfigPath === void 0 ? findV5RootDir(appDir) : dirname(explicitConfigPath);
+  const configPath = explicitConfigPath ?? join(rootDir, CONFIG_FILE);
+  const started = performance.now();
+  const rawConfig = await importConfig(configPath);
+  const config = normalizeConfig(rawConfig);
+  const loadTimeMs = performance.now() - started;
+  const mappingPath = options.mappingFile ? resolve(options.mappingFile) : join(resolve(appDir), APP_MAPPING_FILE);
+  const appMapping = await loadAppMapping(mappingPath, options.mappingFile !== void 0);
+  validateAppMappingReferences(appMapping, config.keys);
+  return {
+    rootDir,
+    configPath,
+    config,
+    appMapping,
+    loadTimeMs
+  };
+}
+async function importConfig(configPath) {
+  return await getJiti().import(configPath, { default: true });
+}
+async function loadAppMapping(mappingPath, required) {
+  try {
+    return parseAppMapping(await readFile(mappingPath, "utf-8"));
+  } catch (err) {
+    if (err.code === "ENOENT") {
+      if (required) {
+        throw new Error(`App mapping file not found: ${mappingPath}`, {
+          cause: err
+        });
+      }
+      return [];
+    }
+    throw err;
+  }
+}
+
+// scripts/write-identity-v5.mjs
+var identity = process.env.KEYSHELF_IDENTITY;
+var cwd = process.env.KEYSHELF_CWD || process.cwd();
+if (!identity) {
+  process.stdout.write("No identity provided; skipping identity write.\n");
+  process.exit(0);
+}
+var loaded = await loadV5Config(cwd);
+var identityFiles = collectAgeIdentityFiles(loaded.config);
+if (identityFiles.length === 0) {
+  process.stdout.write(
+    `::warning::'identity' input was provided but config "${loaded.config.name}" declares no age providers. Ignoring.
+`
+  );
+  process.exit(0);
+}
+for (const filePath of identityFiles) {
+  const target = resolveIdentityPath(filePath, loaded.rootDir);
+  await mkdir(dirname(target), { recursive: true });
+  await writeFile(target, ensureTrailingNewline(identity), { mode: 384 });
+  await chmod(target, 384);
+  process.stdout.write(`Wrote identity to ${target} (mode 0600)
+`);
+}
+function collectAgeIdentityFiles(config) {
+  const seen = /* @__PURE__ */ new Set();
+  for (const record of config.keys) {
+    if (record.kind !== "secret") continue;
+    visitBinding(record.value);
+    for (const v of Object.values(record.values ?? {})) visitBinding(v);
+  }
+  return [...seen];
+  function visitBinding(binding) {
+    if (binding === void 0) return;
+    if (typeof binding !== "object" || binding === null) return;
+    if (binding.__kind !== "provider:age") return;
+    const file = binding.options?.identityFile;
+    if (typeof file === "string" && file.length > 0) seen.add(file);
+  }
+}
+function resolveIdentityPath(filePath, rootDir) {
+  if (filePath === "~" || filePath.startsWith("~/")) {
+    return join(homedir(), filePath.slice(1));
+  }
+  if (isAbsolute(filePath)) return filePath;
+  return resolve(rootDir, filePath);
+}
+function ensureTrailingNewline(content) {
+  return content.endsWith("\n") ? content : content + "\n";
+}

--- a/packages/action/dist/write-identity.mjs
+++ b/packages/action/dist/write-identity.mjs
@@ -1,43 +1,2897 @@
 #!/usr/bin/env node
-import {mkdir,writeFile,chmod,readFile}from'fs/promises';import {dirname,join,isAbsolute,resolve}from'path';import {homedir}from'os';import {existsSync}from'fs';function Re(e){return typeof e>"u"||e===null}function Mn(e){return typeof e=="object"&&e!==null}function Rn(e){return Array.isArray(e)?e:Re(e)?[]:[e]}function Dn(e,n){var r,o,i,u;if(n)for(u=Object.keys(n),r=0,o=u.length;r<o;r+=1)i=u[r],e[i]=n[i];return e}function Pn(e,n){var r="",o;for(o=0;o<n;o+=1)r+=e;return r}function Yn(e){return e===0&&Number.NEGATIVE_INFINITY===1/e}var jn=Re,Hn=Mn,Bn=Rn,Un=Pn,Kn=Yn,$n=Dn,A={isNothing:jn,isObject:Hn,toArray:Bn,repeat:Un,isNegativeZero:Kn,extend:$n};function De(e,n){var r="",o=e.reason||"(unknown reason)";return e.mark?(e.mark.name&&(r+='in "'+e.mark.name+'" '),r+="("+(e.mark.line+1)+":"+(e.mark.column+1)+")",!n&&e.mark.snippet&&(r+=`
+import { mkdir, writeFile, chmod, readFile } from 'fs/promises';
+import { dirname, join, isAbsolute, resolve } from 'path';
+import { homedir } from 'os';
+import { existsSync } from 'fs';
 
-`+e.mark.snippet),o+" "+r):o}function Y(e,n){Error.call(this),this.name="YAMLException",this.reason=e,this.mark=n,this.message=De(this,false),Error.captureStackTrace?Error.captureStackTrace(this,this.constructor):this.stack=new Error().stack||"";}Y.prototype=Object.create(Error.prototype);Y.prototype.constructor=Y;Y.prototype.toString=function(n){return this.name+": "+De(this,n)};var w=Y;function z(e,n,r,o,i){var u="",l="",t=Math.floor(i/2)-1;return o-n>t&&(u=" ... ",n=o-t+u.length),r-o>t&&(l=" ...",r=o+t-l.length),{str:u+e.slice(n,r).replace(/\t/g,"\u2192")+l,pos:o-n+u.length}}function J(e,n){return A.repeat(" ",n-e.length)+e}function qn(e,n){if(n=Object.create(n||null),!e.buffer)return null;n.maxLength||(n.maxLength=79),typeof n.indent!="number"&&(n.indent=1),typeof n.linesBefore!="number"&&(n.linesBefore=3),typeof n.linesAfter!="number"&&(n.linesAfter=2);for(var r=/\r?\n|\r|\0/g,o=[0],i=[],u,l=-1;u=r.exec(e.buffer);)i.push(u.index),o.push(u.index+u[0].length),e.position<=u.index&&l<0&&(l=o.length-2);l<0&&(l=o.length-1);var t="",f,c,s=Math.min(e.line+n.linesAfter,i.length).toString().length,a=n.maxLength-(n.indent+s+3);for(f=1;f<=n.linesBefore&&!(l-f<0);f++)c=z(e.buffer,o[l-f],i[l-f],e.position-(o[l]-o[l-f]),a),t=A.repeat(" ",n.indent)+J((e.line-f+1).toString(),s)+" | "+c.str+`
-`+t;for(c=z(e.buffer,o[l],i[l],e.position,a),t+=A.repeat(" ",n.indent)+J((e.line+1).toString(),s)+" | "+c.str+`
-`,t+=A.repeat("-",n.indent+s+3+c.pos)+`^
-`,f=1;f<=n.linesAfter&&!(l+f>=i.length);f++)c=z(e.buffer,o[l+f],i[l+f],e.position-(o[l]-o[l+f]),a),t+=A.repeat(" ",n.indent)+J((e.line+f+1).toString(),s)+" | "+c.str+`
-`;return t.replace(/\n$/,"")}var Gn=qn,Wn=["kind","multi","resolve","construct","instanceOf","predicate","represent","representName","defaultStyle","styleAliases"],Vn=["scalar","sequence","mapping"];function Qn(e){var n={};return e!==null&&Object.keys(e).forEach(function(r){e[r].forEach(function(o){n[String(o)]=r;});}),n}function Xn(e,n){if(n=n||{},Object.keys(n).forEach(function(r){if(Wn.indexOf(r)===-1)throw new w('Unknown option "'+r+'" is met in definition of "'+e+'" YAML type.')}),this.options=n,this.tag=e,this.kind=n.kind||null,this.resolve=n.resolve||function(){return  true},this.construct=n.construct||function(r){return r},this.instanceOf=n.instanceOf||null,this.predicate=n.predicate||null,this.represent=n.represent||null,this.representName=n.representName||null,this.defaultStyle=n.defaultStyle||null,this.multi=n.multi||false,this.styleAliases=Qn(n.styleAliases||null),Vn.indexOf(this.kind)===-1)throw new w('Unknown kind "'+this.kind+'" is specified for "'+e+'" YAML type.')}var C=Xn;function Ae(e,n){var r=[];return e[n].forEach(function(o){var i=r.length;r.forEach(function(u,l){u.tag===o.tag&&u.kind===o.kind&&u.multi===o.multi&&(i=l);}),r[i]=o;}),r}function Zn(){var e={scalar:{},sequence:{},mapping:{},fallback:{},multi:{scalar:[],sequence:[],mapping:[],fallback:[]}},n,r;function o(i){i.multi?(e.multi[i.kind].push(i),e.multi.fallback.push(i)):e[i.kind][i.tag]=e.fallback[i.tag]=i;}for(n=0,r=arguments.length;n<r;n+=1)arguments[n].forEach(o);return e}function ne(e){return this.extend(e)}ne.prototype.extend=function(n){var r=[],o=[];if(n instanceof C)o.push(n);else if(Array.isArray(n))o=o.concat(n);else if(n&&(Array.isArray(n.implicit)||Array.isArray(n.explicit)))n.implicit&&(r=r.concat(n.implicit)),n.explicit&&(o=o.concat(n.explicit));else throw new w("Schema.extend argument should be a Type, [ Type ], or a schema definition ({ implicit: [...], explicit: [...] })");r.forEach(function(u){if(!(u instanceof C))throw new w("Specified list of YAML types (or a single Type object) contains a non-Type object.");if(u.loadKind&&u.loadKind!=="scalar")throw new w("There is a non-scalar type in the implicit list of a schema. Implicit resolving of such types is not supported.");if(u.multi)throw new w("There is a multi type in the implicit list of a schema. Multi tags can only be listed as explicit.")}),o.forEach(function(u){if(!(u instanceof C))throw new w("Specified list of YAML types (or a single Type object) contains a non-Type object.")});var i=Object.create(ne.prototype);return i.implicit=(this.implicit||[]).concat(r),i.explicit=(this.explicit||[]).concat(o),i.compiledImplicit=Ae(i,"implicit"),i.compiledExplicit=Ae(i,"explicit"),i.compiledTypeMap=Zn(i.compiledImplicit,i.compiledExplicit),i};var Pe=ne,Ye=new C("tag:yaml.org,2002:str",{kind:"scalar",construct:function(e){return e!==null?e:""}}),je=new C("tag:yaml.org,2002:seq",{kind:"sequence",construct:function(e){return e!==null?e:[]}}),He=new C("tag:yaml.org,2002:map",{kind:"mapping",construct:function(e){return e!==null?e:{}}}),Be=new Pe({explicit:[Ye,je,He]});function zn(e){if(e===null)return  true;var n=e.length;return n===1&&e==="~"||n===4&&(e==="null"||e==="Null"||e==="NULL")}function Jn(){return null}function er(e){return e===null}var Ue=new C("tag:yaml.org,2002:null",{kind:"scalar",resolve:zn,construct:Jn,predicate:er,represent:{canonical:function(){return "~"},lowercase:function(){return "null"},uppercase:function(){return "NULL"},camelcase:function(){return "Null"},empty:function(){return ""}},defaultStyle:"lowercase"});function nr(e){if(e===null)return  false;var n=e.length;return n===4&&(e==="true"||e==="True"||e==="TRUE")||n===5&&(e==="false"||e==="False"||e==="FALSE")}function rr(e){return e==="true"||e==="True"||e==="TRUE"}function ir(e){return Object.prototype.toString.call(e)==="[object Boolean]"}var Ke=new C("tag:yaml.org,2002:bool",{kind:"scalar",resolve:nr,construct:rr,predicate:ir,represent:{lowercase:function(e){return e?"true":"false"},uppercase:function(e){return e?"TRUE":"FALSE"},camelcase:function(e){return e?"True":"False"}},defaultStyle:"lowercase"});function or(e){return 48<=e&&e<=57||65<=e&&e<=70||97<=e&&e<=102}function lr(e){return 48<=e&&e<=55}function ur(e){return 48<=e&&e<=57}function tr(e){if(e===null)return  false;var n=e.length,r=0,o=false,i;if(!n)return  false;if(i=e[r],(i==="-"||i==="+")&&(i=e[++r]),i==="0"){if(r+1===n)return  true;if(i=e[++r],i==="b"){for(r++;r<n;r++)if(i=e[r],i!=="_"){if(i!=="0"&&i!=="1")return  false;o=true;}return o&&i!=="_"}if(i==="x"){for(r++;r<n;r++)if(i=e[r],i!=="_"){if(!or(e.charCodeAt(r)))return  false;o=true;}return o&&i!=="_"}if(i==="o"){for(r++;r<n;r++)if(i=e[r],i!=="_"){if(!lr(e.charCodeAt(r)))return  false;o=true;}return o&&i!=="_"}}if(i==="_")return  false;for(;r<n;r++)if(i=e[r],i!=="_"){if(!ur(e.charCodeAt(r)))return  false;o=true;}return !(!o||i==="_")}function fr(e){var n=e,r=1,o;if(n.indexOf("_")!==-1&&(n=n.replace(/_/g,"")),o=n[0],(o==="-"||o==="+")&&(o==="-"&&(r=-1),n=n.slice(1),o=n[0]),n==="0")return 0;if(o==="0"){if(n[1]==="b")return r*parseInt(n.slice(2),2);if(n[1]==="x")return r*parseInt(n.slice(2),16);if(n[1]==="o")return r*parseInt(n.slice(2),8)}return r*parseInt(n,10)}function cr(e){return Object.prototype.toString.call(e)==="[object Number]"&&e%1===0&&!A.isNegativeZero(e)}var $e=new C("tag:yaml.org,2002:int",{kind:"scalar",resolve:tr,construct:fr,predicate:cr,represent:{binary:function(e){return e>=0?"0b"+e.toString(2):"-0b"+e.toString(2).slice(1)},octal:function(e){return e>=0?"0o"+e.toString(8):"-0o"+e.toString(8).slice(1)},decimal:function(e){return e.toString(10)},hexadecimal:function(e){return e>=0?"0x"+e.toString(16).toUpperCase():"-0x"+e.toString(16).toUpperCase().slice(1)}},defaultStyle:"decimal",styleAliases:{binary:[2,"bin"],octal:[8,"oct"],decimal:[10,"dec"],hexadecimal:[16,"hex"]}}),ar=new RegExp("^(?:[-+]?(?:[0-9][0-9_]*)(?:\\.[0-9_]*)?(?:[eE][-+]?[0-9]+)?|\\.[0-9_]+(?:[eE][-+]?[0-9]+)?|[-+]?\\.(?:inf|Inf|INF)|\\.(?:nan|NaN|NAN))$");function pr(e){return !(e===null||!ar.test(e)||e[e.length-1]==="_")}function sr(e){var n,r;return n=e.replace(/_/g,"").toLowerCase(),r=n[0]==="-"?-1:1,"+-".indexOf(n[0])>=0&&(n=n.slice(1)),n===".inf"?r===1?Number.POSITIVE_INFINITY:Number.NEGATIVE_INFINITY:n===".nan"?NaN:r*parseFloat(n,10)}var dr=/^[-+]?[0-9]+e/;function hr(e,n){var r;if(isNaN(e))switch(n){case "lowercase":return ".nan";case "uppercase":return ".NAN";case "camelcase":return ".NaN"}else if(Number.POSITIVE_INFINITY===e)switch(n){case "lowercase":return ".inf";case "uppercase":return ".INF";case "camelcase":return ".Inf"}else if(Number.NEGATIVE_INFINITY===e)switch(n){case "lowercase":return "-.inf";case "uppercase":return "-.INF";case "camelcase":return "-.Inf"}else if(A.isNegativeZero(e))return "-0.0";return r=e.toString(10),dr.test(r)?r.replace("e",".e"):r}function mr(e){return Object.prototype.toString.call(e)==="[object Number]"&&(e%1!==0||A.isNegativeZero(e))}var qe=new C("tag:yaml.org,2002:float",{kind:"scalar",resolve:pr,construct:sr,predicate:mr,represent:hr,defaultStyle:"lowercase"}),Ge=Be.extend({implicit:[Ue,Ke,$e,qe]}),We=Ge,Ve=new RegExp("^([0-9][0-9][0-9][0-9])-([0-9][0-9])-([0-9][0-9])$"),Qe=new RegExp("^([0-9][0-9][0-9][0-9])-([0-9][0-9]?)-([0-9][0-9]?)(?:[Tt]|[ \\t]+)([0-9][0-9]?):([0-9][0-9]):([0-9][0-9])(?:\\.([0-9]*))?(?:[ \\t]*(Z|([-+])([0-9][0-9]?)(?::([0-9][0-9]))?))?$");function gr(e){return e===null?false:Ve.exec(e)!==null||Qe.exec(e)!==null}function xr(e){var n,r,o,i,u,l,t,f=0,c=null,s,a,h;if(n=Ve.exec(e),n===null&&(n=Qe.exec(e)),n===null)throw new Error("Date resolve error");if(r=+n[1],o=+n[2]-1,i=+n[3],!n[4])return new Date(Date.UTC(r,o,i));if(u=+n[4],l=+n[5],t=+n[6],n[7]){for(f=n[7].slice(0,3);f.length<3;)f+="0";f=+f;}return n[9]&&(s=+n[10],a=+(n[11]||0),c=(s*60+a)*6e4,n[9]==="-"&&(c=-c)),h=new Date(Date.UTC(r,o,i,u,l,t,f)),c&&h.setTime(h.getTime()-c),h}function vr(e){return e.toISOString()}var Xe=new C("tag:yaml.org,2002:timestamp",{kind:"scalar",resolve:gr,construct:xr,instanceOf:Date,represent:vr});function yr(e){return e==="<<"||e===null}var Ze=new C("tag:yaml.org,2002:merge",{kind:"scalar",resolve:yr}),ue=`ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=
-\r`;function Ar(e){if(e===null)return  false;var n,r,o=0,i=e.length,u=ue;for(r=0;r<i;r++)if(n=u.indexOf(e.charAt(r)),!(n>64)){if(n<0)return  false;o+=6;}return o%8===0}function Cr(e){var n,r,o=e.replace(/[\r\n=]/g,""),i=o.length,u=ue,l=0,t=[];for(n=0;n<i;n++)n%4===0&&n&&(t.push(l>>16&255),t.push(l>>8&255),t.push(l&255)),l=l<<6|u.indexOf(o.charAt(n));return r=i%4*6,r===0?(t.push(l>>16&255),t.push(l>>8&255),t.push(l&255)):r===18?(t.push(l>>10&255),t.push(l>>2&255)):r===12&&t.push(l>>4&255),new Uint8Array(t)}function Er(e){var n="",r=0,o,i,u=e.length,l=ue;for(o=0;o<u;o++)o%3===0&&o&&(n+=l[r>>18&63],n+=l[r>>12&63],n+=l[r>>6&63],n+=l[r&63]),r=(r<<8)+e[o];return i=u%3,i===0?(n+=l[r>>18&63],n+=l[r>>12&63],n+=l[r>>6&63],n+=l[r&63]):i===2?(n+=l[r>>10&63],n+=l[r>>4&63],n+=l[r<<2&63],n+=l[64]):i===1&&(n+=l[r>>2&63],n+=l[r<<4&63],n+=l[64],n+=l[64]),n}function wr(e){return Object.prototype.toString.call(e)==="[object Uint8Array]"}var ze=new C("tag:yaml.org,2002:binary",{kind:"scalar",resolve:Ar,construct:Cr,predicate:wr,represent:Er}),_r=Object.prototype.hasOwnProperty,Sr=Object.prototype.toString;function br(e){if(e===null)return  true;var n=[],r,o,i,u,l,t=e;for(r=0,o=t.length;r<o;r+=1){if(i=t[r],l=false,Sr.call(i)!=="[object Object]")return  false;for(u in i)if(_r.call(i,u))if(!l)l=true;else return  false;if(!l)return  false;if(n.indexOf(u)===-1)n.push(u);else return  false}return  true}function Fr(e){return e!==null?e:[]}var Je=new C("tag:yaml.org,2002:omap",{kind:"sequence",resolve:br,construct:Fr}),Tr=Object.prototype.toString;function kr(e){if(e===null)return  true;var n,r,o,i,u,l=e;for(u=new Array(l.length),n=0,r=l.length;n<r;n+=1){if(o=l[n],Tr.call(o)!=="[object Object]"||(i=Object.keys(o),i.length!==1))return  false;u[n]=[i[0],o[i[0]]];}return  true}function Or(e){if(e===null)return [];var n,r,o,i,u,l=e;for(u=new Array(l.length),n=0,r=l.length;n<r;n+=1)o=l[n],i=Object.keys(o),u[n]=[i[0],o[i[0]]];return u}var en=new C("tag:yaml.org,2002:pairs",{kind:"sequence",resolve:kr,construct:Or}),Ir=Object.prototype.hasOwnProperty;function Lr(e){if(e===null)return  true;var n,r=e;for(n in r)if(Ir.call(r,n)&&r[n]!==null)return  false;return  true}function Nr(e){return e!==null?e:{}}var nn=new C("tag:yaml.org,2002:set",{kind:"mapping",resolve:Lr,construct:Nr}),te=We.extend({implicit:[Xe,Ze],explicit:[ze,Je,en,nn]}),k=Object.prototype.hasOwnProperty,K=1,rn=2,on=3,$=4,ee=1,Mr=2,Ce=3,Rr=/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x84\x86-\x9F\uFFFE\uFFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF]/,Dr=/[\x85\u2028\u2029]/,Pr=/[,\[\]\{\}]/,ln=/^(?:!|!!|![a-z\-]+!)$/i,un=/^(?:!|[^,\[\]\{\}])(?:%[0-9a-f]{2}|[0-9a-z\-#;\/\?:@&=\+\$,_\.!~\*'\(\)\[\]])*$/i;function Ee(e){return Object.prototype.toString.call(e)}function b(e){return e===10||e===13}function L(e){return e===9||e===32}function _(e){return e===9||e===32||e===10||e===13}function M(e){return e===44||e===91||e===93||e===123||e===125}function Yr(e){var n;return 48<=e&&e<=57?e-48:(n=e|32,97<=n&&n<=102?n-97+10:-1)}function jr(e){return e===120?2:e===117?4:e===85?8:0}function Hr(e){return 48<=e&&e<=57?e-48:-1}function we(e){return e===48?"\0":e===97?"\x07":e===98?"\b":e===116||e===9?"	":e===110?`
-`:e===118?"\v":e===102?"\f":e===114?"\r":e===101?"\x1B":e===32?" ":e===34?'"':e===47?"/":e===92?"\\":e===78?"\x85":e===95?"\xA0":e===76?"\u2028":e===80?"\u2029":""}function Br(e){return e<=65535?String.fromCharCode(e):String.fromCharCode((e-65536>>10)+55296,(e-65536&1023)+56320)}function tn(e,n,r){n==="__proto__"?Object.defineProperty(e,n,{configurable:true,enumerable:true,writable:true,value:r}):e[n]=r;}var fn=new Array(256),cn=new Array(256);for(I=0;I<256;I++)fn[I]=we(I)?1:0,cn[I]=we(I);var I;function Ur(e,n){this.input=e,this.filename=n.filename||null,this.schema=n.schema||te,this.onWarning=n.onWarning||null,this.legacy=n.legacy||false,this.json=n.json||false,this.listener=n.listener||null,this.implicitTypes=this.schema.compiledImplicit,this.typeMap=this.schema.compiledTypeMap,this.length=e.length,this.position=0,this.line=0,this.lineStart=0,this.lineIndent=0,this.firstTabInLine=-1,this.documents=[];}function an(e,n){var r={name:e.filename,buffer:e.input.slice(0,-1),position:e.position,line:e.line,column:e.position-e.lineStart};return r.snippet=Gn(r),new w(n,r)}function d(e,n){throw an(e,n)}function q(e,n){e.onWarning&&e.onWarning.call(null,an(e,n));}var _e={YAML:function(n,r,o){var i,u,l;n.version!==null&&d(n,"duplication of %YAML directive"),o.length!==1&&d(n,"YAML directive accepts exactly one argument"),i=/^([0-9]+)\.([0-9]+)$/.exec(o[0]),i===null&&d(n,"ill-formed argument of the YAML directive"),u=parseInt(i[1],10),l=parseInt(i[2],10),u!==1&&d(n,"unacceptable YAML version of the document"),n.version=o[0],n.checkLineBreaks=l<2,l!==1&&l!==2&&q(n,"unsupported YAML version of the document");},TAG:function(n,r,o){var i,u;o.length!==2&&d(n,"TAG directive accepts exactly two arguments"),i=o[0],u=o[1],ln.test(i)||d(n,"ill-formed tag handle (first argument) of the TAG directive"),k.call(n.tagMap,i)&&d(n,'there is a previously declared suffix for "'+i+'" tag handle'),un.test(u)||d(n,"ill-formed tag prefix (second argument) of the TAG directive");try{u=decodeURIComponent(u);}catch{d(n,"tag prefix is malformed: "+u);}n.tagMap[i]=u;}};function T(e,n,r,o){var i,u,l,t;if(n<r){if(t=e.input.slice(n,r),o)for(i=0,u=t.length;i<u;i+=1)l=t.charCodeAt(i),l===9||32<=l&&l<=1114111||d(e,"expected valid JSON character");else Rr.test(t)&&d(e,"the stream contains non-printable characters");e.result+=t;}}function Se(e,n,r,o){var i,u,l,t;for(A.isObject(r)||d(e,"cannot merge mappings; the provided source object is unacceptable"),i=Object.keys(r),l=0,t=i.length;l<t;l+=1)u=i[l],k.call(n,u)||(tn(n,u,r[u]),o[u]=true);}function R(e,n,r,o,i,u,l,t,f){var c,s;if(Array.isArray(i))for(i=Array.prototype.slice.call(i),c=0,s=i.length;c<s;c+=1)Array.isArray(i[c])&&d(e,"nested arrays are not supported inside keys"),typeof i=="object"&&Ee(i[c])==="[object Object]"&&(i[c]="[object Object]");if(typeof i=="object"&&Ee(i)==="[object Object]"&&(i="[object Object]"),i=String(i),n===null&&(n={}),o==="tag:yaml.org,2002:merge")if(Array.isArray(u))for(c=0,s=u.length;c<s;c+=1)Se(e,n,u[c],r);else Se(e,n,u,r);else !e.json&&!k.call(r,i)&&k.call(n,i)&&(e.line=l||e.line,e.lineStart=t||e.lineStart,e.position=f||e.position,d(e,"duplicated mapping key")),tn(n,i,u),delete r[i];return n}function fe(e){var n;n=e.input.charCodeAt(e.position),n===10?e.position++:n===13?(e.position++,e.input.charCodeAt(e.position)===10&&e.position++):d(e,"a line break is expected"),e.line+=1,e.lineStart=e.position,e.firstTabInLine=-1;}function y(e,n,r){for(var o=0,i=e.input.charCodeAt(e.position);i!==0;){for(;L(i);)i===9&&e.firstTabInLine===-1&&(e.firstTabInLine=e.position),i=e.input.charCodeAt(++e.position);if(n&&i===35)do i=e.input.charCodeAt(++e.position);while(i!==10&&i!==13&&i!==0);if(b(i))for(fe(e),i=e.input.charCodeAt(e.position),o++,e.lineIndent=0;i===32;)e.lineIndent++,i=e.input.charCodeAt(++e.position);else break}return r!==-1&&o!==0&&e.lineIndent<r&&q(e,"deficient indentation"),o}function V(e){var n=e.position,r;return r=e.input.charCodeAt(n),!!((r===45||r===46)&&r===e.input.charCodeAt(n+1)&&r===e.input.charCodeAt(n+2)&&(n+=3,r=e.input.charCodeAt(n),r===0||_(r)))}function ce(e,n){n===1?e.result+=" ":n>1&&(e.result+=A.repeat(`
-`,n-1));}function Kr(e,n,r){var o,i,u,l,t,f,c,s,a=e.kind,h=e.result,p;if(p=e.input.charCodeAt(e.position),_(p)||M(p)||p===35||p===38||p===42||p===33||p===124||p===62||p===39||p===34||p===37||p===64||p===96||(p===63||p===45)&&(i=e.input.charCodeAt(e.position+1),_(i)||r&&M(i)))return  false;for(e.kind="scalar",e.result="",u=l=e.position,t=false;p!==0;){if(p===58){if(i=e.input.charCodeAt(e.position+1),_(i)||r&&M(i))break}else if(p===35){if(o=e.input.charCodeAt(e.position-1),_(o))break}else {if(e.position===e.lineStart&&V(e)||r&&M(p))break;if(b(p))if(f=e.line,c=e.lineStart,s=e.lineIndent,y(e,false,-1),e.lineIndent>=n){t=true,p=e.input.charCodeAt(e.position);continue}else {e.position=l,e.line=f,e.lineStart=c,e.lineIndent=s;break}}t&&(T(e,u,l,false),ce(e,e.line-f),u=l=e.position,t=false),L(p)||(l=e.position+1),p=e.input.charCodeAt(++e.position);}return T(e,u,l,false),e.result?true:(e.kind=a,e.result=h,false)}function $r(e,n){var r,o,i;if(r=e.input.charCodeAt(e.position),r!==39)return  false;for(e.kind="scalar",e.result="",e.position++,o=i=e.position;(r=e.input.charCodeAt(e.position))!==0;)if(r===39)if(T(e,o,e.position,true),r=e.input.charCodeAt(++e.position),r===39)o=e.position,e.position++,i=e.position;else return  true;else b(r)?(T(e,o,i,true),ce(e,y(e,false,n)),o=i=e.position):e.position===e.lineStart&&V(e)?d(e,"unexpected end of the document within a single quoted scalar"):(e.position++,i=e.position);d(e,"unexpected end of the stream within a single quoted scalar");}function qr(e,n){var r,o,i,u,l,t;if(t=e.input.charCodeAt(e.position),t!==34)return  false;for(e.kind="scalar",e.result="",e.position++,r=o=e.position;(t=e.input.charCodeAt(e.position))!==0;){if(t===34)return T(e,r,e.position,true),e.position++,true;if(t===92){if(T(e,r,e.position,true),t=e.input.charCodeAt(++e.position),b(t))y(e,false,n);else if(t<256&&fn[t])e.result+=cn[t],e.position++;else if((l=jr(t))>0){for(i=l,u=0;i>0;i--)t=e.input.charCodeAt(++e.position),(l=Yr(t))>=0?u=(u<<4)+l:d(e,"expected hexadecimal character");e.result+=Br(u),e.position++;}else d(e,"unknown escape sequence");r=o=e.position;}else b(t)?(T(e,r,o,true),ce(e,y(e,false,n)),r=o=e.position):e.position===e.lineStart&&V(e)?d(e,"unexpected end of the document within a double quoted scalar"):(e.position++,o=e.position);}d(e,"unexpected end of the stream within a double quoted scalar");}function Gr(e,n){var r=true,o,i,u,l=e.tag,t,f=e.anchor,c,s,a,h,p,m=Object.create(null),x,v,S,g;if(g=e.input.charCodeAt(e.position),g===91)s=93,p=false,t=[];else if(g===123)s=125,p=true,t={};else return  false;for(e.anchor!==null&&(e.anchorMap[e.anchor]=t),g=e.input.charCodeAt(++e.position);g!==0;){if(y(e,true,n),g=e.input.charCodeAt(e.position),g===s)return e.position++,e.tag=l,e.anchor=f,e.kind=p?"mapping":"sequence",e.result=t,true;r?g===44&&d(e,"expected the node content, but found ','"):d(e,"missed comma between flow collection entries"),v=x=S=null,a=h=false,g===63&&(c=e.input.charCodeAt(e.position+1),_(c)&&(a=h=true,e.position++,y(e,true,n))),o=e.line,i=e.lineStart,u=e.position,D(e,n,K,false,true),v=e.tag,x=e.result,y(e,true,n),g=e.input.charCodeAt(e.position),(h||e.line===o)&&g===58&&(a=true,g=e.input.charCodeAt(++e.position),y(e,true,n),D(e,n,K,false,true),S=e.result),p?R(e,t,m,v,x,S,o,i,u):a?t.push(R(e,null,m,v,x,S,o,i,u)):t.push(x),y(e,true,n),g=e.input.charCodeAt(e.position),g===44?(r=true,g=e.input.charCodeAt(++e.position)):r=false;}d(e,"unexpected end of the stream within a flow collection");}function Wr(e,n){var r,o,i=ee,u=false,l=false,t=n,f=0,c=false,s,a;if(a=e.input.charCodeAt(e.position),a===124)o=false;else if(a===62)o=true;else return  false;for(e.kind="scalar",e.result="";a!==0;)if(a=e.input.charCodeAt(++e.position),a===43||a===45)ee===i?i=a===43?Ce:Mr:d(e,"repeat of a chomping mode identifier");else if((s=Hr(a))>=0)s===0?d(e,"bad explicit indentation width of a block scalar; it cannot be less than one"):l?d(e,"repeat of an indentation width identifier"):(t=n+s-1,l=true);else break;if(L(a)){do a=e.input.charCodeAt(++e.position);while(L(a));if(a===35)do a=e.input.charCodeAt(++e.position);while(!b(a)&&a!==0)}for(;a!==0;){for(fe(e),e.lineIndent=0,a=e.input.charCodeAt(e.position);(!l||e.lineIndent<t)&&a===32;)e.lineIndent++,a=e.input.charCodeAt(++e.position);if(!l&&e.lineIndent>t&&(t=e.lineIndent),b(a)){f++;continue}if(e.lineIndent<t){i===Ce?e.result+=A.repeat(`
-`,u?1+f:f):i===ee&&u&&(e.result+=`
-`);break}for(o?L(a)?(c=true,e.result+=A.repeat(`
-`,u?1+f:f)):c?(c=false,e.result+=A.repeat(`
-`,f+1)):f===0?u&&(e.result+=" "):e.result+=A.repeat(`
-`,f):e.result+=A.repeat(`
-`,u?1+f:f),u=true,l=true,f=0,r=e.position;!b(a)&&a!==0;)a=e.input.charCodeAt(++e.position);T(e,r,e.position,false);}return  true}function be(e,n){var r,o=e.tag,i=e.anchor,u=[],l,t=false,f;if(e.firstTabInLine!==-1)return  false;for(e.anchor!==null&&(e.anchorMap[e.anchor]=u),f=e.input.charCodeAt(e.position);f!==0&&(e.firstTabInLine!==-1&&(e.position=e.firstTabInLine,d(e,"tab characters must not be used in indentation")),!(f!==45||(l=e.input.charCodeAt(e.position+1),!_(l))));){if(t=true,e.position++,y(e,true,-1)&&e.lineIndent<=n){u.push(null),f=e.input.charCodeAt(e.position);continue}if(r=e.line,D(e,n,on,false,true),u.push(e.result),y(e,true,-1),f=e.input.charCodeAt(e.position),(e.line===r||e.lineIndent>n)&&f!==0)d(e,"bad indentation of a sequence entry");else if(e.lineIndent<n)break}return t?(e.tag=o,e.anchor=i,e.kind="sequence",e.result=u,true):false}function Vr(e,n,r){var o,i,u,l,t,f,c=e.tag,s=e.anchor,a={},h=Object.create(null),p=null,m=null,x=null,v=false,S=false,g;if(e.firstTabInLine!==-1)return  false;for(e.anchor!==null&&(e.anchorMap[e.anchor]=a),g=e.input.charCodeAt(e.position);g!==0;){if(!v&&e.firstTabInLine!==-1&&(e.position=e.firstTabInLine,d(e,"tab characters must not be used in indentation")),o=e.input.charCodeAt(e.position+1),u=e.line,(g===63||g===58)&&_(o))g===63?(v&&(R(e,a,h,p,m,null,l,t,f),p=m=x=null),S=true,v=true,i=true):v?(v=false,i=true):d(e,"incomplete explicit mapping pair; a key node is missed; or followed by a non-tabulated empty line"),e.position+=1,g=o;else {if(l=e.line,t=e.lineStart,f=e.position,!D(e,r,rn,false,true))break;if(e.line===u){for(g=e.input.charCodeAt(e.position);L(g);)g=e.input.charCodeAt(++e.position);if(g===58)g=e.input.charCodeAt(++e.position),_(g)||d(e,"a whitespace character is expected after the key-value separator within a block mapping"),v&&(R(e,a,h,p,m,null,l,t,f),p=m=x=null),S=true,v=false,i=false,p=e.tag,m=e.result;else if(S)d(e,"can not read an implicit mapping pair; a colon is missed");else return e.tag=c,e.anchor=s,true}else if(S)d(e,"can not read a block mapping entry; a multiline key may not be an implicit key");else return e.tag=c,e.anchor=s,true}if((e.line===u||e.lineIndent>n)&&(v&&(l=e.line,t=e.lineStart,f=e.position),D(e,n,$,true,i)&&(v?m=e.result:x=e.result),v||(R(e,a,h,p,m,x,l,t,f),p=m=x=null),y(e,true,-1),g=e.input.charCodeAt(e.position)),(e.line===u||e.lineIndent>n)&&g!==0)d(e,"bad indentation of a mapping entry");else if(e.lineIndent<n)break}return v&&R(e,a,h,p,m,null,l,t,f),S&&(e.tag=c,e.anchor=s,e.kind="mapping",e.result=a),S}function Qr(e){var n,r=false,o=false,i,u,l;if(l=e.input.charCodeAt(e.position),l!==33)return  false;if(e.tag!==null&&d(e,"duplication of a tag property"),l=e.input.charCodeAt(++e.position),l===60?(r=true,l=e.input.charCodeAt(++e.position)):l===33?(o=true,i="!!",l=e.input.charCodeAt(++e.position)):i="!",n=e.position,r){do l=e.input.charCodeAt(++e.position);while(l!==0&&l!==62);e.position<e.length?(u=e.input.slice(n,e.position),l=e.input.charCodeAt(++e.position)):d(e,"unexpected end of the stream within a verbatim tag");}else {for(;l!==0&&!_(l);)l===33&&(o?d(e,"tag suffix cannot contain exclamation marks"):(i=e.input.slice(n-1,e.position+1),ln.test(i)||d(e,"named tag handle cannot contain such characters"),o=true,n=e.position+1)),l=e.input.charCodeAt(++e.position);u=e.input.slice(n,e.position),Pr.test(u)&&d(e,"tag suffix cannot contain flow indicator characters");}u&&!un.test(u)&&d(e,"tag name cannot contain such characters: "+u);try{u=decodeURIComponent(u);}catch{d(e,"tag name is malformed: "+u);}return r?e.tag=u:k.call(e.tagMap,i)?e.tag=e.tagMap[i]+u:i==="!"?e.tag="!"+u:i==="!!"?e.tag="tag:yaml.org,2002:"+u:d(e,'undeclared tag handle "'+i+'"'),true}function Xr(e){var n,r;if(r=e.input.charCodeAt(e.position),r!==38)return  false;for(e.anchor!==null&&d(e,"duplication of an anchor property"),r=e.input.charCodeAt(++e.position),n=e.position;r!==0&&!_(r)&&!M(r);)r=e.input.charCodeAt(++e.position);return e.position===n&&d(e,"name of an anchor node must contain at least one character"),e.anchor=e.input.slice(n,e.position),true}function Zr(e){var n,r,o;if(o=e.input.charCodeAt(e.position),o!==42)return  false;for(o=e.input.charCodeAt(++e.position),n=e.position;o!==0&&!_(o)&&!M(o);)o=e.input.charCodeAt(++e.position);return e.position===n&&d(e,"name of an alias node must contain at least one character"),r=e.input.slice(n,e.position),k.call(e.anchorMap,r)||d(e,'unidentified alias "'+r+'"'),e.result=e.anchorMap[r],y(e,true,-1),true}function D(e,n,r,o,i){var u,l,t,f=1,c=false,s=false,a,h,p,m,x,v;if(e.listener!==null&&e.listener("open",e),e.tag=null,e.anchor=null,e.kind=null,e.result=null,u=l=t=$===r||on===r,o&&y(e,true,-1)&&(c=true,e.lineIndent>n?f=1:e.lineIndent===n?f=0:e.lineIndent<n&&(f=-1)),f===1)for(;Qr(e)||Xr(e);)y(e,true,-1)?(c=true,t=u,e.lineIndent>n?f=1:e.lineIndent===n?f=0:e.lineIndent<n&&(f=-1)):t=false;if(t&&(t=c||i),(f===1||$===r)&&(K===r||rn===r?x=n:x=n+1,v=e.position-e.lineStart,f===1?t&&(be(e,v)||Vr(e,v,x))||Gr(e,x)?s=true:(l&&Wr(e,x)||$r(e,x)||qr(e,x)?s=true:Zr(e)?(s=true,(e.tag!==null||e.anchor!==null)&&d(e,"alias node should not have any properties")):Kr(e,x,K===r)&&(s=true,e.tag===null&&(e.tag="?")),e.anchor!==null&&(e.anchorMap[e.anchor]=e.result)):f===0&&(s=t&&be(e,v))),e.tag===null)e.anchor!==null&&(e.anchorMap[e.anchor]=e.result);else if(e.tag==="?"){for(e.result!==null&&e.kind!=="scalar"&&d(e,'unacceptable node kind for !<?> tag; it should be "scalar", not "'+e.kind+'"'),a=0,h=e.implicitTypes.length;a<h;a+=1)if(m=e.implicitTypes[a],m.resolve(e.result)){e.result=m.construct(e.result),e.tag=m.tag,e.anchor!==null&&(e.anchorMap[e.anchor]=e.result);break}}else if(e.tag!=="!"){if(k.call(e.typeMap[e.kind||"fallback"],e.tag))m=e.typeMap[e.kind||"fallback"][e.tag];else for(m=null,p=e.typeMap.multi[e.kind||"fallback"],a=0,h=p.length;a<h;a+=1)if(e.tag.slice(0,p[a].tag.length)===p[a].tag){m=p[a];break}m||d(e,"unknown tag !<"+e.tag+">"),e.result!==null&&m.kind!==e.kind&&d(e,"unacceptable node kind for !<"+e.tag+'> tag; it should be "'+m.kind+'", not "'+e.kind+'"'),m.resolve(e.result,e.tag)?(e.result=m.construct(e.result,e.tag),e.anchor!==null&&(e.anchorMap[e.anchor]=e.result)):d(e,"cannot resolve a node with !<"+e.tag+"> explicit tag");}return e.listener!==null&&e.listener("close",e),e.tag!==null||e.anchor!==null||s}function zr(e){var n=e.position,r,o,i,u=false,l;for(e.version=null,e.checkLineBreaks=e.legacy,e.tagMap=Object.create(null),e.anchorMap=Object.create(null);(l=e.input.charCodeAt(e.position))!==0&&(y(e,true,-1),l=e.input.charCodeAt(e.position),!(e.lineIndent>0||l!==37));){for(u=true,l=e.input.charCodeAt(++e.position),r=e.position;l!==0&&!_(l);)l=e.input.charCodeAt(++e.position);for(o=e.input.slice(r,e.position),i=[],o.length<1&&d(e,"directive name must not be less than one character in length");l!==0;){for(;L(l);)l=e.input.charCodeAt(++e.position);if(l===35){do l=e.input.charCodeAt(++e.position);while(l!==0&&!b(l));break}if(b(l))break;for(r=e.position;l!==0&&!_(l);)l=e.input.charCodeAt(++e.position);i.push(e.input.slice(r,e.position));}l!==0&&fe(e),k.call(_e,o)?_e[o](e,o,i):q(e,'unknown document directive "'+o+'"');}if(y(e,true,-1),e.lineIndent===0&&e.input.charCodeAt(e.position)===45&&e.input.charCodeAt(e.position+1)===45&&e.input.charCodeAt(e.position+2)===45?(e.position+=3,y(e,true,-1)):u&&d(e,"directives end mark is expected"),D(e,e.lineIndent-1,$,false,true),y(e,true,-1),e.checkLineBreaks&&Dr.test(e.input.slice(n,e.position))&&q(e,"non-ASCII line breaks are interpreted as content"),e.documents.push(e.result),e.position===e.lineStart&&V(e)){e.input.charCodeAt(e.position)===46&&(e.position+=3,y(e,true,-1));return}if(e.position<e.length-1)d(e,"end of the stream or a document separator is expected");else return}function pn(e,n){e=String(e),n=n||{},e.length!==0&&(e.charCodeAt(e.length-1)!==10&&e.charCodeAt(e.length-1)!==13&&(e+=`
-`),e.charCodeAt(0)===65279&&(e=e.slice(1)));var r=new Ur(e,n),o=e.indexOf("\0");for(o!==-1&&(r.position=o,d(r,"null byte is not allowed in input")),r.input+="\0";r.input.charCodeAt(r.position)===32;)r.lineIndent+=1,r.position+=1;for(;r.position<r.length-1;)zr(r);return r.documents}function Jr(e,n,r){n!==null&&typeof n=="object"&&typeof r>"u"&&(r=n,n=null);var o=pn(e,r);if(typeof n!="function")return o;for(var i=0,u=o.length;i<u;i+=1)n(o[i]);}function ei(e,n){var r=pn(e,n);if(r.length!==0){if(r.length===1)return r[0];throw new w("expected a single document in the stream, but found more")}}var ni=Jr,ri=ei,sn={loadAll:ni,load:ri},dn=Object.prototype.toString,hn=Object.prototype.hasOwnProperty,ae=65279,ii=9,j=10,oi=13,li=32,ui=33,ti=34,re=35,fi=37,ci=38,ai=39,pi=42,mn=44,si=45,G=58,di=61,hi=62,mi=63,gi=64,gn=91,xn=93,xi=96,vn=123,vi=124,yn=125,E={};E[0]="\\0";E[7]="\\a";E[8]="\\b";E[9]="\\t";E[10]="\\n";E[11]="\\v";E[12]="\\f";E[13]="\\r";E[27]="\\e";E[34]='\\"';E[92]="\\\\";E[133]="\\N";E[160]="\\_";E[8232]="\\L";E[8233]="\\P";var yi=["y","Y","yes","Yes","YES","on","On","ON","n","N","no","No","NO","off","Off","OFF"],Ai=/^[-+]?[0-9_]+(?::[0-9_]+)+(?:\.[0-9_]*)?$/;function Ci(e,n){var r,o,i,u,l,t,f;if(n===null)return {};for(r={},o=Object.keys(n),i=0,u=o.length;i<u;i+=1)l=o[i],t=String(n[l]),l.slice(0,2)==="!!"&&(l="tag:yaml.org,2002:"+l.slice(2)),f=e.compiledTypeMap.fallback[l],f&&hn.call(f.styleAliases,t)&&(t=f.styleAliases[t]),r[l]=t;return r}function Ei(e){var n,r,o;if(n=e.toString(16).toUpperCase(),e<=255)r="x",o=2;else if(e<=65535)r="u",o=4;else if(e<=4294967295)r="U",o=8;else throw new w("code point within a string may not be greater than 0xFFFFFFFF");return "\\"+r+A.repeat("0",o-n.length)+n}var wi=1,H=2;function _i(e){this.schema=e.schema||te,this.indent=Math.max(1,e.indent||2),this.noArrayIndent=e.noArrayIndent||false,this.skipInvalid=e.skipInvalid||false,this.flowLevel=A.isNothing(e.flowLevel)?-1:e.flowLevel,this.styleMap=Ci(this.schema,e.styles||null),this.sortKeys=e.sortKeys||false,this.lineWidth=e.lineWidth||80,this.noRefs=e.noRefs||false,this.noCompatMode=e.noCompatMode||false,this.condenseFlow=e.condenseFlow||false,this.quotingType=e.quotingType==='"'?H:wi,this.forceQuotes=e.forceQuotes||false,this.replacer=typeof e.replacer=="function"?e.replacer:null,this.implicitTypes=this.schema.compiledImplicit,this.explicitTypes=this.schema.compiledExplicit,this.tag=null,this.result="",this.duplicates=[],this.usedDuplicates=null;}function Fe(e,n){for(var r=A.repeat(" ",n),o=0,i=-1,u="",l,t=e.length;o<t;)i=e.indexOf(`
-`,o),i===-1?(l=e.slice(o),o=t):(l=e.slice(o,i+1),o=i+1),l.length&&l!==`
-`&&(u+=r),u+=l;return u}function ie(e,n){return `
-`+A.repeat(" ",e.indent*n)}function Si(e,n){var r,o,i;for(r=0,o=e.implicitTypes.length;r<o;r+=1)if(i=e.implicitTypes[r],i.resolve(n))return  true;return  false}function W(e){return e===li||e===ii}function B(e){return 32<=e&&e<=126||161<=e&&e<=55295&&e!==8232&&e!==8233||57344<=e&&e<=65533&&e!==ae||65536<=e&&e<=1114111}function Te(e){return B(e)&&e!==ae&&e!==oi&&e!==j}function ke(e,n,r){var o=Te(e),i=o&&!W(e);return (r?o:o&&e!==mn&&e!==gn&&e!==xn&&e!==vn&&e!==yn)&&e!==re&&!(n===G&&!i)||Te(n)&&!W(n)&&e===re||n===G&&i}function bi(e){return B(e)&&e!==ae&&!W(e)&&e!==si&&e!==mi&&e!==G&&e!==mn&&e!==gn&&e!==xn&&e!==vn&&e!==yn&&e!==re&&e!==ci&&e!==pi&&e!==ui&&e!==vi&&e!==di&&e!==hi&&e!==ai&&e!==ti&&e!==fi&&e!==gi&&e!==xi}function Fi(e){return !W(e)&&e!==G}function P(e,n){var r=e.charCodeAt(n),o;return r>=55296&&r<=56319&&n+1<e.length&&(o=e.charCodeAt(n+1),o>=56320&&o<=57343)?(r-55296)*1024+o-56320+65536:r}function An(e){var n=/^\n* /;return n.test(e)}var Cn=1,oe=2,En=3,wn=4,N=5;function Ti(e,n,r,o,i,u,l,t){var f,c=0,s=null,a=false,h=false,p=o!==-1,m=-1,x=bi(P(e,0))&&Fi(P(e,e.length-1));if(n||l)for(f=0;f<e.length;c>=65536?f+=2:f++){if(c=P(e,f),!B(c))return N;x=x&&ke(c,s,t),s=c;}else {for(f=0;f<e.length;c>=65536?f+=2:f++){if(c=P(e,f),c===j)a=true,p&&(h=h||f-m-1>o&&e[m+1]!==" ",m=f);else if(!B(c))return N;x=x&&ke(c,s,t),s=c;}h=h||p&&f-m-1>o&&e[m+1]!==" ";}return !a&&!h?x&&!l&&!i(e)?Cn:u===H?N:oe:r>9&&An(e)?N:l?u===H?N:oe:h?wn:En}function ki(e,n,r,o,i){e.dump=(function(){if(n.length===0)return e.quotingType===H?'""':"''";if(!e.noCompatMode&&(yi.indexOf(n)!==-1||Ai.test(n)))return e.quotingType===H?'"'+n+'"':"'"+n+"'";var u=e.indent*Math.max(1,r),l=e.lineWidth===-1?-1:Math.max(Math.min(e.lineWidth,40),e.lineWidth-u),t=o||e.flowLevel>-1&&r>=e.flowLevel;function f(c){return Si(e,c)}switch(Ti(n,t,e.indent,l,f,e.quotingType,e.forceQuotes&&!o,i)){case Cn:return n;case oe:return "'"+n.replace(/'/g,"''")+"'";case En:return "|"+Oe(n,e.indent)+Ie(Fe(n,u));case wn:return ">"+Oe(n,e.indent)+Ie(Fe(Oi(n,l),u));case N:return '"'+Ii(n)+'"';default:throw new w("impossible error: invalid scalar style")}})();}function Oe(e,n){var r=An(e)?String(n):"",o=e[e.length-1]===`
-`,i=o&&(e[e.length-2]===`
-`||e===`
-`),u=i?"+":o?"":"-";return r+u+`
-`}function Ie(e){return e[e.length-1]===`
-`?e.slice(0,-1):e}function Oi(e,n){for(var r=/(\n+)([^\n]*)/g,o=(function(){var c=e.indexOf(`
-`);return c=c!==-1?c:e.length,r.lastIndex=c,Le(e.slice(0,c),n)})(),i=e[0]===`
-`||e[0]===" ",u,l;l=r.exec(e);){var t=l[1],f=l[2];u=f[0]===" ",o+=t+(!i&&!u&&f!==""?`
-`:"")+Le(f,n),i=u;}return o}function Le(e,n){if(e===""||e[0]===" ")return e;for(var r=/ [^ ]/g,o,i=0,u,l=0,t=0,f="";o=r.exec(e);)t=o.index,t-i>n&&(u=l>i?l:t,f+=`
-`+e.slice(i,u),i=u+1),l=t;return f+=`
-`,e.length-i>n&&l>i?f+=e.slice(i,l)+`
-`+e.slice(l+1):f+=e.slice(i),f.slice(1)}function Ii(e){for(var n="",r=0,o,i=0;i<e.length;r>=65536?i+=2:i++)r=P(e,i),o=E[r],!o&&B(r)?(n+=e[i],r>=65536&&(n+=e[i+1])):n+=o||Ei(r);return n}function Li(e,n,r){var o="",i=e.tag,u,l,t;for(u=0,l=r.length;u<l;u+=1)t=r[u],e.replacer&&(t=e.replacer.call(r,String(u),t)),(F(e,n,t,false,false)||typeof t>"u"&&F(e,n,null,false,false))&&(o!==""&&(o+=","+(e.condenseFlow?"":" ")),o+=e.dump);e.tag=i,e.dump="["+o+"]";}function Ne(e,n,r,o){var i="",u=e.tag,l,t,f;for(l=0,t=r.length;l<t;l+=1)f=r[l],e.replacer&&(f=e.replacer.call(r,String(l),f)),(F(e,n+1,f,true,true,false,true)||typeof f>"u"&&F(e,n+1,null,true,true,false,true))&&((!o||i!=="")&&(i+=ie(e,n)),e.dump&&j===e.dump.charCodeAt(0)?i+="-":i+="- ",i+=e.dump);e.tag=u,e.dump=i||"[]";}function Ni(e,n,r){var o="",i=e.tag,u=Object.keys(r),l,t,f,c,s;for(l=0,t=u.length;l<t;l+=1)s="",o!==""&&(s+=", "),e.condenseFlow&&(s+='"'),f=u[l],c=r[f],e.replacer&&(c=e.replacer.call(r,f,c)),F(e,n,f,false,false)&&(e.dump.length>1024&&(s+="? "),s+=e.dump+(e.condenseFlow?'"':"")+":"+(e.condenseFlow?"":" "),F(e,n,c,false,false)&&(s+=e.dump,o+=s));e.tag=i,e.dump="{"+o+"}";}function Mi(e,n,r,o){var i="",u=e.tag,l=Object.keys(r),t,f,c,s,a,h;if(e.sortKeys===true)l.sort();else if(typeof e.sortKeys=="function")l.sort(e.sortKeys);else if(e.sortKeys)throw new w("sortKeys must be a boolean or a function");for(t=0,f=l.length;t<f;t+=1)h="",(!o||i!=="")&&(h+=ie(e,n)),c=l[t],s=r[c],e.replacer&&(s=e.replacer.call(r,c,s)),F(e,n+1,c,true,true,true)&&(a=e.tag!==null&&e.tag!=="?"||e.dump&&e.dump.length>1024,a&&(e.dump&&j===e.dump.charCodeAt(0)?h+="?":h+="? "),h+=e.dump,a&&(h+=ie(e,n)),F(e,n+1,s,true,a)&&(e.dump&&j===e.dump.charCodeAt(0)?h+=":":h+=": ",h+=e.dump,i+=h));e.tag=u,e.dump=i||"{}";}function Me(e,n,r){var o,i,u,l,t,f;for(i=r?e.explicitTypes:e.implicitTypes,u=0,l=i.length;u<l;u+=1)if(t=i[u],(t.instanceOf||t.predicate)&&(!t.instanceOf||typeof n=="object"&&n instanceof t.instanceOf)&&(!t.predicate||t.predicate(n))){if(r?t.multi&&t.representName?e.tag=t.representName(n):e.tag=t.tag:e.tag="?",t.represent){if(f=e.styleMap[t.tag]||t.defaultStyle,dn.call(t.represent)==="[object Function]")o=t.represent(n,f);else if(hn.call(t.represent,f))o=t.represent[f](n,f);else throw new w("!<"+t.tag+'> tag resolver accepts not "'+f+'" style');e.dump=o;}return  true}return  false}function F(e,n,r,o,i,u,l){e.tag=null,e.dump=r,Me(e,r,false)||Me(e,r,true);var t=dn.call(e.dump),f=o,c;o&&(o=e.flowLevel<0||e.flowLevel>n);var s=t==="[object Object]"||t==="[object Array]",a,h;if(s&&(a=e.duplicates.indexOf(r),h=a!==-1),(e.tag!==null&&e.tag!=="?"||h||e.indent!==2&&n>0)&&(i=false),h&&e.usedDuplicates[a])e.dump="*ref_"+a;else {if(s&&h&&!e.usedDuplicates[a]&&(e.usedDuplicates[a]=true),t==="[object Object]")o&&Object.keys(e.dump).length!==0?(Mi(e,n,e.dump,i),h&&(e.dump="&ref_"+a+e.dump)):(Ni(e,n,e.dump),h&&(e.dump="&ref_"+a+" "+e.dump));else if(t==="[object Array]")o&&e.dump.length!==0?(e.noArrayIndent&&!l&&n>0?Ne(e,n-1,e.dump,i):Ne(e,n,e.dump,i),h&&(e.dump="&ref_"+a+e.dump)):(Li(e,n,e.dump),h&&(e.dump="&ref_"+a+" "+e.dump));else if(t==="[object String]")e.tag!=="?"&&ki(e,e.dump,n,u,f);else {if(t==="[object Undefined]")return  false;if(e.skipInvalid)return  false;throw new w("unacceptable kind of an object to dump "+t)}e.tag!==null&&e.tag!=="?"&&(c=encodeURI(e.tag[0]==="!"?e.tag.slice(1):e.tag).replace(/!/g,"%21"),e.tag[0]==="!"?c="!"+c:c.slice(0,18)==="tag:yaml.org,2002:"?c="!!"+c.slice(18):c="!<"+c+">",e.dump=c+" "+e.dump);}return  true}function Ri(e,n){var r=[],o=[],i,u;for(le(e,r,o),i=0,u=o.length;i<u;i+=1)n.duplicates.push(r[o[i]]);n.usedDuplicates=new Array(u);}function le(e,n,r){var o,i,u;if(e!==null&&typeof e=="object")if(i=n.indexOf(e),i!==-1)r.indexOf(i)===-1&&r.push(i);else if(n.push(e),Array.isArray(e))for(i=0,u=e.length;i<u;i+=1)le(e[i],n,r);else for(o=Object.keys(e),i=0,u=o.length;i<u;i+=1)le(e[o[i]],n,r);}function Di(e,n){n=n||{};var r=new _i(n);r.noRefs||Ri(e,r);var o=e;return r.replacer&&(o=r.replacer.call({"":o},"",o)),F(r,0,o,true,true)?r.dump+`
-`:""}var Pi=Di,Yi={dump:Pi};function pe(e,n){return function(){throw new Error("Function yaml."+e+" is removed in js-yaml 4. Use yaml."+n+" instead, which is now safe by default.")}}var ji=C,Hi=Pe,Bi=Be,Ui=Ge,Ki=We,$i=te,qi=sn.load,Gi=sn.loadAll,Wi=Yi.dump,Vi=w,Qi={binary:ze,float:qe,map:He,null:Ue,pairs:en,set:nn,timestamp:Xe,bool:Ke,int:$e,merge:Ze,omap:Je,seq:je,str:Ye},Xi=pe("safeLoad","load"),Zi=pe("safeLoadAll","loadAll"),zi=pe("safeDump","dump"),O={Type:ji,Schema:Hi,FAILSAFE_SCHEMA:Bi,JSON_SCHEMA:Ui,CORE_SCHEMA:Ki,DEFAULT_SCHEMA:$i,load:qi,loadAll:Gi,dump:Wi,YAMLException:Vi,types:Qi,safeLoad:Xi,safeLoadAll:Zi,safeDump:zi};function Ji(e){return new O.Type(`!${e}`,{kind:"mapping",construct(n){return {tag:e,config:n??{}}},instanceOf:Object,represent(n){return n.config}})}function eo(e){return new O.Type(`!${e}`,{kind:"scalar",construct(){return {tag:e,config:{}}},instanceOf:Object,represent(){return ""}})}var _n=["secret","gcp","aws","age","sops"],no=_n.map(e=>Ji(e)),ro=_n.map(e=>eo(e)),Q=O.DEFAULT_SCHEMA.extend([...ro,...no]);function Sn(e){return typeof e=="object"&&e!==null&&"tag"in e&&"config"in e&&typeof e.tag=="string"}function U(e,n=""){let r={};for(let[o,i]of Object.entries(e)){let u=n?`${n}/${o}`:o;typeof i=="object"&&i!==null&&!Array.isArray(i)&&!("tag"in i&&"config"in i)?Object.assign(r,U(i,u)):r[u]=i;}return r}function bn(e){let n=O.load(e,{schema:Q});if(!n||typeof n!="object")return {overrides:{}};let r=n,o=se(r["default-provider"]),i=r.keys;if(i!=null&&typeof i!="object")throw new Error('Environment file "keys:" must be a mapping');let l=U(i??{}),t={};for(let[f,c]of Object.entries(l))c!=null&&(t[f]=c);return {defaultProvider:o,overrides:t}}function se(e){if(!e||typeof e!="object")return;let n=e,r=n.name;if(typeof r!="string")return;let o={};for(let[i,u]of Object.entries(n))i!=="name"&&(o[i]=u);return {name:r,options:o}}function Fn(e){let n=O.load(e,{schema:Q});if(!n||typeof n!="object")throw new Error('keyshelf.yaml must contain a "keys:" block defining your keys');let r=n;if(!("keys"in r)||r.keys==null||typeof r.keys!="object")throw new Error('keyshelf.yaml must contain a "keys:" block defining your keys');let o=se(r["default-provider"]),i;if("name"in r&&r.name!==void 0){if(typeof r.name!="string"||r.name==="")throw new Error('keyshelf.yaml "name" must be a non-empty string');if(!/^[a-zA-Z0-9_-]+$/.test(r.name))throw new Error('keyshelf.yaml "name" must contain only letters, digits, hyphens, and underscores');i=r.name;}let u=U(r.keys),l=[];for(let[t,f]of Object.entries(u))if(Sn(f))l.push({path:t,isSecret:true,optional:f.tag==="secret"&&f.config.optional===true});else {if(f!=null&&typeof f=="object")throw new Error(`Unexpected object value at "${t}" in schema. Use nested keys or a tag instead.`);l.push({path:t,isSecret:false,optional:false,defaultValue:f==null?void 0:String(f)});}return {keys:l,config:{name:i,provider:o}}}var de=/\$\{([^}]+)\}/g;function Tn(e){let n=[];for(let r of e.split(`
-`)){let o=r.trim();if(!o||o.startsWith("#"))continue;let i=o.indexOf("=");if(i===-1)continue;let u=o.slice(0,i).trim(),l=o.slice(i+1).trim();if(!(!u||!l))if(de.test(l)){de.lastIndex=0;let t=[...l.matchAll(de)].map(f=>f[1].trim());n.push({envVar:u,template:l,keyPaths:t});}else n.push({envVar:u,keyPath:l});}return n}var me="keyshelf.yaml",lo=".keyshelf",uo=".env.keyshelf";function On(e){let n=resolve(e);for(;;){if(existsSync(join(n,me)))return n;let r=dirname(n);if(r===n)throw new Error(`Could not find ${me} in ${e} or any parent directory`);n=r;}}async function ge(e,n,r){let o=On(e),i=join(o,me),u=await readFile(i,"utf-8"),l=Fn(u),t=l.keys,f=join(o,lo,`${n}.yaml`),c;try{let p=await readFile(f,"utf-8");c=bn(p);}catch(p){throw p.code==="ENOENT"?new Error(`Environment file not found: ${f}`,{cause:p}):p}let s=join(e,uo),a;try{let p=await readFile(s,"utf-8");a=Tn(p);}catch(p){if(p.code==="ENOENT"){a=[];}else throw p}let h=l.config.provider;if(h&&!c.defaultProvider)c={...c,defaultProvider:h};else if(h&&c.defaultProvider){let p=c.defaultProvider;c={...c,defaultProvider:{name:p.name,options:{...h.name===p.name?h.options:{},...p.options}}};}return {rootDir:o,name:l.config.name,schema:t,env:c,appMapping:a}}var ve=process.env.KEYSHELF_ENV,In=process.env.KEYSHELF_IDENTITY,go=process.env.KEYSHELF_CWD||process.cwd();ve||Nn("KEYSHELF_ENV is required");In||(process.stdout.write(`No identity provided; skipping identity write.
-`),process.exit(0));var Ln=await ge(go,ve),ye=Ln.env.defaultProvider;ye||Nn(`Environment "${ve}" has no default-provider configured`);var xe=ye.options?.identityFile;(typeof xe!="string"||xe.length===0)&&(process.stdout.write(`::warning::'identity' input was provided but provider "${ye.name}" does not declare an identityFile (e.g. gcp). Ignoring.
-`),process.exit(0));var Z=xo(xe,Ln.rootDir);await mkdir(dirname(Z),{recursive:true});await writeFile(Z,vo(In),{mode:384});await chmod(Z,384);process.stdout.write(`Wrote identity to ${Z} (mode 0600)
-`);function xo(e,n){return e==="~"||e.startsWith("~/")?join(homedir(),e.slice(1)):isAbsolute(e)?e:resolve(n,e)}function vo(e){return e.endsWith(`
-`)?e:e+`
-`}function Nn(e){process.stderr.write(`::error::${e}
-`),process.exit(1);}
+// ../../node_modules/js-yaml/dist/js-yaml.mjs
+function isNothing(subject) {
+  return typeof subject === "undefined" || subject === null;
+}
+function isObject(subject) {
+  return typeof subject === "object" && subject !== null;
+}
+function toArray(sequence) {
+  if (Array.isArray(sequence)) return sequence;
+  else if (isNothing(sequence)) return [];
+  return [sequence];
+}
+function extend(target2, source) {
+  var index, length, key, sourceKeys;
+  if (source) {
+    sourceKeys = Object.keys(source);
+    for (index = 0, length = sourceKeys.length; index < length; index += 1) {
+      key = sourceKeys[index];
+      target2[key] = source[key];
+    }
+  }
+  return target2;
+}
+function repeat(string, count) {
+  var result = "", cycle;
+  for (cycle = 0; cycle < count; cycle += 1) {
+    result += string;
+  }
+  return result;
+}
+function isNegativeZero(number) {
+  return number === 0 && Number.NEGATIVE_INFINITY === 1 / number;
+}
+var isNothing_1 = isNothing;
+var isObject_1 = isObject;
+var toArray_1 = toArray;
+var repeat_1 = repeat;
+var isNegativeZero_1 = isNegativeZero;
+var extend_1 = extend;
+var common = {
+  isNothing: isNothing_1,
+  isObject: isObject_1,
+  toArray: toArray_1,
+  repeat: repeat_1,
+  isNegativeZero: isNegativeZero_1,
+  extend: extend_1
+};
+function formatError(exception2, compact) {
+  var where = "", message = exception2.reason || "(unknown reason)";
+  if (!exception2.mark) return message;
+  if (exception2.mark.name) {
+    where += 'in "' + exception2.mark.name + '" ';
+  }
+  where += "(" + (exception2.mark.line + 1) + ":" + (exception2.mark.column + 1) + ")";
+  if (!compact && exception2.mark.snippet) {
+    where += "\n\n" + exception2.mark.snippet;
+  }
+  return message + " " + where;
+}
+function YAMLException$1(reason, mark) {
+  Error.call(this);
+  this.name = "YAMLException";
+  this.reason = reason;
+  this.mark = mark;
+  this.message = formatError(this, false);
+  if (Error.captureStackTrace) {
+    Error.captureStackTrace(this, this.constructor);
+  } else {
+    this.stack = new Error().stack || "";
+  }
+}
+YAMLException$1.prototype = Object.create(Error.prototype);
+YAMLException$1.prototype.constructor = YAMLException$1;
+YAMLException$1.prototype.toString = function toString(compact) {
+  return this.name + ": " + formatError(this, compact);
+};
+var exception = YAMLException$1;
+function getLine(buffer, lineStart, lineEnd, position, maxLineLength) {
+  var head = "";
+  var tail = "";
+  var maxHalfLength = Math.floor(maxLineLength / 2) - 1;
+  if (position - lineStart > maxHalfLength) {
+    head = " ... ";
+    lineStart = position - maxHalfLength + head.length;
+  }
+  if (lineEnd - position > maxHalfLength) {
+    tail = " ...";
+    lineEnd = position + maxHalfLength - tail.length;
+  }
+  return {
+    str: head + buffer.slice(lineStart, lineEnd).replace(/\t/g, "\u2192") + tail,
+    pos: position - lineStart + head.length
+    // relative position
+  };
+}
+function padStart(string, max) {
+  return common.repeat(" ", max - string.length) + string;
+}
+function makeSnippet(mark, options) {
+  options = Object.create(options || null);
+  if (!mark.buffer) return null;
+  if (!options.maxLength) options.maxLength = 79;
+  if (typeof options.indent !== "number") options.indent = 1;
+  if (typeof options.linesBefore !== "number") options.linesBefore = 3;
+  if (typeof options.linesAfter !== "number") options.linesAfter = 2;
+  var re = /\r?\n|\r|\0/g;
+  var lineStarts = [0];
+  var lineEnds = [];
+  var match;
+  var foundLineNo = -1;
+  while (match = re.exec(mark.buffer)) {
+    lineEnds.push(match.index);
+    lineStarts.push(match.index + match[0].length);
+    if (mark.position <= match.index && foundLineNo < 0) {
+      foundLineNo = lineStarts.length - 2;
+    }
+  }
+  if (foundLineNo < 0) foundLineNo = lineStarts.length - 1;
+  var result = "", i, line;
+  var lineNoLength = Math.min(mark.line + options.linesAfter, lineEnds.length).toString().length;
+  var maxLineLength = options.maxLength - (options.indent + lineNoLength + 3);
+  for (i = 1; i <= options.linesBefore; i++) {
+    if (foundLineNo - i < 0) break;
+    line = getLine(
+      mark.buffer,
+      lineStarts[foundLineNo - i],
+      lineEnds[foundLineNo - i],
+      mark.position - (lineStarts[foundLineNo] - lineStarts[foundLineNo - i]),
+      maxLineLength
+    );
+    result = common.repeat(" ", options.indent) + padStart((mark.line - i + 1).toString(), lineNoLength) + " | " + line.str + "\n" + result;
+  }
+  line = getLine(mark.buffer, lineStarts[foundLineNo], lineEnds[foundLineNo], mark.position, maxLineLength);
+  result += common.repeat(" ", options.indent) + padStart((mark.line + 1).toString(), lineNoLength) + " | " + line.str + "\n";
+  result += common.repeat("-", options.indent + lineNoLength + 3 + line.pos) + "^\n";
+  for (i = 1; i <= options.linesAfter; i++) {
+    if (foundLineNo + i >= lineEnds.length) break;
+    line = getLine(
+      mark.buffer,
+      lineStarts[foundLineNo + i],
+      lineEnds[foundLineNo + i],
+      mark.position - (lineStarts[foundLineNo] - lineStarts[foundLineNo + i]),
+      maxLineLength
+    );
+    result += common.repeat(" ", options.indent) + padStart((mark.line + i + 1).toString(), lineNoLength) + " | " + line.str + "\n";
+  }
+  return result.replace(/\n$/, "");
+}
+var snippet = makeSnippet;
+var TYPE_CONSTRUCTOR_OPTIONS = [
+  "kind",
+  "multi",
+  "resolve",
+  "construct",
+  "instanceOf",
+  "predicate",
+  "represent",
+  "representName",
+  "defaultStyle",
+  "styleAliases"
+];
+var YAML_NODE_KINDS = [
+  "scalar",
+  "sequence",
+  "mapping"
+];
+function compileStyleAliases(map2) {
+  var result = {};
+  if (map2 !== null) {
+    Object.keys(map2).forEach(function(style) {
+      map2[style].forEach(function(alias) {
+        result[String(alias)] = style;
+      });
+    });
+  }
+  return result;
+}
+function Type$1(tag, options) {
+  options = options || {};
+  Object.keys(options).forEach(function(name) {
+    if (TYPE_CONSTRUCTOR_OPTIONS.indexOf(name) === -1) {
+      throw new exception('Unknown option "' + name + '" is met in definition of "' + tag + '" YAML type.');
+    }
+  });
+  this.options = options;
+  this.tag = tag;
+  this.kind = options["kind"] || null;
+  this.resolve = options["resolve"] || function() {
+    return true;
+  };
+  this.construct = options["construct"] || function(data) {
+    return data;
+  };
+  this.instanceOf = options["instanceOf"] || null;
+  this.predicate = options["predicate"] || null;
+  this.represent = options["represent"] || null;
+  this.representName = options["representName"] || null;
+  this.defaultStyle = options["defaultStyle"] || null;
+  this.multi = options["multi"] || false;
+  this.styleAliases = compileStyleAliases(options["styleAliases"] || null);
+  if (YAML_NODE_KINDS.indexOf(this.kind) === -1) {
+    throw new exception('Unknown kind "' + this.kind + '" is specified for "' + tag + '" YAML type.');
+  }
+}
+var type = Type$1;
+function compileList(schema2, name) {
+  var result = [];
+  schema2[name].forEach(function(currentType) {
+    var newIndex = result.length;
+    result.forEach(function(previousType, previousIndex) {
+      if (previousType.tag === currentType.tag && previousType.kind === currentType.kind && previousType.multi === currentType.multi) {
+        newIndex = previousIndex;
+      }
+    });
+    result[newIndex] = currentType;
+  });
+  return result;
+}
+function compileMap() {
+  var result = {
+    scalar: {},
+    sequence: {},
+    mapping: {},
+    fallback: {},
+    multi: {
+      scalar: [],
+      sequence: [],
+      mapping: [],
+      fallback: []
+    }
+  }, index, length;
+  function collectType(type2) {
+    if (type2.multi) {
+      result.multi[type2.kind].push(type2);
+      result.multi["fallback"].push(type2);
+    } else {
+      result[type2.kind][type2.tag] = result["fallback"][type2.tag] = type2;
+    }
+  }
+  for (index = 0, length = arguments.length; index < length; index += 1) {
+    arguments[index].forEach(collectType);
+  }
+  return result;
+}
+function Schema$1(definition) {
+  return this.extend(definition);
+}
+Schema$1.prototype.extend = function extend2(definition) {
+  var implicit = [];
+  var explicit = [];
+  if (definition instanceof type) {
+    explicit.push(definition);
+  } else if (Array.isArray(definition)) {
+    explicit = explicit.concat(definition);
+  } else if (definition && (Array.isArray(definition.implicit) || Array.isArray(definition.explicit))) {
+    if (definition.implicit) implicit = implicit.concat(definition.implicit);
+    if (definition.explicit) explicit = explicit.concat(definition.explicit);
+  } else {
+    throw new exception("Schema.extend argument should be a Type, [ Type ], or a schema definition ({ implicit: [...], explicit: [...] })");
+  }
+  implicit.forEach(function(type$1) {
+    if (!(type$1 instanceof type)) {
+      throw new exception("Specified list of YAML types (or a single Type object) contains a non-Type object.");
+    }
+    if (type$1.loadKind && type$1.loadKind !== "scalar") {
+      throw new exception("There is a non-scalar type in the implicit list of a schema. Implicit resolving of such types is not supported.");
+    }
+    if (type$1.multi) {
+      throw new exception("There is a multi type in the implicit list of a schema. Multi tags can only be listed as explicit.");
+    }
+  });
+  explicit.forEach(function(type$1) {
+    if (!(type$1 instanceof type)) {
+      throw new exception("Specified list of YAML types (or a single Type object) contains a non-Type object.");
+    }
+  });
+  var result = Object.create(Schema$1.prototype);
+  result.implicit = (this.implicit || []).concat(implicit);
+  result.explicit = (this.explicit || []).concat(explicit);
+  result.compiledImplicit = compileList(result, "implicit");
+  result.compiledExplicit = compileList(result, "explicit");
+  result.compiledTypeMap = compileMap(result.compiledImplicit, result.compiledExplicit);
+  return result;
+};
+var schema = Schema$1;
+var str = new type("tag:yaml.org,2002:str", {
+  kind: "scalar",
+  construct: function(data) {
+    return data !== null ? data : "";
+  }
+});
+var seq = new type("tag:yaml.org,2002:seq", {
+  kind: "sequence",
+  construct: function(data) {
+    return data !== null ? data : [];
+  }
+});
+var map = new type("tag:yaml.org,2002:map", {
+  kind: "mapping",
+  construct: function(data) {
+    return data !== null ? data : {};
+  }
+});
+var failsafe = new schema({
+  explicit: [
+    str,
+    seq,
+    map
+  ]
+});
+function resolveYamlNull(data) {
+  if (data === null) return true;
+  var max = data.length;
+  return max === 1 && data === "~" || max === 4 && (data === "null" || data === "Null" || data === "NULL");
+}
+function constructYamlNull() {
+  return null;
+}
+function isNull(object) {
+  return object === null;
+}
+var _null = new type("tag:yaml.org,2002:null", {
+  kind: "scalar",
+  resolve: resolveYamlNull,
+  construct: constructYamlNull,
+  predicate: isNull,
+  represent: {
+    canonical: function() {
+      return "~";
+    },
+    lowercase: function() {
+      return "null";
+    },
+    uppercase: function() {
+      return "NULL";
+    },
+    camelcase: function() {
+      return "Null";
+    },
+    empty: function() {
+      return "";
+    }
+  },
+  defaultStyle: "lowercase"
+});
+function resolveYamlBoolean(data) {
+  if (data === null) return false;
+  var max = data.length;
+  return max === 4 && (data === "true" || data === "True" || data === "TRUE") || max === 5 && (data === "false" || data === "False" || data === "FALSE");
+}
+function constructYamlBoolean(data) {
+  return data === "true" || data === "True" || data === "TRUE";
+}
+function isBoolean(object) {
+  return Object.prototype.toString.call(object) === "[object Boolean]";
+}
+var bool = new type("tag:yaml.org,2002:bool", {
+  kind: "scalar",
+  resolve: resolveYamlBoolean,
+  construct: constructYamlBoolean,
+  predicate: isBoolean,
+  represent: {
+    lowercase: function(object) {
+      return object ? "true" : "false";
+    },
+    uppercase: function(object) {
+      return object ? "TRUE" : "FALSE";
+    },
+    camelcase: function(object) {
+      return object ? "True" : "False";
+    }
+  },
+  defaultStyle: "lowercase"
+});
+function isHexCode(c) {
+  return 48 <= c && c <= 57 || 65 <= c && c <= 70 || 97 <= c && c <= 102;
+}
+function isOctCode(c) {
+  return 48 <= c && c <= 55;
+}
+function isDecCode(c) {
+  return 48 <= c && c <= 57;
+}
+function resolveYamlInteger(data) {
+  if (data === null) return false;
+  var max = data.length, index = 0, hasDigits = false, ch;
+  if (!max) return false;
+  ch = data[index];
+  if (ch === "-" || ch === "+") {
+    ch = data[++index];
+  }
+  if (ch === "0") {
+    if (index + 1 === max) return true;
+    ch = data[++index];
+    if (ch === "b") {
+      index++;
+      for (; index < max; index++) {
+        ch = data[index];
+        if (ch === "_") continue;
+        if (ch !== "0" && ch !== "1") return false;
+        hasDigits = true;
+      }
+      return hasDigits && ch !== "_";
+    }
+    if (ch === "x") {
+      index++;
+      for (; index < max; index++) {
+        ch = data[index];
+        if (ch === "_") continue;
+        if (!isHexCode(data.charCodeAt(index))) return false;
+        hasDigits = true;
+      }
+      return hasDigits && ch !== "_";
+    }
+    if (ch === "o") {
+      index++;
+      for (; index < max; index++) {
+        ch = data[index];
+        if (ch === "_") continue;
+        if (!isOctCode(data.charCodeAt(index))) return false;
+        hasDigits = true;
+      }
+      return hasDigits && ch !== "_";
+    }
+  }
+  if (ch === "_") return false;
+  for (; index < max; index++) {
+    ch = data[index];
+    if (ch === "_") continue;
+    if (!isDecCode(data.charCodeAt(index))) {
+      return false;
+    }
+    hasDigits = true;
+  }
+  if (!hasDigits || ch === "_") return false;
+  return true;
+}
+function constructYamlInteger(data) {
+  var value = data, sign = 1, ch;
+  if (value.indexOf("_") !== -1) {
+    value = value.replace(/_/g, "");
+  }
+  ch = value[0];
+  if (ch === "-" || ch === "+") {
+    if (ch === "-") sign = -1;
+    value = value.slice(1);
+    ch = value[0];
+  }
+  if (value === "0") return 0;
+  if (ch === "0") {
+    if (value[1] === "b") return sign * parseInt(value.slice(2), 2);
+    if (value[1] === "x") return sign * parseInt(value.slice(2), 16);
+    if (value[1] === "o") return sign * parseInt(value.slice(2), 8);
+  }
+  return sign * parseInt(value, 10);
+}
+function isInteger(object) {
+  return Object.prototype.toString.call(object) === "[object Number]" && (object % 1 === 0 && !common.isNegativeZero(object));
+}
+var int = new type("tag:yaml.org,2002:int", {
+  kind: "scalar",
+  resolve: resolveYamlInteger,
+  construct: constructYamlInteger,
+  predicate: isInteger,
+  represent: {
+    binary: function(obj) {
+      return obj >= 0 ? "0b" + obj.toString(2) : "-0b" + obj.toString(2).slice(1);
+    },
+    octal: function(obj) {
+      return obj >= 0 ? "0o" + obj.toString(8) : "-0o" + obj.toString(8).slice(1);
+    },
+    decimal: function(obj) {
+      return obj.toString(10);
+    },
+    /* eslint-disable max-len */
+    hexadecimal: function(obj) {
+      return obj >= 0 ? "0x" + obj.toString(16).toUpperCase() : "-0x" + obj.toString(16).toUpperCase().slice(1);
+    }
+  },
+  defaultStyle: "decimal",
+  styleAliases: {
+    binary: [2, "bin"],
+    octal: [8, "oct"],
+    decimal: [10, "dec"],
+    hexadecimal: [16, "hex"]
+  }
+});
+var YAML_FLOAT_PATTERN = new RegExp(
+  // 2.5e4, 2.5 and integers
+  "^(?:[-+]?(?:[0-9][0-9_]*)(?:\\.[0-9_]*)?(?:[eE][-+]?[0-9]+)?|\\.[0-9_]+(?:[eE][-+]?[0-9]+)?|[-+]?\\.(?:inf|Inf|INF)|\\.(?:nan|NaN|NAN))$"
+);
+function resolveYamlFloat(data) {
+  if (data === null) return false;
+  if (!YAML_FLOAT_PATTERN.test(data) || // Quick hack to not allow integers end with `_`
+  // Probably should update regexp & check speed
+  data[data.length - 1] === "_") {
+    return false;
+  }
+  return true;
+}
+function constructYamlFloat(data) {
+  var value, sign;
+  value = data.replace(/_/g, "").toLowerCase();
+  sign = value[0] === "-" ? -1 : 1;
+  if ("+-".indexOf(value[0]) >= 0) {
+    value = value.slice(1);
+  }
+  if (value === ".inf") {
+    return sign === 1 ? Number.POSITIVE_INFINITY : Number.NEGATIVE_INFINITY;
+  } else if (value === ".nan") {
+    return NaN;
+  }
+  return sign * parseFloat(value, 10);
+}
+var SCIENTIFIC_WITHOUT_DOT = /^[-+]?[0-9]+e/;
+function representYamlFloat(object, style) {
+  var res;
+  if (isNaN(object)) {
+    switch (style) {
+      case "lowercase":
+        return ".nan";
+      case "uppercase":
+        return ".NAN";
+      case "camelcase":
+        return ".NaN";
+    }
+  } else if (Number.POSITIVE_INFINITY === object) {
+    switch (style) {
+      case "lowercase":
+        return ".inf";
+      case "uppercase":
+        return ".INF";
+      case "camelcase":
+        return ".Inf";
+    }
+  } else if (Number.NEGATIVE_INFINITY === object) {
+    switch (style) {
+      case "lowercase":
+        return "-.inf";
+      case "uppercase":
+        return "-.INF";
+      case "camelcase":
+        return "-.Inf";
+    }
+  } else if (common.isNegativeZero(object)) {
+    return "-0.0";
+  }
+  res = object.toString(10);
+  return SCIENTIFIC_WITHOUT_DOT.test(res) ? res.replace("e", ".e") : res;
+}
+function isFloat(object) {
+  return Object.prototype.toString.call(object) === "[object Number]" && (object % 1 !== 0 || common.isNegativeZero(object));
+}
+var float = new type("tag:yaml.org,2002:float", {
+  kind: "scalar",
+  resolve: resolveYamlFloat,
+  construct: constructYamlFloat,
+  predicate: isFloat,
+  represent: representYamlFloat,
+  defaultStyle: "lowercase"
+});
+var json = failsafe.extend({
+  implicit: [
+    _null,
+    bool,
+    int,
+    float
+  ]
+});
+var core = json;
+var YAML_DATE_REGEXP = new RegExp(
+  "^([0-9][0-9][0-9][0-9])-([0-9][0-9])-([0-9][0-9])$"
+);
+var YAML_TIMESTAMP_REGEXP = new RegExp(
+  "^([0-9][0-9][0-9][0-9])-([0-9][0-9]?)-([0-9][0-9]?)(?:[Tt]|[ \\t]+)([0-9][0-9]?):([0-9][0-9]):([0-9][0-9])(?:\\.([0-9]*))?(?:[ \\t]*(Z|([-+])([0-9][0-9]?)(?::([0-9][0-9]))?))?$"
+);
+function resolveYamlTimestamp(data) {
+  if (data === null) return false;
+  if (YAML_DATE_REGEXP.exec(data) !== null) return true;
+  if (YAML_TIMESTAMP_REGEXP.exec(data) !== null) return true;
+  return false;
+}
+function constructYamlTimestamp(data) {
+  var match, year, month, day, hour, minute, second, fraction = 0, delta = null, tz_hour, tz_minute, date;
+  match = YAML_DATE_REGEXP.exec(data);
+  if (match === null) match = YAML_TIMESTAMP_REGEXP.exec(data);
+  if (match === null) throw new Error("Date resolve error");
+  year = +match[1];
+  month = +match[2] - 1;
+  day = +match[3];
+  if (!match[4]) {
+    return new Date(Date.UTC(year, month, day));
+  }
+  hour = +match[4];
+  minute = +match[5];
+  second = +match[6];
+  if (match[7]) {
+    fraction = match[7].slice(0, 3);
+    while (fraction.length < 3) {
+      fraction += "0";
+    }
+    fraction = +fraction;
+  }
+  if (match[9]) {
+    tz_hour = +match[10];
+    tz_minute = +(match[11] || 0);
+    delta = (tz_hour * 60 + tz_minute) * 6e4;
+    if (match[9] === "-") delta = -delta;
+  }
+  date = new Date(Date.UTC(year, month, day, hour, minute, second, fraction));
+  if (delta) date.setTime(date.getTime() - delta);
+  return date;
+}
+function representYamlTimestamp(object) {
+  return object.toISOString();
+}
+var timestamp = new type("tag:yaml.org,2002:timestamp", {
+  kind: "scalar",
+  resolve: resolveYamlTimestamp,
+  construct: constructYamlTimestamp,
+  instanceOf: Date,
+  represent: representYamlTimestamp
+});
+function resolveYamlMerge(data) {
+  return data === "<<" || data === null;
+}
+var merge = new type("tag:yaml.org,2002:merge", {
+  kind: "scalar",
+  resolve: resolveYamlMerge
+});
+var BASE64_MAP = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=\n\r";
+function resolveYamlBinary(data) {
+  if (data === null) return false;
+  var code, idx, bitlen = 0, max = data.length, map2 = BASE64_MAP;
+  for (idx = 0; idx < max; idx++) {
+    code = map2.indexOf(data.charAt(idx));
+    if (code > 64) continue;
+    if (code < 0) return false;
+    bitlen += 6;
+  }
+  return bitlen % 8 === 0;
+}
+function constructYamlBinary(data) {
+  var idx, tailbits, input = data.replace(/[\r\n=]/g, ""), max = input.length, map2 = BASE64_MAP, bits = 0, result = [];
+  for (idx = 0; idx < max; idx++) {
+    if (idx % 4 === 0 && idx) {
+      result.push(bits >> 16 & 255);
+      result.push(bits >> 8 & 255);
+      result.push(bits & 255);
+    }
+    bits = bits << 6 | map2.indexOf(input.charAt(idx));
+  }
+  tailbits = max % 4 * 6;
+  if (tailbits === 0) {
+    result.push(bits >> 16 & 255);
+    result.push(bits >> 8 & 255);
+    result.push(bits & 255);
+  } else if (tailbits === 18) {
+    result.push(bits >> 10 & 255);
+    result.push(bits >> 2 & 255);
+  } else if (tailbits === 12) {
+    result.push(bits >> 4 & 255);
+  }
+  return new Uint8Array(result);
+}
+function representYamlBinary(object) {
+  var result = "", bits = 0, idx, tail, max = object.length, map2 = BASE64_MAP;
+  for (idx = 0; idx < max; idx++) {
+    if (idx % 3 === 0 && idx) {
+      result += map2[bits >> 18 & 63];
+      result += map2[bits >> 12 & 63];
+      result += map2[bits >> 6 & 63];
+      result += map2[bits & 63];
+    }
+    bits = (bits << 8) + object[idx];
+  }
+  tail = max % 3;
+  if (tail === 0) {
+    result += map2[bits >> 18 & 63];
+    result += map2[bits >> 12 & 63];
+    result += map2[bits >> 6 & 63];
+    result += map2[bits & 63];
+  } else if (tail === 2) {
+    result += map2[bits >> 10 & 63];
+    result += map2[bits >> 4 & 63];
+    result += map2[bits << 2 & 63];
+    result += map2[64];
+  } else if (tail === 1) {
+    result += map2[bits >> 2 & 63];
+    result += map2[bits << 4 & 63];
+    result += map2[64];
+    result += map2[64];
+  }
+  return result;
+}
+function isBinary(obj) {
+  return Object.prototype.toString.call(obj) === "[object Uint8Array]";
+}
+var binary = new type("tag:yaml.org,2002:binary", {
+  kind: "scalar",
+  resolve: resolveYamlBinary,
+  construct: constructYamlBinary,
+  predicate: isBinary,
+  represent: representYamlBinary
+});
+var _hasOwnProperty$3 = Object.prototype.hasOwnProperty;
+var _toString$2 = Object.prototype.toString;
+function resolveYamlOmap(data) {
+  if (data === null) return true;
+  var objectKeys = [], index, length, pair, pairKey, pairHasKey, object = data;
+  for (index = 0, length = object.length; index < length; index += 1) {
+    pair = object[index];
+    pairHasKey = false;
+    if (_toString$2.call(pair) !== "[object Object]") return false;
+    for (pairKey in pair) {
+      if (_hasOwnProperty$3.call(pair, pairKey)) {
+        if (!pairHasKey) pairHasKey = true;
+        else return false;
+      }
+    }
+    if (!pairHasKey) return false;
+    if (objectKeys.indexOf(pairKey) === -1) objectKeys.push(pairKey);
+    else return false;
+  }
+  return true;
+}
+function constructYamlOmap(data) {
+  return data !== null ? data : [];
+}
+var omap = new type("tag:yaml.org,2002:omap", {
+  kind: "sequence",
+  resolve: resolveYamlOmap,
+  construct: constructYamlOmap
+});
+var _toString$1 = Object.prototype.toString;
+function resolveYamlPairs(data) {
+  if (data === null) return true;
+  var index, length, pair, keys, result, object = data;
+  result = new Array(object.length);
+  for (index = 0, length = object.length; index < length; index += 1) {
+    pair = object[index];
+    if (_toString$1.call(pair) !== "[object Object]") return false;
+    keys = Object.keys(pair);
+    if (keys.length !== 1) return false;
+    result[index] = [keys[0], pair[keys[0]]];
+  }
+  return true;
+}
+function constructYamlPairs(data) {
+  if (data === null) return [];
+  var index, length, pair, keys, result, object = data;
+  result = new Array(object.length);
+  for (index = 0, length = object.length; index < length; index += 1) {
+    pair = object[index];
+    keys = Object.keys(pair);
+    result[index] = [keys[0], pair[keys[0]]];
+  }
+  return result;
+}
+var pairs = new type("tag:yaml.org,2002:pairs", {
+  kind: "sequence",
+  resolve: resolveYamlPairs,
+  construct: constructYamlPairs
+});
+var _hasOwnProperty$2 = Object.prototype.hasOwnProperty;
+function resolveYamlSet(data) {
+  if (data === null) return true;
+  var key, object = data;
+  for (key in object) {
+    if (_hasOwnProperty$2.call(object, key)) {
+      if (object[key] !== null) return false;
+    }
+  }
+  return true;
+}
+function constructYamlSet(data) {
+  return data !== null ? data : {};
+}
+var set = new type("tag:yaml.org,2002:set", {
+  kind: "mapping",
+  resolve: resolveYamlSet,
+  construct: constructYamlSet
+});
+var _default = core.extend({
+  implicit: [
+    timestamp,
+    merge
+  ],
+  explicit: [
+    binary,
+    omap,
+    pairs,
+    set
+  ]
+});
+var _hasOwnProperty$1 = Object.prototype.hasOwnProperty;
+var CONTEXT_FLOW_IN = 1;
+var CONTEXT_FLOW_OUT = 2;
+var CONTEXT_BLOCK_IN = 3;
+var CONTEXT_BLOCK_OUT = 4;
+var CHOMPING_CLIP = 1;
+var CHOMPING_STRIP = 2;
+var CHOMPING_KEEP = 3;
+var PATTERN_NON_PRINTABLE = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x84\x86-\x9F\uFFFE\uFFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF]/;
+var PATTERN_NON_ASCII_LINE_BREAKS = /[\x85\u2028\u2029]/;
+var PATTERN_FLOW_INDICATORS = /[,\[\]\{\}]/;
+var PATTERN_TAG_HANDLE = /^(?:!|!!|![a-z\-]+!)$/i;
+var PATTERN_TAG_URI = /^(?:!|[^,\[\]\{\}])(?:%[0-9a-f]{2}|[0-9a-z\-#;\/\?:@&=\+\$,_\.!~\*'\(\)\[\]])*$/i;
+function _class(obj) {
+  return Object.prototype.toString.call(obj);
+}
+function is_EOL(c) {
+  return c === 10 || c === 13;
+}
+function is_WHITE_SPACE(c) {
+  return c === 9 || c === 32;
+}
+function is_WS_OR_EOL(c) {
+  return c === 9 || c === 32 || c === 10 || c === 13;
+}
+function is_FLOW_INDICATOR(c) {
+  return c === 44 || c === 91 || c === 93 || c === 123 || c === 125;
+}
+function fromHexCode(c) {
+  var lc;
+  if (48 <= c && c <= 57) {
+    return c - 48;
+  }
+  lc = c | 32;
+  if (97 <= lc && lc <= 102) {
+    return lc - 97 + 10;
+  }
+  return -1;
+}
+function escapedHexLen(c) {
+  if (c === 120) {
+    return 2;
+  }
+  if (c === 117) {
+    return 4;
+  }
+  if (c === 85) {
+    return 8;
+  }
+  return 0;
+}
+function fromDecimalCode(c) {
+  if (48 <= c && c <= 57) {
+    return c - 48;
+  }
+  return -1;
+}
+function simpleEscapeSequence(c) {
+  return c === 48 ? "\0" : c === 97 ? "\x07" : c === 98 ? "\b" : c === 116 ? "	" : c === 9 ? "	" : c === 110 ? "\n" : c === 118 ? "\v" : c === 102 ? "\f" : c === 114 ? "\r" : c === 101 ? "\x1B" : c === 32 ? " " : c === 34 ? '"' : c === 47 ? "/" : c === 92 ? "\\" : c === 78 ? "\x85" : c === 95 ? "\xA0" : c === 76 ? "\u2028" : c === 80 ? "\u2029" : "";
+}
+function charFromCodepoint(c) {
+  if (c <= 65535) {
+    return String.fromCharCode(c);
+  }
+  return String.fromCharCode(
+    (c - 65536 >> 10) + 55296,
+    (c - 65536 & 1023) + 56320
+  );
+}
+function setProperty(object, key, value) {
+  if (key === "__proto__") {
+    Object.defineProperty(object, key, {
+      configurable: true,
+      enumerable: true,
+      writable: true,
+      value
+    });
+  } else {
+    object[key] = value;
+  }
+}
+var simpleEscapeCheck = new Array(256);
+var simpleEscapeMap = new Array(256);
+for (i = 0; i < 256; i++) {
+  simpleEscapeCheck[i] = simpleEscapeSequence(i) ? 1 : 0;
+  simpleEscapeMap[i] = simpleEscapeSequence(i);
+}
+var i;
+function State$1(input, options) {
+  this.input = input;
+  this.filename = options["filename"] || null;
+  this.schema = options["schema"] || _default;
+  this.onWarning = options["onWarning"] || null;
+  this.legacy = options["legacy"] || false;
+  this.json = options["json"] || false;
+  this.listener = options["listener"] || null;
+  this.implicitTypes = this.schema.compiledImplicit;
+  this.typeMap = this.schema.compiledTypeMap;
+  this.length = input.length;
+  this.position = 0;
+  this.line = 0;
+  this.lineStart = 0;
+  this.lineIndent = 0;
+  this.firstTabInLine = -1;
+  this.documents = [];
+}
+function generateError(state, message) {
+  var mark = {
+    name: state.filename,
+    buffer: state.input.slice(0, -1),
+    // omit trailing \0
+    position: state.position,
+    line: state.line,
+    column: state.position - state.lineStart
+  };
+  mark.snippet = snippet(mark);
+  return new exception(message, mark);
+}
+function throwError(state, message) {
+  throw generateError(state, message);
+}
+function throwWarning(state, message) {
+  if (state.onWarning) {
+    state.onWarning.call(null, generateError(state, message));
+  }
+}
+var directiveHandlers = {
+  YAML: function handleYamlDirective(state, name, args) {
+    var match, major, minor;
+    if (state.version !== null) {
+      throwError(state, "duplication of %YAML directive");
+    }
+    if (args.length !== 1) {
+      throwError(state, "YAML directive accepts exactly one argument");
+    }
+    match = /^([0-9]+)\.([0-9]+)$/.exec(args[0]);
+    if (match === null) {
+      throwError(state, "ill-formed argument of the YAML directive");
+    }
+    major = parseInt(match[1], 10);
+    minor = parseInt(match[2], 10);
+    if (major !== 1) {
+      throwError(state, "unacceptable YAML version of the document");
+    }
+    state.version = args[0];
+    state.checkLineBreaks = minor < 2;
+    if (minor !== 1 && minor !== 2) {
+      throwWarning(state, "unsupported YAML version of the document");
+    }
+  },
+  TAG: function handleTagDirective(state, name, args) {
+    var handle, prefix;
+    if (args.length !== 2) {
+      throwError(state, "TAG directive accepts exactly two arguments");
+    }
+    handle = args[0];
+    prefix = args[1];
+    if (!PATTERN_TAG_HANDLE.test(handle)) {
+      throwError(state, "ill-formed tag handle (first argument) of the TAG directive");
+    }
+    if (_hasOwnProperty$1.call(state.tagMap, handle)) {
+      throwError(state, 'there is a previously declared suffix for "' + handle + '" tag handle');
+    }
+    if (!PATTERN_TAG_URI.test(prefix)) {
+      throwError(state, "ill-formed tag prefix (second argument) of the TAG directive");
+    }
+    try {
+      prefix = decodeURIComponent(prefix);
+    } catch (err) {
+      throwError(state, "tag prefix is malformed: " + prefix);
+    }
+    state.tagMap[handle] = prefix;
+  }
+};
+function captureSegment(state, start, end, checkJson) {
+  var _position, _length, _character, _result;
+  if (start < end) {
+    _result = state.input.slice(start, end);
+    if (checkJson) {
+      for (_position = 0, _length = _result.length; _position < _length; _position += 1) {
+        _character = _result.charCodeAt(_position);
+        if (!(_character === 9 || 32 <= _character && _character <= 1114111)) {
+          throwError(state, "expected valid JSON character");
+        }
+      }
+    } else if (PATTERN_NON_PRINTABLE.test(_result)) {
+      throwError(state, "the stream contains non-printable characters");
+    }
+    state.result += _result;
+  }
+}
+function mergeMappings(state, destination, source, overridableKeys) {
+  var sourceKeys, key, index, quantity;
+  if (!common.isObject(source)) {
+    throwError(state, "cannot merge mappings; the provided source object is unacceptable");
+  }
+  sourceKeys = Object.keys(source);
+  for (index = 0, quantity = sourceKeys.length; index < quantity; index += 1) {
+    key = sourceKeys[index];
+    if (!_hasOwnProperty$1.call(destination, key)) {
+      setProperty(destination, key, source[key]);
+      overridableKeys[key] = true;
+    }
+  }
+}
+function storeMappingPair(state, _result, overridableKeys, keyTag, keyNode, valueNode, startLine, startLineStart, startPos) {
+  var index, quantity;
+  if (Array.isArray(keyNode)) {
+    keyNode = Array.prototype.slice.call(keyNode);
+    for (index = 0, quantity = keyNode.length; index < quantity; index += 1) {
+      if (Array.isArray(keyNode[index])) {
+        throwError(state, "nested arrays are not supported inside keys");
+      }
+      if (typeof keyNode === "object" && _class(keyNode[index]) === "[object Object]") {
+        keyNode[index] = "[object Object]";
+      }
+    }
+  }
+  if (typeof keyNode === "object" && _class(keyNode) === "[object Object]") {
+    keyNode = "[object Object]";
+  }
+  keyNode = String(keyNode);
+  if (_result === null) {
+    _result = {};
+  }
+  if (keyTag === "tag:yaml.org,2002:merge") {
+    if (Array.isArray(valueNode)) {
+      for (index = 0, quantity = valueNode.length; index < quantity; index += 1) {
+        mergeMappings(state, _result, valueNode[index], overridableKeys);
+      }
+    } else {
+      mergeMappings(state, _result, valueNode, overridableKeys);
+    }
+  } else {
+    if (!state.json && !_hasOwnProperty$1.call(overridableKeys, keyNode) && _hasOwnProperty$1.call(_result, keyNode)) {
+      state.line = startLine || state.line;
+      state.lineStart = startLineStart || state.lineStart;
+      state.position = startPos || state.position;
+      throwError(state, "duplicated mapping key");
+    }
+    setProperty(_result, keyNode, valueNode);
+    delete overridableKeys[keyNode];
+  }
+  return _result;
+}
+function readLineBreak(state) {
+  var ch;
+  ch = state.input.charCodeAt(state.position);
+  if (ch === 10) {
+    state.position++;
+  } else if (ch === 13) {
+    state.position++;
+    if (state.input.charCodeAt(state.position) === 10) {
+      state.position++;
+    }
+  } else {
+    throwError(state, "a line break is expected");
+  }
+  state.line += 1;
+  state.lineStart = state.position;
+  state.firstTabInLine = -1;
+}
+function skipSeparationSpace(state, allowComments, checkIndent) {
+  var lineBreaks = 0, ch = state.input.charCodeAt(state.position);
+  while (ch !== 0) {
+    while (is_WHITE_SPACE(ch)) {
+      if (ch === 9 && state.firstTabInLine === -1) {
+        state.firstTabInLine = state.position;
+      }
+      ch = state.input.charCodeAt(++state.position);
+    }
+    if (allowComments && ch === 35) {
+      do {
+        ch = state.input.charCodeAt(++state.position);
+      } while (ch !== 10 && ch !== 13 && ch !== 0);
+    }
+    if (is_EOL(ch)) {
+      readLineBreak(state);
+      ch = state.input.charCodeAt(state.position);
+      lineBreaks++;
+      state.lineIndent = 0;
+      while (ch === 32) {
+        state.lineIndent++;
+        ch = state.input.charCodeAt(++state.position);
+      }
+    } else {
+      break;
+    }
+  }
+  if (checkIndent !== -1 && lineBreaks !== 0 && state.lineIndent < checkIndent) {
+    throwWarning(state, "deficient indentation");
+  }
+  return lineBreaks;
+}
+function testDocumentSeparator(state) {
+  var _position = state.position, ch;
+  ch = state.input.charCodeAt(_position);
+  if ((ch === 45 || ch === 46) && ch === state.input.charCodeAt(_position + 1) && ch === state.input.charCodeAt(_position + 2)) {
+    _position += 3;
+    ch = state.input.charCodeAt(_position);
+    if (ch === 0 || is_WS_OR_EOL(ch)) {
+      return true;
+    }
+  }
+  return false;
+}
+function writeFoldedLines(state, count) {
+  if (count === 1) {
+    state.result += " ";
+  } else if (count > 1) {
+    state.result += common.repeat("\n", count - 1);
+  }
+}
+function readPlainScalar(state, nodeIndent, withinFlowCollection) {
+  var preceding, following, captureStart, captureEnd, hasPendingContent, _line, _lineStart, _lineIndent, _kind = state.kind, _result = state.result, ch;
+  ch = state.input.charCodeAt(state.position);
+  if (is_WS_OR_EOL(ch) || is_FLOW_INDICATOR(ch) || ch === 35 || ch === 38 || ch === 42 || ch === 33 || ch === 124 || ch === 62 || ch === 39 || ch === 34 || ch === 37 || ch === 64 || ch === 96) {
+    return false;
+  }
+  if (ch === 63 || ch === 45) {
+    following = state.input.charCodeAt(state.position + 1);
+    if (is_WS_OR_EOL(following) || withinFlowCollection && is_FLOW_INDICATOR(following)) {
+      return false;
+    }
+  }
+  state.kind = "scalar";
+  state.result = "";
+  captureStart = captureEnd = state.position;
+  hasPendingContent = false;
+  while (ch !== 0) {
+    if (ch === 58) {
+      following = state.input.charCodeAt(state.position + 1);
+      if (is_WS_OR_EOL(following) || withinFlowCollection && is_FLOW_INDICATOR(following)) {
+        break;
+      }
+    } else if (ch === 35) {
+      preceding = state.input.charCodeAt(state.position - 1);
+      if (is_WS_OR_EOL(preceding)) {
+        break;
+      }
+    } else if (state.position === state.lineStart && testDocumentSeparator(state) || withinFlowCollection && is_FLOW_INDICATOR(ch)) {
+      break;
+    } else if (is_EOL(ch)) {
+      _line = state.line;
+      _lineStart = state.lineStart;
+      _lineIndent = state.lineIndent;
+      skipSeparationSpace(state, false, -1);
+      if (state.lineIndent >= nodeIndent) {
+        hasPendingContent = true;
+        ch = state.input.charCodeAt(state.position);
+        continue;
+      } else {
+        state.position = captureEnd;
+        state.line = _line;
+        state.lineStart = _lineStart;
+        state.lineIndent = _lineIndent;
+        break;
+      }
+    }
+    if (hasPendingContent) {
+      captureSegment(state, captureStart, captureEnd, false);
+      writeFoldedLines(state, state.line - _line);
+      captureStart = captureEnd = state.position;
+      hasPendingContent = false;
+    }
+    if (!is_WHITE_SPACE(ch)) {
+      captureEnd = state.position + 1;
+    }
+    ch = state.input.charCodeAt(++state.position);
+  }
+  captureSegment(state, captureStart, captureEnd, false);
+  if (state.result) {
+    return true;
+  }
+  state.kind = _kind;
+  state.result = _result;
+  return false;
+}
+function readSingleQuotedScalar(state, nodeIndent) {
+  var ch, captureStart, captureEnd;
+  ch = state.input.charCodeAt(state.position);
+  if (ch !== 39) {
+    return false;
+  }
+  state.kind = "scalar";
+  state.result = "";
+  state.position++;
+  captureStart = captureEnd = state.position;
+  while ((ch = state.input.charCodeAt(state.position)) !== 0) {
+    if (ch === 39) {
+      captureSegment(state, captureStart, state.position, true);
+      ch = state.input.charCodeAt(++state.position);
+      if (ch === 39) {
+        captureStart = state.position;
+        state.position++;
+        captureEnd = state.position;
+      } else {
+        return true;
+      }
+    } else if (is_EOL(ch)) {
+      captureSegment(state, captureStart, captureEnd, true);
+      writeFoldedLines(state, skipSeparationSpace(state, false, nodeIndent));
+      captureStart = captureEnd = state.position;
+    } else if (state.position === state.lineStart && testDocumentSeparator(state)) {
+      throwError(state, "unexpected end of the document within a single quoted scalar");
+    } else {
+      state.position++;
+      captureEnd = state.position;
+    }
+  }
+  throwError(state, "unexpected end of the stream within a single quoted scalar");
+}
+function readDoubleQuotedScalar(state, nodeIndent) {
+  var captureStart, captureEnd, hexLength, hexResult, tmp, ch;
+  ch = state.input.charCodeAt(state.position);
+  if (ch !== 34) {
+    return false;
+  }
+  state.kind = "scalar";
+  state.result = "";
+  state.position++;
+  captureStart = captureEnd = state.position;
+  while ((ch = state.input.charCodeAt(state.position)) !== 0) {
+    if (ch === 34) {
+      captureSegment(state, captureStart, state.position, true);
+      state.position++;
+      return true;
+    } else if (ch === 92) {
+      captureSegment(state, captureStart, state.position, true);
+      ch = state.input.charCodeAt(++state.position);
+      if (is_EOL(ch)) {
+        skipSeparationSpace(state, false, nodeIndent);
+      } else if (ch < 256 && simpleEscapeCheck[ch]) {
+        state.result += simpleEscapeMap[ch];
+        state.position++;
+      } else if ((tmp = escapedHexLen(ch)) > 0) {
+        hexLength = tmp;
+        hexResult = 0;
+        for (; hexLength > 0; hexLength--) {
+          ch = state.input.charCodeAt(++state.position);
+          if ((tmp = fromHexCode(ch)) >= 0) {
+            hexResult = (hexResult << 4) + tmp;
+          } else {
+            throwError(state, "expected hexadecimal character");
+          }
+        }
+        state.result += charFromCodepoint(hexResult);
+        state.position++;
+      } else {
+        throwError(state, "unknown escape sequence");
+      }
+      captureStart = captureEnd = state.position;
+    } else if (is_EOL(ch)) {
+      captureSegment(state, captureStart, captureEnd, true);
+      writeFoldedLines(state, skipSeparationSpace(state, false, nodeIndent));
+      captureStart = captureEnd = state.position;
+    } else if (state.position === state.lineStart && testDocumentSeparator(state)) {
+      throwError(state, "unexpected end of the document within a double quoted scalar");
+    } else {
+      state.position++;
+      captureEnd = state.position;
+    }
+  }
+  throwError(state, "unexpected end of the stream within a double quoted scalar");
+}
+function readFlowCollection(state, nodeIndent) {
+  var readNext = true, _line, _lineStart, _pos, _tag = state.tag, _result, _anchor = state.anchor, following, terminator, isPair, isExplicitPair, isMapping, overridableKeys = /* @__PURE__ */ Object.create(null), keyNode, keyTag, valueNode, ch;
+  ch = state.input.charCodeAt(state.position);
+  if (ch === 91) {
+    terminator = 93;
+    isMapping = false;
+    _result = [];
+  } else if (ch === 123) {
+    terminator = 125;
+    isMapping = true;
+    _result = {};
+  } else {
+    return false;
+  }
+  if (state.anchor !== null) {
+    state.anchorMap[state.anchor] = _result;
+  }
+  ch = state.input.charCodeAt(++state.position);
+  while (ch !== 0) {
+    skipSeparationSpace(state, true, nodeIndent);
+    ch = state.input.charCodeAt(state.position);
+    if (ch === terminator) {
+      state.position++;
+      state.tag = _tag;
+      state.anchor = _anchor;
+      state.kind = isMapping ? "mapping" : "sequence";
+      state.result = _result;
+      return true;
+    } else if (!readNext) {
+      throwError(state, "missed comma between flow collection entries");
+    } else if (ch === 44) {
+      throwError(state, "expected the node content, but found ','");
+    }
+    keyTag = keyNode = valueNode = null;
+    isPair = isExplicitPair = false;
+    if (ch === 63) {
+      following = state.input.charCodeAt(state.position + 1);
+      if (is_WS_OR_EOL(following)) {
+        isPair = isExplicitPair = true;
+        state.position++;
+        skipSeparationSpace(state, true, nodeIndent);
+      }
+    }
+    _line = state.line;
+    _lineStart = state.lineStart;
+    _pos = state.position;
+    composeNode(state, nodeIndent, CONTEXT_FLOW_IN, false, true);
+    keyTag = state.tag;
+    keyNode = state.result;
+    skipSeparationSpace(state, true, nodeIndent);
+    ch = state.input.charCodeAt(state.position);
+    if ((isExplicitPair || state.line === _line) && ch === 58) {
+      isPair = true;
+      ch = state.input.charCodeAt(++state.position);
+      skipSeparationSpace(state, true, nodeIndent);
+      composeNode(state, nodeIndent, CONTEXT_FLOW_IN, false, true);
+      valueNode = state.result;
+    }
+    if (isMapping) {
+      storeMappingPair(state, _result, overridableKeys, keyTag, keyNode, valueNode, _line, _lineStart, _pos);
+    } else if (isPair) {
+      _result.push(storeMappingPair(state, null, overridableKeys, keyTag, keyNode, valueNode, _line, _lineStart, _pos));
+    } else {
+      _result.push(keyNode);
+    }
+    skipSeparationSpace(state, true, nodeIndent);
+    ch = state.input.charCodeAt(state.position);
+    if (ch === 44) {
+      readNext = true;
+      ch = state.input.charCodeAt(++state.position);
+    } else {
+      readNext = false;
+    }
+  }
+  throwError(state, "unexpected end of the stream within a flow collection");
+}
+function readBlockScalar(state, nodeIndent) {
+  var captureStart, folding, chomping = CHOMPING_CLIP, didReadContent = false, detectedIndent = false, textIndent = nodeIndent, emptyLines = 0, atMoreIndented = false, tmp, ch;
+  ch = state.input.charCodeAt(state.position);
+  if (ch === 124) {
+    folding = false;
+  } else if (ch === 62) {
+    folding = true;
+  } else {
+    return false;
+  }
+  state.kind = "scalar";
+  state.result = "";
+  while (ch !== 0) {
+    ch = state.input.charCodeAt(++state.position);
+    if (ch === 43 || ch === 45) {
+      if (CHOMPING_CLIP === chomping) {
+        chomping = ch === 43 ? CHOMPING_KEEP : CHOMPING_STRIP;
+      } else {
+        throwError(state, "repeat of a chomping mode identifier");
+      }
+    } else if ((tmp = fromDecimalCode(ch)) >= 0) {
+      if (tmp === 0) {
+        throwError(state, "bad explicit indentation width of a block scalar; it cannot be less than one");
+      } else if (!detectedIndent) {
+        textIndent = nodeIndent + tmp - 1;
+        detectedIndent = true;
+      } else {
+        throwError(state, "repeat of an indentation width identifier");
+      }
+    } else {
+      break;
+    }
+  }
+  if (is_WHITE_SPACE(ch)) {
+    do {
+      ch = state.input.charCodeAt(++state.position);
+    } while (is_WHITE_SPACE(ch));
+    if (ch === 35) {
+      do {
+        ch = state.input.charCodeAt(++state.position);
+      } while (!is_EOL(ch) && ch !== 0);
+    }
+  }
+  while (ch !== 0) {
+    readLineBreak(state);
+    state.lineIndent = 0;
+    ch = state.input.charCodeAt(state.position);
+    while ((!detectedIndent || state.lineIndent < textIndent) && ch === 32) {
+      state.lineIndent++;
+      ch = state.input.charCodeAt(++state.position);
+    }
+    if (!detectedIndent && state.lineIndent > textIndent) {
+      textIndent = state.lineIndent;
+    }
+    if (is_EOL(ch)) {
+      emptyLines++;
+      continue;
+    }
+    if (state.lineIndent < textIndent) {
+      if (chomping === CHOMPING_KEEP) {
+        state.result += common.repeat("\n", didReadContent ? 1 + emptyLines : emptyLines);
+      } else if (chomping === CHOMPING_CLIP) {
+        if (didReadContent) {
+          state.result += "\n";
+        }
+      }
+      break;
+    }
+    if (folding) {
+      if (is_WHITE_SPACE(ch)) {
+        atMoreIndented = true;
+        state.result += common.repeat("\n", didReadContent ? 1 + emptyLines : emptyLines);
+      } else if (atMoreIndented) {
+        atMoreIndented = false;
+        state.result += common.repeat("\n", emptyLines + 1);
+      } else if (emptyLines === 0) {
+        if (didReadContent) {
+          state.result += " ";
+        }
+      } else {
+        state.result += common.repeat("\n", emptyLines);
+      }
+    } else {
+      state.result += common.repeat("\n", didReadContent ? 1 + emptyLines : emptyLines);
+    }
+    didReadContent = true;
+    detectedIndent = true;
+    emptyLines = 0;
+    captureStart = state.position;
+    while (!is_EOL(ch) && ch !== 0) {
+      ch = state.input.charCodeAt(++state.position);
+    }
+    captureSegment(state, captureStart, state.position, false);
+  }
+  return true;
+}
+function readBlockSequence(state, nodeIndent) {
+  var _line, _tag = state.tag, _anchor = state.anchor, _result = [], following, detected = false, ch;
+  if (state.firstTabInLine !== -1) return false;
+  if (state.anchor !== null) {
+    state.anchorMap[state.anchor] = _result;
+  }
+  ch = state.input.charCodeAt(state.position);
+  while (ch !== 0) {
+    if (state.firstTabInLine !== -1) {
+      state.position = state.firstTabInLine;
+      throwError(state, "tab characters must not be used in indentation");
+    }
+    if (ch !== 45) {
+      break;
+    }
+    following = state.input.charCodeAt(state.position + 1);
+    if (!is_WS_OR_EOL(following)) {
+      break;
+    }
+    detected = true;
+    state.position++;
+    if (skipSeparationSpace(state, true, -1)) {
+      if (state.lineIndent <= nodeIndent) {
+        _result.push(null);
+        ch = state.input.charCodeAt(state.position);
+        continue;
+      }
+    }
+    _line = state.line;
+    composeNode(state, nodeIndent, CONTEXT_BLOCK_IN, false, true);
+    _result.push(state.result);
+    skipSeparationSpace(state, true, -1);
+    ch = state.input.charCodeAt(state.position);
+    if ((state.line === _line || state.lineIndent > nodeIndent) && ch !== 0) {
+      throwError(state, "bad indentation of a sequence entry");
+    } else if (state.lineIndent < nodeIndent) {
+      break;
+    }
+  }
+  if (detected) {
+    state.tag = _tag;
+    state.anchor = _anchor;
+    state.kind = "sequence";
+    state.result = _result;
+    return true;
+  }
+  return false;
+}
+function readBlockMapping(state, nodeIndent, flowIndent) {
+  var following, allowCompact, _line, _keyLine, _keyLineStart, _keyPos, _tag = state.tag, _anchor = state.anchor, _result = {}, overridableKeys = /* @__PURE__ */ Object.create(null), keyTag = null, keyNode = null, valueNode = null, atExplicitKey = false, detected = false, ch;
+  if (state.firstTabInLine !== -1) return false;
+  if (state.anchor !== null) {
+    state.anchorMap[state.anchor] = _result;
+  }
+  ch = state.input.charCodeAt(state.position);
+  while (ch !== 0) {
+    if (!atExplicitKey && state.firstTabInLine !== -1) {
+      state.position = state.firstTabInLine;
+      throwError(state, "tab characters must not be used in indentation");
+    }
+    following = state.input.charCodeAt(state.position + 1);
+    _line = state.line;
+    if ((ch === 63 || ch === 58) && is_WS_OR_EOL(following)) {
+      if (ch === 63) {
+        if (atExplicitKey) {
+          storeMappingPair(state, _result, overridableKeys, keyTag, keyNode, null, _keyLine, _keyLineStart, _keyPos);
+          keyTag = keyNode = valueNode = null;
+        }
+        detected = true;
+        atExplicitKey = true;
+        allowCompact = true;
+      } else if (atExplicitKey) {
+        atExplicitKey = false;
+        allowCompact = true;
+      } else {
+        throwError(state, "incomplete explicit mapping pair; a key node is missed; or followed by a non-tabulated empty line");
+      }
+      state.position += 1;
+      ch = following;
+    } else {
+      _keyLine = state.line;
+      _keyLineStart = state.lineStart;
+      _keyPos = state.position;
+      if (!composeNode(state, flowIndent, CONTEXT_FLOW_OUT, false, true)) {
+        break;
+      }
+      if (state.line === _line) {
+        ch = state.input.charCodeAt(state.position);
+        while (is_WHITE_SPACE(ch)) {
+          ch = state.input.charCodeAt(++state.position);
+        }
+        if (ch === 58) {
+          ch = state.input.charCodeAt(++state.position);
+          if (!is_WS_OR_EOL(ch)) {
+            throwError(state, "a whitespace character is expected after the key-value separator within a block mapping");
+          }
+          if (atExplicitKey) {
+            storeMappingPair(state, _result, overridableKeys, keyTag, keyNode, null, _keyLine, _keyLineStart, _keyPos);
+            keyTag = keyNode = valueNode = null;
+          }
+          detected = true;
+          atExplicitKey = false;
+          allowCompact = false;
+          keyTag = state.tag;
+          keyNode = state.result;
+        } else if (detected) {
+          throwError(state, "can not read an implicit mapping pair; a colon is missed");
+        } else {
+          state.tag = _tag;
+          state.anchor = _anchor;
+          return true;
+        }
+      } else if (detected) {
+        throwError(state, "can not read a block mapping entry; a multiline key may not be an implicit key");
+      } else {
+        state.tag = _tag;
+        state.anchor = _anchor;
+        return true;
+      }
+    }
+    if (state.line === _line || state.lineIndent > nodeIndent) {
+      if (atExplicitKey) {
+        _keyLine = state.line;
+        _keyLineStart = state.lineStart;
+        _keyPos = state.position;
+      }
+      if (composeNode(state, nodeIndent, CONTEXT_BLOCK_OUT, true, allowCompact)) {
+        if (atExplicitKey) {
+          keyNode = state.result;
+        } else {
+          valueNode = state.result;
+        }
+      }
+      if (!atExplicitKey) {
+        storeMappingPair(state, _result, overridableKeys, keyTag, keyNode, valueNode, _keyLine, _keyLineStart, _keyPos);
+        keyTag = keyNode = valueNode = null;
+      }
+      skipSeparationSpace(state, true, -1);
+      ch = state.input.charCodeAt(state.position);
+    }
+    if ((state.line === _line || state.lineIndent > nodeIndent) && ch !== 0) {
+      throwError(state, "bad indentation of a mapping entry");
+    } else if (state.lineIndent < nodeIndent) {
+      break;
+    }
+  }
+  if (atExplicitKey) {
+    storeMappingPair(state, _result, overridableKeys, keyTag, keyNode, null, _keyLine, _keyLineStart, _keyPos);
+  }
+  if (detected) {
+    state.tag = _tag;
+    state.anchor = _anchor;
+    state.kind = "mapping";
+    state.result = _result;
+  }
+  return detected;
+}
+function readTagProperty(state) {
+  var _position, isVerbatim = false, isNamed = false, tagHandle, tagName, ch;
+  ch = state.input.charCodeAt(state.position);
+  if (ch !== 33) return false;
+  if (state.tag !== null) {
+    throwError(state, "duplication of a tag property");
+  }
+  ch = state.input.charCodeAt(++state.position);
+  if (ch === 60) {
+    isVerbatim = true;
+    ch = state.input.charCodeAt(++state.position);
+  } else if (ch === 33) {
+    isNamed = true;
+    tagHandle = "!!";
+    ch = state.input.charCodeAt(++state.position);
+  } else {
+    tagHandle = "!";
+  }
+  _position = state.position;
+  if (isVerbatim) {
+    do {
+      ch = state.input.charCodeAt(++state.position);
+    } while (ch !== 0 && ch !== 62);
+    if (state.position < state.length) {
+      tagName = state.input.slice(_position, state.position);
+      ch = state.input.charCodeAt(++state.position);
+    } else {
+      throwError(state, "unexpected end of the stream within a verbatim tag");
+    }
+  } else {
+    while (ch !== 0 && !is_WS_OR_EOL(ch)) {
+      if (ch === 33) {
+        if (!isNamed) {
+          tagHandle = state.input.slice(_position - 1, state.position + 1);
+          if (!PATTERN_TAG_HANDLE.test(tagHandle)) {
+            throwError(state, "named tag handle cannot contain such characters");
+          }
+          isNamed = true;
+          _position = state.position + 1;
+        } else {
+          throwError(state, "tag suffix cannot contain exclamation marks");
+        }
+      }
+      ch = state.input.charCodeAt(++state.position);
+    }
+    tagName = state.input.slice(_position, state.position);
+    if (PATTERN_FLOW_INDICATORS.test(tagName)) {
+      throwError(state, "tag suffix cannot contain flow indicator characters");
+    }
+  }
+  if (tagName && !PATTERN_TAG_URI.test(tagName)) {
+    throwError(state, "tag name cannot contain such characters: " + tagName);
+  }
+  try {
+    tagName = decodeURIComponent(tagName);
+  } catch (err) {
+    throwError(state, "tag name is malformed: " + tagName);
+  }
+  if (isVerbatim) {
+    state.tag = tagName;
+  } else if (_hasOwnProperty$1.call(state.tagMap, tagHandle)) {
+    state.tag = state.tagMap[tagHandle] + tagName;
+  } else if (tagHandle === "!") {
+    state.tag = "!" + tagName;
+  } else if (tagHandle === "!!") {
+    state.tag = "tag:yaml.org,2002:" + tagName;
+  } else {
+    throwError(state, 'undeclared tag handle "' + tagHandle + '"');
+  }
+  return true;
+}
+function readAnchorProperty(state) {
+  var _position, ch;
+  ch = state.input.charCodeAt(state.position);
+  if (ch !== 38) return false;
+  if (state.anchor !== null) {
+    throwError(state, "duplication of an anchor property");
+  }
+  ch = state.input.charCodeAt(++state.position);
+  _position = state.position;
+  while (ch !== 0 && !is_WS_OR_EOL(ch) && !is_FLOW_INDICATOR(ch)) {
+    ch = state.input.charCodeAt(++state.position);
+  }
+  if (state.position === _position) {
+    throwError(state, "name of an anchor node must contain at least one character");
+  }
+  state.anchor = state.input.slice(_position, state.position);
+  return true;
+}
+function readAlias(state) {
+  var _position, alias, ch;
+  ch = state.input.charCodeAt(state.position);
+  if (ch !== 42) return false;
+  ch = state.input.charCodeAt(++state.position);
+  _position = state.position;
+  while (ch !== 0 && !is_WS_OR_EOL(ch) && !is_FLOW_INDICATOR(ch)) {
+    ch = state.input.charCodeAt(++state.position);
+  }
+  if (state.position === _position) {
+    throwError(state, "name of an alias node must contain at least one character");
+  }
+  alias = state.input.slice(_position, state.position);
+  if (!_hasOwnProperty$1.call(state.anchorMap, alias)) {
+    throwError(state, 'unidentified alias "' + alias + '"');
+  }
+  state.result = state.anchorMap[alias];
+  skipSeparationSpace(state, true, -1);
+  return true;
+}
+function composeNode(state, parentIndent, nodeContext, allowToSeek, allowCompact) {
+  var allowBlockStyles, allowBlockScalars, allowBlockCollections, indentStatus = 1, atNewLine = false, hasContent = false, typeIndex, typeQuantity, typeList, type2, flowIndent, blockIndent;
+  if (state.listener !== null) {
+    state.listener("open", state);
+  }
+  state.tag = null;
+  state.anchor = null;
+  state.kind = null;
+  state.result = null;
+  allowBlockStyles = allowBlockScalars = allowBlockCollections = CONTEXT_BLOCK_OUT === nodeContext || CONTEXT_BLOCK_IN === nodeContext;
+  if (allowToSeek) {
+    if (skipSeparationSpace(state, true, -1)) {
+      atNewLine = true;
+      if (state.lineIndent > parentIndent) {
+        indentStatus = 1;
+      } else if (state.lineIndent === parentIndent) {
+        indentStatus = 0;
+      } else if (state.lineIndent < parentIndent) {
+        indentStatus = -1;
+      }
+    }
+  }
+  if (indentStatus === 1) {
+    while (readTagProperty(state) || readAnchorProperty(state)) {
+      if (skipSeparationSpace(state, true, -1)) {
+        atNewLine = true;
+        allowBlockCollections = allowBlockStyles;
+        if (state.lineIndent > parentIndent) {
+          indentStatus = 1;
+        } else if (state.lineIndent === parentIndent) {
+          indentStatus = 0;
+        } else if (state.lineIndent < parentIndent) {
+          indentStatus = -1;
+        }
+      } else {
+        allowBlockCollections = false;
+      }
+    }
+  }
+  if (allowBlockCollections) {
+    allowBlockCollections = atNewLine || allowCompact;
+  }
+  if (indentStatus === 1 || CONTEXT_BLOCK_OUT === nodeContext) {
+    if (CONTEXT_FLOW_IN === nodeContext || CONTEXT_FLOW_OUT === nodeContext) {
+      flowIndent = parentIndent;
+    } else {
+      flowIndent = parentIndent + 1;
+    }
+    blockIndent = state.position - state.lineStart;
+    if (indentStatus === 1) {
+      if (allowBlockCollections && (readBlockSequence(state, blockIndent) || readBlockMapping(state, blockIndent, flowIndent)) || readFlowCollection(state, flowIndent)) {
+        hasContent = true;
+      } else {
+        if (allowBlockScalars && readBlockScalar(state, flowIndent) || readSingleQuotedScalar(state, flowIndent) || readDoubleQuotedScalar(state, flowIndent)) {
+          hasContent = true;
+        } else if (readAlias(state)) {
+          hasContent = true;
+          if (state.tag !== null || state.anchor !== null) {
+            throwError(state, "alias node should not have any properties");
+          }
+        } else if (readPlainScalar(state, flowIndent, CONTEXT_FLOW_IN === nodeContext)) {
+          hasContent = true;
+          if (state.tag === null) {
+            state.tag = "?";
+          }
+        }
+        if (state.anchor !== null) {
+          state.anchorMap[state.anchor] = state.result;
+        }
+      }
+    } else if (indentStatus === 0) {
+      hasContent = allowBlockCollections && readBlockSequence(state, blockIndent);
+    }
+  }
+  if (state.tag === null) {
+    if (state.anchor !== null) {
+      state.anchorMap[state.anchor] = state.result;
+    }
+  } else if (state.tag === "?") {
+    if (state.result !== null && state.kind !== "scalar") {
+      throwError(state, 'unacceptable node kind for !<?> tag; it should be "scalar", not "' + state.kind + '"');
+    }
+    for (typeIndex = 0, typeQuantity = state.implicitTypes.length; typeIndex < typeQuantity; typeIndex += 1) {
+      type2 = state.implicitTypes[typeIndex];
+      if (type2.resolve(state.result)) {
+        state.result = type2.construct(state.result);
+        state.tag = type2.tag;
+        if (state.anchor !== null) {
+          state.anchorMap[state.anchor] = state.result;
+        }
+        break;
+      }
+    }
+  } else if (state.tag !== "!") {
+    if (_hasOwnProperty$1.call(state.typeMap[state.kind || "fallback"], state.tag)) {
+      type2 = state.typeMap[state.kind || "fallback"][state.tag];
+    } else {
+      type2 = null;
+      typeList = state.typeMap.multi[state.kind || "fallback"];
+      for (typeIndex = 0, typeQuantity = typeList.length; typeIndex < typeQuantity; typeIndex += 1) {
+        if (state.tag.slice(0, typeList[typeIndex].tag.length) === typeList[typeIndex].tag) {
+          type2 = typeList[typeIndex];
+          break;
+        }
+      }
+    }
+    if (!type2) {
+      throwError(state, "unknown tag !<" + state.tag + ">");
+    }
+    if (state.result !== null && type2.kind !== state.kind) {
+      throwError(state, "unacceptable node kind for !<" + state.tag + '> tag; it should be "' + type2.kind + '", not "' + state.kind + '"');
+    }
+    if (!type2.resolve(state.result, state.tag)) {
+      throwError(state, "cannot resolve a node with !<" + state.tag + "> explicit tag");
+    } else {
+      state.result = type2.construct(state.result, state.tag);
+      if (state.anchor !== null) {
+        state.anchorMap[state.anchor] = state.result;
+      }
+    }
+  }
+  if (state.listener !== null) {
+    state.listener("close", state);
+  }
+  return state.tag !== null || state.anchor !== null || hasContent;
+}
+function readDocument(state) {
+  var documentStart = state.position, _position, directiveName, directiveArgs, hasDirectives = false, ch;
+  state.version = null;
+  state.checkLineBreaks = state.legacy;
+  state.tagMap = /* @__PURE__ */ Object.create(null);
+  state.anchorMap = /* @__PURE__ */ Object.create(null);
+  while ((ch = state.input.charCodeAt(state.position)) !== 0) {
+    skipSeparationSpace(state, true, -1);
+    ch = state.input.charCodeAt(state.position);
+    if (state.lineIndent > 0 || ch !== 37) {
+      break;
+    }
+    hasDirectives = true;
+    ch = state.input.charCodeAt(++state.position);
+    _position = state.position;
+    while (ch !== 0 && !is_WS_OR_EOL(ch)) {
+      ch = state.input.charCodeAt(++state.position);
+    }
+    directiveName = state.input.slice(_position, state.position);
+    directiveArgs = [];
+    if (directiveName.length < 1) {
+      throwError(state, "directive name must not be less than one character in length");
+    }
+    while (ch !== 0) {
+      while (is_WHITE_SPACE(ch)) {
+        ch = state.input.charCodeAt(++state.position);
+      }
+      if (ch === 35) {
+        do {
+          ch = state.input.charCodeAt(++state.position);
+        } while (ch !== 0 && !is_EOL(ch));
+        break;
+      }
+      if (is_EOL(ch)) break;
+      _position = state.position;
+      while (ch !== 0 && !is_WS_OR_EOL(ch)) {
+        ch = state.input.charCodeAt(++state.position);
+      }
+      directiveArgs.push(state.input.slice(_position, state.position));
+    }
+    if (ch !== 0) readLineBreak(state);
+    if (_hasOwnProperty$1.call(directiveHandlers, directiveName)) {
+      directiveHandlers[directiveName](state, directiveName, directiveArgs);
+    } else {
+      throwWarning(state, 'unknown document directive "' + directiveName + '"');
+    }
+  }
+  skipSeparationSpace(state, true, -1);
+  if (state.lineIndent === 0 && state.input.charCodeAt(state.position) === 45 && state.input.charCodeAt(state.position + 1) === 45 && state.input.charCodeAt(state.position + 2) === 45) {
+    state.position += 3;
+    skipSeparationSpace(state, true, -1);
+  } else if (hasDirectives) {
+    throwError(state, "directives end mark is expected");
+  }
+  composeNode(state, state.lineIndent - 1, CONTEXT_BLOCK_OUT, false, true);
+  skipSeparationSpace(state, true, -1);
+  if (state.checkLineBreaks && PATTERN_NON_ASCII_LINE_BREAKS.test(state.input.slice(documentStart, state.position))) {
+    throwWarning(state, "non-ASCII line breaks are interpreted as content");
+  }
+  state.documents.push(state.result);
+  if (state.position === state.lineStart && testDocumentSeparator(state)) {
+    if (state.input.charCodeAt(state.position) === 46) {
+      state.position += 3;
+      skipSeparationSpace(state, true, -1);
+    }
+    return;
+  }
+  if (state.position < state.length - 1) {
+    throwError(state, "end of the stream or a document separator is expected");
+  } else {
+    return;
+  }
+}
+function loadDocuments(input, options) {
+  input = String(input);
+  options = options || {};
+  if (input.length !== 0) {
+    if (input.charCodeAt(input.length - 1) !== 10 && input.charCodeAt(input.length - 1) !== 13) {
+      input += "\n";
+    }
+    if (input.charCodeAt(0) === 65279) {
+      input = input.slice(1);
+    }
+  }
+  var state = new State$1(input, options);
+  var nullpos = input.indexOf("\0");
+  if (nullpos !== -1) {
+    state.position = nullpos;
+    throwError(state, "null byte is not allowed in input");
+  }
+  state.input += "\0";
+  while (state.input.charCodeAt(state.position) === 32) {
+    state.lineIndent += 1;
+    state.position += 1;
+  }
+  while (state.position < state.length - 1) {
+    readDocument(state);
+  }
+  return state.documents;
+}
+function loadAll$1(input, iterator, options) {
+  if (iterator !== null && typeof iterator === "object" && typeof options === "undefined") {
+    options = iterator;
+    iterator = null;
+  }
+  var documents = loadDocuments(input, options);
+  if (typeof iterator !== "function") {
+    return documents;
+  }
+  for (var index = 0, length = documents.length; index < length; index += 1) {
+    iterator(documents[index]);
+  }
+}
+function load$1(input, options) {
+  var documents = loadDocuments(input, options);
+  if (documents.length === 0) {
+    return void 0;
+  } else if (documents.length === 1) {
+    return documents[0];
+  }
+  throw new exception("expected a single document in the stream, but found more");
+}
+var loadAll_1 = loadAll$1;
+var load_1 = load$1;
+var loader = {
+  loadAll: loadAll_1,
+  load: load_1
+};
+var _toString = Object.prototype.toString;
+var _hasOwnProperty = Object.prototype.hasOwnProperty;
+var CHAR_BOM = 65279;
+var CHAR_TAB = 9;
+var CHAR_LINE_FEED = 10;
+var CHAR_CARRIAGE_RETURN = 13;
+var CHAR_SPACE = 32;
+var CHAR_EXCLAMATION = 33;
+var CHAR_DOUBLE_QUOTE = 34;
+var CHAR_SHARP = 35;
+var CHAR_PERCENT = 37;
+var CHAR_AMPERSAND = 38;
+var CHAR_SINGLE_QUOTE = 39;
+var CHAR_ASTERISK = 42;
+var CHAR_COMMA = 44;
+var CHAR_MINUS = 45;
+var CHAR_COLON = 58;
+var CHAR_EQUALS = 61;
+var CHAR_GREATER_THAN = 62;
+var CHAR_QUESTION = 63;
+var CHAR_COMMERCIAL_AT = 64;
+var CHAR_LEFT_SQUARE_BRACKET = 91;
+var CHAR_RIGHT_SQUARE_BRACKET = 93;
+var CHAR_GRAVE_ACCENT = 96;
+var CHAR_LEFT_CURLY_BRACKET = 123;
+var CHAR_VERTICAL_LINE = 124;
+var CHAR_RIGHT_CURLY_BRACKET = 125;
+var ESCAPE_SEQUENCES = {};
+ESCAPE_SEQUENCES[0] = "\\0";
+ESCAPE_SEQUENCES[7] = "\\a";
+ESCAPE_SEQUENCES[8] = "\\b";
+ESCAPE_SEQUENCES[9] = "\\t";
+ESCAPE_SEQUENCES[10] = "\\n";
+ESCAPE_SEQUENCES[11] = "\\v";
+ESCAPE_SEQUENCES[12] = "\\f";
+ESCAPE_SEQUENCES[13] = "\\r";
+ESCAPE_SEQUENCES[27] = "\\e";
+ESCAPE_SEQUENCES[34] = '\\"';
+ESCAPE_SEQUENCES[92] = "\\\\";
+ESCAPE_SEQUENCES[133] = "\\N";
+ESCAPE_SEQUENCES[160] = "\\_";
+ESCAPE_SEQUENCES[8232] = "\\L";
+ESCAPE_SEQUENCES[8233] = "\\P";
+var DEPRECATED_BOOLEANS_SYNTAX = [
+  "y",
+  "Y",
+  "yes",
+  "Yes",
+  "YES",
+  "on",
+  "On",
+  "ON",
+  "n",
+  "N",
+  "no",
+  "No",
+  "NO",
+  "off",
+  "Off",
+  "OFF"
+];
+var DEPRECATED_BASE60_SYNTAX = /^[-+]?[0-9_]+(?::[0-9_]+)+(?:\.[0-9_]*)?$/;
+function compileStyleMap(schema2, map2) {
+  var result, keys, index, length, tag, style, type2;
+  if (map2 === null) return {};
+  result = {};
+  keys = Object.keys(map2);
+  for (index = 0, length = keys.length; index < length; index += 1) {
+    tag = keys[index];
+    style = String(map2[tag]);
+    if (tag.slice(0, 2) === "!!") {
+      tag = "tag:yaml.org,2002:" + tag.slice(2);
+    }
+    type2 = schema2.compiledTypeMap["fallback"][tag];
+    if (type2 && _hasOwnProperty.call(type2.styleAliases, style)) {
+      style = type2.styleAliases[style];
+    }
+    result[tag] = style;
+  }
+  return result;
+}
+function encodeHex(character) {
+  var string, handle, length;
+  string = character.toString(16).toUpperCase();
+  if (character <= 255) {
+    handle = "x";
+    length = 2;
+  } else if (character <= 65535) {
+    handle = "u";
+    length = 4;
+  } else if (character <= 4294967295) {
+    handle = "U";
+    length = 8;
+  } else {
+    throw new exception("code point within a string may not be greater than 0xFFFFFFFF");
+  }
+  return "\\" + handle + common.repeat("0", length - string.length) + string;
+}
+var QUOTING_TYPE_SINGLE = 1;
+var QUOTING_TYPE_DOUBLE = 2;
+function State(options) {
+  this.schema = options["schema"] || _default;
+  this.indent = Math.max(1, options["indent"] || 2);
+  this.noArrayIndent = options["noArrayIndent"] || false;
+  this.skipInvalid = options["skipInvalid"] || false;
+  this.flowLevel = common.isNothing(options["flowLevel"]) ? -1 : options["flowLevel"];
+  this.styleMap = compileStyleMap(this.schema, options["styles"] || null);
+  this.sortKeys = options["sortKeys"] || false;
+  this.lineWidth = options["lineWidth"] || 80;
+  this.noRefs = options["noRefs"] || false;
+  this.noCompatMode = options["noCompatMode"] || false;
+  this.condenseFlow = options["condenseFlow"] || false;
+  this.quotingType = options["quotingType"] === '"' ? QUOTING_TYPE_DOUBLE : QUOTING_TYPE_SINGLE;
+  this.forceQuotes = options["forceQuotes"] || false;
+  this.replacer = typeof options["replacer"] === "function" ? options["replacer"] : null;
+  this.implicitTypes = this.schema.compiledImplicit;
+  this.explicitTypes = this.schema.compiledExplicit;
+  this.tag = null;
+  this.result = "";
+  this.duplicates = [];
+  this.usedDuplicates = null;
+}
+function indentString(string, spaces) {
+  var ind = common.repeat(" ", spaces), position = 0, next = -1, result = "", line, length = string.length;
+  while (position < length) {
+    next = string.indexOf("\n", position);
+    if (next === -1) {
+      line = string.slice(position);
+      position = length;
+    } else {
+      line = string.slice(position, next + 1);
+      position = next + 1;
+    }
+    if (line.length && line !== "\n") result += ind;
+    result += line;
+  }
+  return result;
+}
+function generateNextLine(state, level) {
+  return "\n" + common.repeat(" ", state.indent * level);
+}
+function testImplicitResolving(state, str2) {
+  var index, length, type2;
+  for (index = 0, length = state.implicitTypes.length; index < length; index += 1) {
+    type2 = state.implicitTypes[index];
+    if (type2.resolve(str2)) {
+      return true;
+    }
+  }
+  return false;
+}
+function isWhitespace(c) {
+  return c === CHAR_SPACE || c === CHAR_TAB;
+}
+function isPrintable(c) {
+  return 32 <= c && c <= 126 || 161 <= c && c <= 55295 && c !== 8232 && c !== 8233 || 57344 <= c && c <= 65533 && c !== CHAR_BOM || 65536 <= c && c <= 1114111;
+}
+function isNsCharOrWhitespace(c) {
+  return isPrintable(c) && c !== CHAR_BOM && c !== CHAR_CARRIAGE_RETURN && c !== CHAR_LINE_FEED;
+}
+function isPlainSafe(c, prev, inblock) {
+  var cIsNsCharOrWhitespace = isNsCharOrWhitespace(c);
+  var cIsNsChar = cIsNsCharOrWhitespace && !isWhitespace(c);
+  return (
+    // ns-plain-safe
+    (inblock ? (
+      // c = flow-in
+      cIsNsCharOrWhitespace
+    ) : cIsNsCharOrWhitespace && c !== CHAR_COMMA && c !== CHAR_LEFT_SQUARE_BRACKET && c !== CHAR_RIGHT_SQUARE_BRACKET && c !== CHAR_LEFT_CURLY_BRACKET && c !== CHAR_RIGHT_CURLY_BRACKET) && c !== CHAR_SHARP && !(prev === CHAR_COLON && !cIsNsChar) || isNsCharOrWhitespace(prev) && !isWhitespace(prev) && c === CHAR_SHARP || prev === CHAR_COLON && cIsNsChar
+  );
+}
+function isPlainSafeFirst(c) {
+  return isPrintable(c) && c !== CHAR_BOM && !isWhitespace(c) && c !== CHAR_MINUS && c !== CHAR_QUESTION && c !== CHAR_COLON && c !== CHAR_COMMA && c !== CHAR_LEFT_SQUARE_BRACKET && c !== CHAR_RIGHT_SQUARE_BRACKET && c !== CHAR_LEFT_CURLY_BRACKET && c !== CHAR_RIGHT_CURLY_BRACKET && c !== CHAR_SHARP && c !== CHAR_AMPERSAND && c !== CHAR_ASTERISK && c !== CHAR_EXCLAMATION && c !== CHAR_VERTICAL_LINE && c !== CHAR_EQUALS && c !== CHAR_GREATER_THAN && c !== CHAR_SINGLE_QUOTE && c !== CHAR_DOUBLE_QUOTE && c !== CHAR_PERCENT && c !== CHAR_COMMERCIAL_AT && c !== CHAR_GRAVE_ACCENT;
+}
+function isPlainSafeLast(c) {
+  return !isWhitespace(c) && c !== CHAR_COLON;
+}
+function codePointAt(string, pos) {
+  var first = string.charCodeAt(pos), second;
+  if (first >= 55296 && first <= 56319 && pos + 1 < string.length) {
+    second = string.charCodeAt(pos + 1);
+    if (second >= 56320 && second <= 57343) {
+      return (first - 55296) * 1024 + second - 56320 + 65536;
+    }
+  }
+  return first;
+}
+function needIndentIndicator(string) {
+  var leadingSpaceRe = /^\n* /;
+  return leadingSpaceRe.test(string);
+}
+var STYLE_PLAIN = 1;
+var STYLE_SINGLE = 2;
+var STYLE_LITERAL = 3;
+var STYLE_FOLDED = 4;
+var STYLE_DOUBLE = 5;
+function chooseScalarStyle(string, singleLineOnly, indentPerLevel, lineWidth, testAmbiguousType, quotingType, forceQuotes, inblock) {
+  var i;
+  var char = 0;
+  var prevChar = null;
+  var hasLineBreak = false;
+  var hasFoldableLine = false;
+  var shouldTrackWidth = lineWidth !== -1;
+  var previousLineBreak = -1;
+  var plain = isPlainSafeFirst(codePointAt(string, 0)) && isPlainSafeLast(codePointAt(string, string.length - 1));
+  if (singleLineOnly || forceQuotes) {
+    for (i = 0; i < string.length; char >= 65536 ? i += 2 : i++) {
+      char = codePointAt(string, i);
+      if (!isPrintable(char)) {
+        return STYLE_DOUBLE;
+      }
+      plain = plain && isPlainSafe(char, prevChar, inblock);
+      prevChar = char;
+    }
+  } else {
+    for (i = 0; i < string.length; char >= 65536 ? i += 2 : i++) {
+      char = codePointAt(string, i);
+      if (char === CHAR_LINE_FEED) {
+        hasLineBreak = true;
+        if (shouldTrackWidth) {
+          hasFoldableLine = hasFoldableLine || // Foldable line = too long, and not more-indented.
+          i - previousLineBreak - 1 > lineWidth && string[previousLineBreak + 1] !== " ";
+          previousLineBreak = i;
+        }
+      } else if (!isPrintable(char)) {
+        return STYLE_DOUBLE;
+      }
+      plain = plain && isPlainSafe(char, prevChar, inblock);
+      prevChar = char;
+    }
+    hasFoldableLine = hasFoldableLine || shouldTrackWidth && (i - previousLineBreak - 1 > lineWidth && string[previousLineBreak + 1] !== " ");
+  }
+  if (!hasLineBreak && !hasFoldableLine) {
+    if (plain && !forceQuotes && !testAmbiguousType(string)) {
+      return STYLE_PLAIN;
+    }
+    return quotingType === QUOTING_TYPE_DOUBLE ? STYLE_DOUBLE : STYLE_SINGLE;
+  }
+  if (indentPerLevel > 9 && needIndentIndicator(string)) {
+    return STYLE_DOUBLE;
+  }
+  if (!forceQuotes) {
+    return hasFoldableLine ? STYLE_FOLDED : STYLE_LITERAL;
+  }
+  return quotingType === QUOTING_TYPE_DOUBLE ? STYLE_DOUBLE : STYLE_SINGLE;
+}
+function writeScalar(state, string, level, iskey, inblock) {
+  state.dump = (function() {
+    if (string.length === 0) {
+      return state.quotingType === QUOTING_TYPE_DOUBLE ? '""' : "''";
+    }
+    if (!state.noCompatMode) {
+      if (DEPRECATED_BOOLEANS_SYNTAX.indexOf(string) !== -1 || DEPRECATED_BASE60_SYNTAX.test(string)) {
+        return state.quotingType === QUOTING_TYPE_DOUBLE ? '"' + string + '"' : "'" + string + "'";
+      }
+    }
+    var indent = state.indent * Math.max(1, level);
+    var lineWidth = state.lineWidth === -1 ? -1 : Math.max(Math.min(state.lineWidth, 40), state.lineWidth - indent);
+    var singleLineOnly = iskey || state.flowLevel > -1 && level >= state.flowLevel;
+    function testAmbiguity(string2) {
+      return testImplicitResolving(state, string2);
+    }
+    switch (chooseScalarStyle(
+      string,
+      singleLineOnly,
+      state.indent,
+      lineWidth,
+      testAmbiguity,
+      state.quotingType,
+      state.forceQuotes && !iskey,
+      inblock
+    )) {
+      case STYLE_PLAIN:
+        return string;
+      case STYLE_SINGLE:
+        return "'" + string.replace(/'/g, "''") + "'";
+      case STYLE_LITERAL:
+        return "|" + blockHeader(string, state.indent) + dropEndingNewline(indentString(string, indent));
+      case STYLE_FOLDED:
+        return ">" + blockHeader(string, state.indent) + dropEndingNewline(indentString(foldString(string, lineWidth), indent));
+      case STYLE_DOUBLE:
+        return '"' + escapeString(string) + '"';
+      default:
+        throw new exception("impossible error: invalid scalar style");
+    }
+  })();
+}
+function blockHeader(string, indentPerLevel) {
+  var indentIndicator = needIndentIndicator(string) ? String(indentPerLevel) : "";
+  var clip = string[string.length - 1] === "\n";
+  var keep = clip && (string[string.length - 2] === "\n" || string === "\n");
+  var chomp = keep ? "+" : clip ? "" : "-";
+  return indentIndicator + chomp + "\n";
+}
+function dropEndingNewline(string) {
+  return string[string.length - 1] === "\n" ? string.slice(0, -1) : string;
+}
+function foldString(string, width) {
+  var lineRe = /(\n+)([^\n]*)/g;
+  var result = (function() {
+    var nextLF = string.indexOf("\n");
+    nextLF = nextLF !== -1 ? nextLF : string.length;
+    lineRe.lastIndex = nextLF;
+    return foldLine(string.slice(0, nextLF), width);
+  })();
+  var prevMoreIndented = string[0] === "\n" || string[0] === " ";
+  var moreIndented;
+  var match;
+  while (match = lineRe.exec(string)) {
+    var prefix = match[1], line = match[2];
+    moreIndented = line[0] === " ";
+    result += prefix + (!prevMoreIndented && !moreIndented && line !== "" ? "\n" : "") + foldLine(line, width);
+    prevMoreIndented = moreIndented;
+  }
+  return result;
+}
+function foldLine(line, width) {
+  if (line === "" || line[0] === " ") return line;
+  var breakRe = / [^ ]/g;
+  var match;
+  var start = 0, end, curr = 0, next = 0;
+  var result = "";
+  while (match = breakRe.exec(line)) {
+    next = match.index;
+    if (next - start > width) {
+      end = curr > start ? curr : next;
+      result += "\n" + line.slice(start, end);
+      start = end + 1;
+    }
+    curr = next;
+  }
+  result += "\n";
+  if (line.length - start > width && curr > start) {
+    result += line.slice(start, curr) + "\n" + line.slice(curr + 1);
+  } else {
+    result += line.slice(start);
+  }
+  return result.slice(1);
+}
+function escapeString(string) {
+  var result = "";
+  var char = 0;
+  var escapeSeq;
+  for (var i = 0; i < string.length; char >= 65536 ? i += 2 : i++) {
+    char = codePointAt(string, i);
+    escapeSeq = ESCAPE_SEQUENCES[char];
+    if (!escapeSeq && isPrintable(char)) {
+      result += string[i];
+      if (char >= 65536) result += string[i + 1];
+    } else {
+      result += escapeSeq || encodeHex(char);
+    }
+  }
+  return result;
+}
+function writeFlowSequence(state, level, object) {
+  var _result = "", _tag = state.tag, index, length, value;
+  for (index = 0, length = object.length; index < length; index += 1) {
+    value = object[index];
+    if (state.replacer) {
+      value = state.replacer.call(object, String(index), value);
+    }
+    if (writeNode(state, level, value, false, false) || typeof value === "undefined" && writeNode(state, level, null, false, false)) {
+      if (_result !== "") _result += "," + (!state.condenseFlow ? " " : "");
+      _result += state.dump;
+    }
+  }
+  state.tag = _tag;
+  state.dump = "[" + _result + "]";
+}
+function writeBlockSequence(state, level, object, compact) {
+  var _result = "", _tag = state.tag, index, length, value;
+  for (index = 0, length = object.length; index < length; index += 1) {
+    value = object[index];
+    if (state.replacer) {
+      value = state.replacer.call(object, String(index), value);
+    }
+    if (writeNode(state, level + 1, value, true, true, false, true) || typeof value === "undefined" && writeNode(state, level + 1, null, true, true, false, true)) {
+      if (!compact || _result !== "") {
+        _result += generateNextLine(state, level);
+      }
+      if (state.dump && CHAR_LINE_FEED === state.dump.charCodeAt(0)) {
+        _result += "-";
+      } else {
+        _result += "- ";
+      }
+      _result += state.dump;
+    }
+  }
+  state.tag = _tag;
+  state.dump = _result || "[]";
+}
+function writeFlowMapping(state, level, object) {
+  var _result = "", _tag = state.tag, objectKeyList = Object.keys(object), index, length, objectKey, objectValue, pairBuffer;
+  for (index = 0, length = objectKeyList.length; index < length; index += 1) {
+    pairBuffer = "";
+    if (_result !== "") pairBuffer += ", ";
+    if (state.condenseFlow) pairBuffer += '"';
+    objectKey = objectKeyList[index];
+    objectValue = object[objectKey];
+    if (state.replacer) {
+      objectValue = state.replacer.call(object, objectKey, objectValue);
+    }
+    if (!writeNode(state, level, objectKey, false, false)) {
+      continue;
+    }
+    if (state.dump.length > 1024) pairBuffer += "? ";
+    pairBuffer += state.dump + (state.condenseFlow ? '"' : "") + ":" + (state.condenseFlow ? "" : " ");
+    if (!writeNode(state, level, objectValue, false, false)) {
+      continue;
+    }
+    pairBuffer += state.dump;
+    _result += pairBuffer;
+  }
+  state.tag = _tag;
+  state.dump = "{" + _result + "}";
+}
+function writeBlockMapping(state, level, object, compact) {
+  var _result = "", _tag = state.tag, objectKeyList = Object.keys(object), index, length, objectKey, objectValue, explicitPair, pairBuffer;
+  if (state.sortKeys === true) {
+    objectKeyList.sort();
+  } else if (typeof state.sortKeys === "function") {
+    objectKeyList.sort(state.sortKeys);
+  } else if (state.sortKeys) {
+    throw new exception("sortKeys must be a boolean or a function");
+  }
+  for (index = 0, length = objectKeyList.length; index < length; index += 1) {
+    pairBuffer = "";
+    if (!compact || _result !== "") {
+      pairBuffer += generateNextLine(state, level);
+    }
+    objectKey = objectKeyList[index];
+    objectValue = object[objectKey];
+    if (state.replacer) {
+      objectValue = state.replacer.call(object, objectKey, objectValue);
+    }
+    if (!writeNode(state, level + 1, objectKey, true, true, true)) {
+      continue;
+    }
+    explicitPair = state.tag !== null && state.tag !== "?" || state.dump && state.dump.length > 1024;
+    if (explicitPair) {
+      if (state.dump && CHAR_LINE_FEED === state.dump.charCodeAt(0)) {
+        pairBuffer += "?";
+      } else {
+        pairBuffer += "? ";
+      }
+    }
+    pairBuffer += state.dump;
+    if (explicitPair) {
+      pairBuffer += generateNextLine(state, level);
+    }
+    if (!writeNode(state, level + 1, objectValue, true, explicitPair)) {
+      continue;
+    }
+    if (state.dump && CHAR_LINE_FEED === state.dump.charCodeAt(0)) {
+      pairBuffer += ":";
+    } else {
+      pairBuffer += ": ";
+    }
+    pairBuffer += state.dump;
+    _result += pairBuffer;
+  }
+  state.tag = _tag;
+  state.dump = _result || "{}";
+}
+function detectType(state, object, explicit) {
+  var _result, typeList, index, length, type2, style;
+  typeList = explicit ? state.explicitTypes : state.implicitTypes;
+  for (index = 0, length = typeList.length; index < length; index += 1) {
+    type2 = typeList[index];
+    if ((type2.instanceOf || type2.predicate) && (!type2.instanceOf || typeof object === "object" && object instanceof type2.instanceOf) && (!type2.predicate || type2.predicate(object))) {
+      if (explicit) {
+        if (type2.multi && type2.representName) {
+          state.tag = type2.representName(object);
+        } else {
+          state.tag = type2.tag;
+        }
+      } else {
+        state.tag = "?";
+      }
+      if (type2.represent) {
+        style = state.styleMap[type2.tag] || type2.defaultStyle;
+        if (_toString.call(type2.represent) === "[object Function]") {
+          _result = type2.represent(object, style);
+        } else if (_hasOwnProperty.call(type2.represent, style)) {
+          _result = type2.represent[style](object, style);
+        } else {
+          throw new exception("!<" + type2.tag + '> tag resolver accepts not "' + style + '" style');
+        }
+        state.dump = _result;
+      }
+      return true;
+    }
+  }
+  return false;
+}
+function writeNode(state, level, object, block, compact, iskey, isblockseq) {
+  state.tag = null;
+  state.dump = object;
+  if (!detectType(state, object, false)) {
+    detectType(state, object, true);
+  }
+  var type2 = _toString.call(state.dump);
+  var inblock = block;
+  var tagStr;
+  if (block) {
+    block = state.flowLevel < 0 || state.flowLevel > level;
+  }
+  var objectOrArray = type2 === "[object Object]" || type2 === "[object Array]", duplicateIndex, duplicate;
+  if (objectOrArray) {
+    duplicateIndex = state.duplicates.indexOf(object);
+    duplicate = duplicateIndex !== -1;
+  }
+  if (state.tag !== null && state.tag !== "?" || duplicate || state.indent !== 2 && level > 0) {
+    compact = false;
+  }
+  if (duplicate && state.usedDuplicates[duplicateIndex]) {
+    state.dump = "*ref_" + duplicateIndex;
+  } else {
+    if (objectOrArray && duplicate && !state.usedDuplicates[duplicateIndex]) {
+      state.usedDuplicates[duplicateIndex] = true;
+    }
+    if (type2 === "[object Object]") {
+      if (block && Object.keys(state.dump).length !== 0) {
+        writeBlockMapping(state, level, state.dump, compact);
+        if (duplicate) {
+          state.dump = "&ref_" + duplicateIndex + state.dump;
+        }
+      } else {
+        writeFlowMapping(state, level, state.dump);
+        if (duplicate) {
+          state.dump = "&ref_" + duplicateIndex + " " + state.dump;
+        }
+      }
+    } else if (type2 === "[object Array]") {
+      if (block && state.dump.length !== 0) {
+        if (state.noArrayIndent && !isblockseq && level > 0) {
+          writeBlockSequence(state, level - 1, state.dump, compact);
+        } else {
+          writeBlockSequence(state, level, state.dump, compact);
+        }
+        if (duplicate) {
+          state.dump = "&ref_" + duplicateIndex + state.dump;
+        }
+      } else {
+        writeFlowSequence(state, level, state.dump);
+        if (duplicate) {
+          state.dump = "&ref_" + duplicateIndex + " " + state.dump;
+        }
+      }
+    } else if (type2 === "[object String]") {
+      if (state.tag !== "?") {
+        writeScalar(state, state.dump, level, iskey, inblock);
+      }
+    } else if (type2 === "[object Undefined]") {
+      return false;
+    } else {
+      if (state.skipInvalid) return false;
+      throw new exception("unacceptable kind of an object to dump " + type2);
+    }
+    if (state.tag !== null && state.tag !== "?") {
+      tagStr = encodeURI(
+        state.tag[0] === "!" ? state.tag.slice(1) : state.tag
+      ).replace(/!/g, "%21");
+      if (state.tag[0] === "!") {
+        tagStr = "!" + tagStr;
+      } else if (tagStr.slice(0, 18) === "tag:yaml.org,2002:") {
+        tagStr = "!!" + tagStr.slice(18);
+      } else {
+        tagStr = "!<" + tagStr + ">";
+      }
+      state.dump = tagStr + " " + state.dump;
+    }
+  }
+  return true;
+}
+function getDuplicateReferences(object, state) {
+  var objects = [], duplicatesIndexes = [], index, length;
+  inspectNode(object, objects, duplicatesIndexes);
+  for (index = 0, length = duplicatesIndexes.length; index < length; index += 1) {
+    state.duplicates.push(objects[duplicatesIndexes[index]]);
+  }
+  state.usedDuplicates = new Array(length);
+}
+function inspectNode(object, objects, duplicatesIndexes) {
+  var objectKeyList, index, length;
+  if (object !== null && typeof object === "object") {
+    index = objects.indexOf(object);
+    if (index !== -1) {
+      if (duplicatesIndexes.indexOf(index) === -1) {
+        duplicatesIndexes.push(index);
+      }
+    } else {
+      objects.push(object);
+      if (Array.isArray(object)) {
+        for (index = 0, length = object.length; index < length; index += 1) {
+          inspectNode(object[index], objects, duplicatesIndexes);
+        }
+      } else {
+        objectKeyList = Object.keys(object);
+        for (index = 0, length = objectKeyList.length; index < length; index += 1) {
+          inspectNode(object[objectKeyList[index]], objects, duplicatesIndexes);
+        }
+      }
+    }
+  }
+}
+function dump$1(input, options) {
+  options = options || {};
+  var state = new State(options);
+  if (!state.noRefs) getDuplicateReferences(input, state);
+  var value = input;
+  if (state.replacer) {
+    value = state.replacer.call({ "": value }, "", value);
+  }
+  if (writeNode(state, 0, value, true, true)) return state.dump + "\n";
+  return "";
+}
+var dump_1 = dump$1;
+var dumper = {
+  dump: dump_1
+};
+function renamed(from, to) {
+  return function() {
+    throw new Error("Function yaml." + from + " is removed in js-yaml 4. Use yaml." + to + " instead, which is now safe by default.");
+  };
+}
+var Type = type;
+var Schema = schema;
+var FAILSAFE_SCHEMA = failsafe;
+var JSON_SCHEMA = json;
+var CORE_SCHEMA = core;
+var DEFAULT_SCHEMA = _default;
+var load = loader.load;
+var loadAll = loader.loadAll;
+var dump = dumper.dump;
+var YAMLException = exception;
+var types = {
+  binary,
+  float,
+  map,
+  null: _null,
+  pairs,
+  set,
+  timestamp,
+  bool,
+  int,
+  merge,
+  omap,
+  seq,
+  str
+};
+var safeLoad = renamed("safeLoad", "load");
+var safeLoadAll = renamed("safeLoadAll", "loadAll");
+var safeDump = renamed("safeDump", "dump");
+var jsYaml = {
+  Type,
+  Schema,
+  FAILSAFE_SCHEMA,
+  JSON_SCHEMA,
+  CORE_SCHEMA,
+  DEFAULT_SCHEMA,
+  load,
+  loadAll,
+  dump,
+  YAMLException,
+  types,
+  safeLoad,
+  safeLoadAll,
+  safeDump
+};
+
+// ../cli/dist/src/config/yaml-tags.js
+function createTagType(tagName) {
+  return new jsYaml.Type(`!${tagName}`, {
+    kind: "mapping",
+    construct(data) {
+      return { tag: tagName, config: data ?? {} };
+    },
+    instanceOf: Object,
+    represent(value) {
+      const tv = value;
+      return tv.config;
+    }
+  });
+}
+function createBareTagType(tagName) {
+  return new jsYaml.Type(`!${tagName}`, {
+    kind: "scalar",
+    construct() {
+      return { tag: tagName, config: {} };
+    },
+    instanceOf: Object,
+    represent() {
+      return "";
+    }
+  });
+}
+var TAG_NAMES = ["secret", "gcp", "aws", "age", "sops"];
+var mappingTypes = TAG_NAMES.map((name) => createTagType(name));
+var bareTypes = TAG_NAMES.map((name) => createBareTagType(name));
+var KEYSHELF_SCHEMA = jsYaml.DEFAULT_SCHEMA.extend([...bareTypes, ...mappingTypes]);
+function isTaggedValue(value) {
+  return typeof value === "object" && value !== null && "tag" in value && "config" in value && typeof value.tag === "string";
+}
+
+// ../cli/dist/src/utils/paths.js
+function flattenKeys(obj, prefix = "") {
+  const result = {};
+  for (const [key, value] of Object.entries(obj)) {
+    const path = prefix ? `${prefix}/${key}` : key;
+    if (typeof value === "object" && value !== null && !Array.isArray(value) && !("tag" in value && "config" in value)) {
+      Object.assign(result, flattenKeys(value, path));
+    } else {
+      result[path] = value;
+    }
+  }
+  return result;
+}
+
+// ../cli/dist/src/config/environment.js
+function parseEnvironment(content) {
+  const raw = jsYaml.load(content, { schema: KEYSHELF_SCHEMA });
+  if (!raw || typeof raw !== "object") {
+    return { overrides: {} };
+  }
+  const doc = raw;
+  const defaultProvider = parseProviderBlock(doc["default-provider"]);
+  const keysBlock = doc.keys;
+  if (keysBlock != null && typeof keysBlock !== "object") {
+    throw new Error('Environment file "keys:" must be a mapping');
+  }
+  const source = keysBlock ?? {};
+  const flat = flattenKeys(source);
+  const overrides = {};
+  for (const [path, value] of Object.entries(flat)) {
+    if (value != null) {
+      overrides[path] = value;
+    }
+  }
+  return { defaultProvider, overrides };
+}
+function parseProviderBlock(raw) {
+  if (!raw || typeof raw !== "object") return void 0;
+  const block = raw;
+  const name = block.name;
+  if (typeof name !== "string") return void 0;
+  const options = {};
+  for (const [key, value] of Object.entries(block)) {
+    if (key !== "name") {
+      options[key] = value;
+    }
+  }
+  return { name, options };
+}
+
+// ../cli/dist/src/config/schema.js
+function parseSchema(content) {
+  const raw = jsYaml.load(content, { schema: KEYSHELF_SCHEMA });
+  if (!raw || typeof raw !== "object") {
+    throw new Error('keyshelf.yaml must contain a "keys:" block defining your keys');
+  }
+  const doc = raw;
+  if (!("keys" in doc) || doc.keys == null || typeof doc.keys !== "object") {
+    throw new Error('keyshelf.yaml must contain a "keys:" block defining your keys');
+  }
+  const provider2 = parseProviderBlock(doc["default-provider"]);
+  let name;
+  if ("name" in doc && doc.name !== void 0) {
+    if (typeof doc.name !== "string" || doc.name === "") {
+      throw new Error('keyshelf.yaml "name" must be a non-empty string');
+    }
+    if (!/^[a-zA-Z0-9_-]+$/.test(doc.name)) {
+      throw new Error(
+        'keyshelf.yaml "name" must contain only letters, digits, hyphens, and underscores'
+      );
+    }
+    name = doc.name;
+  }
+  const flat = flattenKeys(doc.keys);
+  const definitions = [];
+  for (const [path, value] of Object.entries(flat)) {
+    if (isTaggedValue(value)) {
+      definitions.push({
+        path,
+        isSecret: true,
+        optional: value.tag === "secret" && value.config.optional === true
+      });
+    } else {
+      if (value != null && typeof value === "object") {
+        throw new Error(
+          `Unexpected object value at "${path}" in schema. Use nested keys or a tag instead.`
+        );
+      }
+      definitions.push({
+        path,
+        isSecret: false,
+        optional: false,
+        defaultValue: value == null ? void 0 : String(value)
+      });
+    }
+  }
+  return { keys: definitions, config: { name, provider: provider2 } };
+}
+
+// ../cli/dist/src/config/app-mapping.js
+var TEMPLATE_RE = /\$\{([^}]+)\}/g;
+function parseAppMapping(content) {
+  const mappings = [];
+  for (const raw of content.split("\n")) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eqIndex = line.indexOf("=");
+    if (eqIndex === -1) continue;
+    const envVar = line.slice(0, eqIndex).trim();
+    const value = line.slice(eqIndex + 1).trim();
+    if (!envVar || !value) continue;
+    if (TEMPLATE_RE.test(value)) {
+      TEMPLATE_RE.lastIndex = 0;
+      const keyPaths = [...value.matchAll(TEMPLATE_RE)].map((m) => m[1].trim());
+      mappings.push({ envVar, template: value, keyPaths });
+    } else {
+      mappings.push({ envVar, keyPath: value });
+    }
+  }
+  return mappings;
+}
+var SCHEMA_FILE = "keyshelf.yaml";
+var ENV_DIR = ".keyshelf";
+var APP_MAPPING_FILE = ".env.keyshelf";
+function findRootDir(from) {
+  let dir = resolve(from);
+  while (true) {
+    if (existsSync(join(dir, SCHEMA_FILE))) {
+      return dir;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) {
+      throw new Error(`Could not find ${SCHEMA_FILE} in ${from} or any parent directory`);
+    }
+    dir = parent;
+  }
+}
+async function loadConfig(appDir, envName, options) {
+  const rootDir = findRootDir(appDir);
+  const schemaPath = join(rootDir, SCHEMA_FILE);
+  const schemaContent = await readFile(schemaPath, "utf-8");
+  const parsed = parseSchema(schemaContent);
+  const schema2 = parsed.keys;
+  const envPath = join(rootDir, ENV_DIR, `${envName}.yaml`);
+  let env2;
+  try {
+    const envContent = await readFile(envPath, "utf-8");
+    env2 = parseEnvironment(envContent);
+  } catch (err) {
+    if (err.code === "ENOENT") {
+      throw new Error(`Environment file not found: ${envPath}`, {
+        cause: err
+      });
+    }
+    throw err;
+  }
+  const mappingPath = join(appDir, APP_MAPPING_FILE);
+  let appMapping;
+  try {
+    const mappingContent = await readFile(mappingPath, "utf-8");
+    appMapping = parseAppMapping(mappingContent);
+  } catch (err) {
+    if (err.code === "ENOENT") {
+      appMapping = [];
+    } else {
+      throw err;
+    }
+  }
+  const globalProvider = parsed.config.provider;
+  if (globalProvider && !env2.defaultProvider) {
+    env2 = { ...env2, defaultProvider: globalProvider };
+  } else if (globalProvider && env2.defaultProvider) {
+    const envProvider = env2.defaultProvider;
+    env2 = {
+      ...env2,
+      defaultProvider: {
+        name: envProvider.name,
+        options: {
+          ...globalProvider.name === envProvider.name ? globalProvider.options : {},
+          ...envProvider.options
+        }
+      }
+    };
+  }
+  return { rootDir, name: parsed.config.name, schema: schema2, env: env2, appMapping };
+}
+
+// scripts/write-identity.mjs
+var env = process.env.KEYSHELF_ENV;
+var identity = process.env.KEYSHELF_IDENTITY;
+var cwd = process.env.KEYSHELF_CWD || process.cwd();
+if (!env) fail("KEYSHELF_ENV is required");
+if (!identity) {
+  process.stdout.write("No identity provided; skipping identity write.\n");
+  process.exit(0);
+}
+var config = await loadConfig(cwd, env);
+var provider = config.env.defaultProvider;
+if (!provider) {
+  fail(`Environment "${env}" has no default-provider configured`);
+}
+var identityFile = provider.options?.identityFile;
+if (typeof identityFile !== "string" || identityFile.length === 0) {
+  process.stdout.write(
+    `::warning::'identity' input was provided but provider "${provider.name}" does not declare an identityFile (e.g. gcp). Ignoring.
+`
+  );
+  process.exit(0);
+}
+var target = resolveIdentityPath(identityFile, config.rootDir);
+await mkdir(dirname(target), { recursive: true });
+await writeFile(target, ensureTrailingNewline(identity), { mode: 384 });
+await chmod(target, 384);
+process.stdout.write(`Wrote identity to ${target} (mode 0600)
+`);
+function resolveIdentityPath(filePath, rootDir) {
+  if (filePath === "~" || filePath.startsWith("~/")) {
+    return join(homedir(), filePath.slice(1));
+  }
+  if (isAbsolute(filePath)) return filePath;
+  return resolve(rootDir, filePath);
+}
+function ensureTrailingNewline(content) {
+  return content.endsWith("\n") ? content : content + "\n";
+}
+function fail(msg) {
+  process.stderr.write(`::error::${msg}
+`);
+  process.exit(1);
+}
 /*! Bundled license information:
 
 js-yaml/dist/js-yaml.mjs:

--- a/packages/action/scripts/emit-env-v5.mjs
+++ b/packages/action/scripts/emit-env-v5.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+import { appendFileSync } from "node:fs";
+import { randomBytes } from "node:crypto";
+import {
+  AgeProvider,
+  PlaintextProvider,
+  ProviderRegistry,
+  SopsProvider,
+  formatSkipCause,
+  loadV5Config,
+  renderAppMapping,
+  resolveWithStatus,
+  validate
+} from "keyshelf/v5";
+
+const envName = process.env.KEYSHELF_ENV || undefined;
+const mapsRaw = process.env.KEYSHELF_MAPS || "";
+const groupsRaw = process.env.KEYSHELF_GROUPS || "";
+const filtersRaw = process.env.KEYSHELF_FILTERS || "";
+const cwd = process.env.KEYSHELF_CWD || process.cwd();
+const githubEnv = process.env.GITHUB_ENV;
+
+if (!githubEnv) fail("GITHUB_ENV is not set; this script must run inside GitHub Actions");
+
+const maps = mapsRaw
+  .split("\n")
+  .map((s) => s.trim())
+  .filter(Boolean);
+if (maps.length === 0) fail("'map' input is empty");
+
+const groups = splitList(groupsRaw);
+const filters = splitList(filtersRaw);
+
+const registry = new ProviderRegistry();
+registry.register(new PlaintextProvider());
+registry.register(new AgeProvider());
+registry.register(new SopsProvider());
+
+for (const mapFile of maps) {
+  let vars;
+  try {
+    vars = await resolveMap(cwd, envName, mapFile);
+  } catch (err) {
+    fail(`Failed to resolve map "${mapFile}": ${err.message}`);
+  }
+
+  for (const v of vars) {
+    if (v.secret) process.stdout.write(`::add-mask::${v.value}\n`);
+  }
+  for (const v of vars) {
+    appendEnv(v.envVar, v.value);
+  }
+}
+
+async function resolveMap(appDir, envName, mapFile) {
+  const loaded = await loadV5Config(appDir, { mappingFile: mapFile });
+  const resolveOpts = {
+    config: loaded.config,
+    envName,
+    rootDir: loaded.rootDir,
+    registry,
+    groups,
+    filters
+  };
+
+  const validation = await validate(resolveOpts);
+  if (validation.topLevelErrors.length > 0) {
+    fail(validation.topLevelErrors.map((e) => e.message).join("; "));
+  }
+  if (validation.keyErrors.length > 0) {
+    const lines = validation.keyErrors.map((e) => `  - ${e.path}: ${e.message}`).join("\n");
+    fail(`Validation errors:\n${lines}`);
+  }
+
+  const resolution = await resolveWithStatus(resolveOpts);
+  const rendered = renderAppMapping(loaded.appMapping, resolution);
+  const recordByPath = new Map(loaded.config.keys.map((k) => [k.path, k]));
+
+  const vars = [];
+  for (const result of rendered) {
+    if (result.status === "skipped") {
+      process.stderr.write(
+        `keyshelf: skipping ${result.envVar} — referenced key '${result.keyPath}' ${formatSkipCause(result.cause)}\n`
+      );
+      continue;
+    }
+
+    const secret =
+      "template" in result.mapping
+        ? result.mapping.keyPaths.some((p) => recordByPath.get(p)?.kind === "secret")
+        : recordByPath.get(result.mapping.keyPath)?.kind === "secret";
+    vars.push({ envVar: result.envVar, value: result.value, secret });
+  }
+  return vars;
+}
+
+function splitList(raw) {
+  return raw
+    .split(/[\n,]/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function appendEnv(name, value) {
+  const delim = `EOF_${randomBytes(8).toString("hex")}`;
+  if (value.includes(delim)) {
+    fail(`Generated heredoc delimiter collided with value of ${name}; refusing to emit`);
+  }
+  appendFileSync(githubEnv, `${name}<<${delim}\n${value}\n${delim}\n`);
+}
+
+function fail(msg) {
+  process.stderr.write(`::error::${msg}\n`);
+  process.exit(1);
+}

--- a/packages/action/scripts/write-identity-v5.mjs
+++ b/packages/action/scripts/write-identity-v5.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+import { writeFile, mkdir, chmod } from "node:fs/promises";
+import { dirname, isAbsolute, join, resolve as pathResolve } from "node:path";
+import { homedir } from "node:os";
+import { loadV5Config } from "keyshelf/v5";
+
+const identity = process.env.KEYSHELF_IDENTITY;
+const cwd = process.env.KEYSHELF_CWD || process.cwd();
+
+if (!identity) {
+  process.stdout.write("No identity provided; skipping identity write.\n");
+  process.exit(0);
+}
+
+const loaded = await loadV5Config(cwd);
+const identityFiles = collectAgeIdentityFiles(loaded.config);
+
+if (identityFiles.length === 0) {
+  process.stdout.write(
+    `::warning::'identity' input was provided but config "${loaded.config.name}" declares no age providers. Ignoring.\n`
+  );
+  process.exit(0);
+}
+
+for (const filePath of identityFiles) {
+  const target = resolveIdentityPath(filePath, loaded.rootDir);
+  await mkdir(dirname(target), { recursive: true });
+  await writeFile(target, ensureTrailingNewline(identity), { mode: 0o600 });
+  await chmod(target, 0o600);
+  process.stdout.write(`Wrote identity to ${target} (mode 0600)\n`);
+}
+
+function collectAgeIdentityFiles(config) {
+  const seen = new Set();
+  for (const record of config.keys) {
+    if (record.kind !== "secret") continue;
+    visitBinding(record.value);
+    for (const v of Object.values(record.values ?? {})) visitBinding(v);
+  }
+  return [...seen];
+
+  function visitBinding(binding) {
+    if (binding === undefined) return;
+    if (typeof binding !== "object" || binding === null) return;
+    if (binding.__kind !== "provider:age") return;
+    const file = binding.options?.identityFile;
+    if (typeof file === "string" && file.length > 0) seen.add(file);
+  }
+}
+
+function resolveIdentityPath(filePath, rootDir) {
+  if (filePath === "~" || filePath.startsWith("~/")) {
+    return join(homedir(), filePath.slice(1));
+  }
+  if (isAbsolute(filePath)) return filePath;
+  return pathResolve(rootDir, filePath);
+}
+
+function ensureTrailingNewline(content) {
+  return content.endsWith("\n") ? content : content + "\n";
+}

--- a/packages/action/test/scripts.test.ts
+++ b/packages/action/test/scripts.test.ts
@@ -8,9 +8,12 @@ import { generateIdentity, identityToRecipient } from "keyshelf";
 
 const require = createRequire(import.meta.url);
 const KEYSHELF_BIN = require.resolve("keyshelf/bin");
+const KEYSHELF_BIN_NEXT = require.resolve("keyshelf/bin-next");
 const ACTION_DIR = join(import.meta.dirname, "..");
 const WRITE_IDENTITY = join(ACTION_DIR, "scripts", "write-identity.mjs");
 const EMIT_ENV = join(ACTION_DIR, "scripts", "emit-env.mjs");
+const WRITE_IDENTITY_V5 = join(ACTION_DIR, "scripts", "write-identity-v5.mjs");
+const EMIT_ENV_V5 = join(ACTION_DIR, "scripts", "emit-env-v5.mjs");
 
 async function setupAgeFixture(): Promise<{ root: string; identity: string }> {
   const root = await mkdtemp(join(tmpdir(), "keyshelf-action-test-"));
@@ -127,6 +130,204 @@ describe("write-identity.mjs", () => {
     });
     expect(res.status).toBe(0);
     expect(res.stdout).toContain("No identity provided");
+  });
+});
+
+async function setupV5AgeFixture(): Promise<{ root: string; identity: string }> {
+  const root = await mkdtemp(join(tmpdir(), "keyshelf-action-v5-"));
+  const identity = await generateIdentity();
+
+  await writeFile(
+    join(root, "keyshelf.config.ts"),
+    [
+      'import { config, defineConfig, secret, age } from "keyshelf/config";',
+      "",
+      "export default defineConfig({",
+      '  name: "v5action",',
+      '  envs: ["test"],',
+      "  keys: {",
+      "    db: {",
+      '      host: "localhost",',
+      "      password: secret({",
+      '        value: age({ identityFile: "./keys/age.txt", secretsDir: "./.keyshelf/secrets" })',
+      "      })",
+      "    },",
+      "    service: {",
+      '      name: "api"',
+      "    }",
+      "  }",
+      "});"
+    ].join("\n")
+  );
+
+  await writeFile(
+    join(root, ".env.keyshelf"),
+    [
+      "DB_HOST=db/host",
+      "DB_PASSWORD=db/password",
+      "DB_URL=postgres://${db/host}:${db/password}@srv/db",
+      "SERVICE_NAME=service/name"
+    ].join("\n")
+  );
+
+  await mkdir(join(root, "keys"));
+  await writeFile(join(root, "keys/age.txt"), identity);
+
+  execFileSync(
+    process.execPath,
+    [KEYSHELF_BIN_NEXT, "set", "--env", "test", "--value", "hunter2", "db/password"],
+    { cwd: root, encoding: "utf-8" }
+  );
+
+  await unlink(join(root, "keys/age.txt"));
+  return { root, identity };
+}
+
+describe("write-identity-v5.mjs", () => {
+  it("writes identity to every unique age identityFile path declared in the v5 config", async () => {
+    const { root, identity } = await setupV5AgeFixture();
+
+    const res = spawnSync(process.execPath, [WRITE_IDENTITY_V5], {
+      cwd: root,
+      env: { ...process.env, KEYSHELF_IDENTITY: identity, KEYSHELF_CWD: root },
+      encoding: "utf-8"
+    });
+
+    expect(res.status, res.stderr).toBe(0);
+    expect(res.stdout).toContain("Wrote identity to");
+    expect(res.stdout).toContain("keys/age.txt");
+
+    const target = join(root, "keys/age.txt");
+    expect((await readFile(target, "utf-8")).trim()).toBe(identity.trim());
+    expect((await stat(target)).mode & 0o777).toBe(0o600);
+  });
+
+  it("warns and skips when the v5 config declares no age providers", async () => {
+    const root = await mkdtemp(join(tmpdir(), "keyshelf-action-v5-noage-"));
+    await writeFile(
+      join(root, "keyshelf.config.ts"),
+      [
+        'import { defineConfig } from "keyshelf/config";',
+        "",
+        "export default defineConfig({",
+        '  name: "noage",',
+        '  envs: ["test"],',
+        '  keys: { db: { host: "localhost" } }',
+        "});"
+      ].join("\n")
+    );
+
+    const res = spawnSync(process.execPath, [WRITE_IDENTITY_V5], {
+      cwd: root,
+      env: { ...process.env, KEYSHELF_IDENTITY: "fake", KEYSHELF_CWD: root },
+      encoding: "utf-8"
+    });
+
+    expect(res.status).toBe(0);
+    expect(res.stdout).toContain("::warning::");
+    expect(res.stdout).toContain("declares no age providers");
+  });
+
+  it("is a no-op when no identity is provided", async () => {
+    const { root } = await setupV5AgeFixture();
+    const res = spawnSync(process.execPath, [WRITE_IDENTITY_V5], {
+      cwd: root,
+      env: { ...process.env, KEYSHELF_CWD: root },
+      encoding: "utf-8"
+    });
+    expect(res.status).toBe(0);
+    expect(res.stdout).toContain("No identity provided");
+  });
+});
+
+describe("emit-env-v5.mjs", () => {
+  it("masks v5 secrets, resolves templates, and emits to GITHUB_ENV via heredoc", async () => {
+    const { root, identity } = await setupV5AgeFixture();
+    await writeFile(join(root, "keys/age.txt"), identity, { mode: 0o600 });
+
+    const githubEnvPath = join(root, "github-env");
+    await writeFile(githubEnvPath, "");
+
+    const res = spawnSync(process.execPath, [EMIT_ENV_V5], {
+      cwd: root,
+      env: {
+        ...process.env,
+        KEYSHELF_ENV: "test",
+        KEYSHELF_MAPS: ".env.keyshelf",
+        KEYSHELF_CWD: root,
+        GITHUB_ENV: githubEnvPath
+      },
+      encoding: "utf-8"
+    });
+
+    expect(res.status, res.stderr).toBe(0);
+    expect(res.stdout).toContain("::add-mask::hunter2");
+    expect(res.stdout).toContain("::add-mask::postgres://localhost:hunter2@srv/db");
+    expect(res.stdout).not.toContain("::add-mask::api");
+
+    const env = await readFile(githubEnvPath, "utf-8");
+    expect(env).toMatch(/DB_HOST<<EOF_[a-f0-9]+\nlocalhost\nEOF_/);
+    expect(env).toMatch(/DB_PASSWORD<<EOF_[a-f0-9]+\nhunter2\nEOF_/);
+    expect(env).toMatch(/DB_URL<<EOF_[a-f0-9]+\npostgres:\/\/localhost:hunter2@srv\/db\nEOF_/);
+    expect(env).toMatch(/SERVICE_NAME<<EOF_[a-f0-9]+\napi\nEOF_/);
+  });
+
+  it("emits a stderr skip warning when --groups filters out a referenced key", async () => {
+    const root = await mkdtemp(join(tmpdir(), "keyshelf-action-v5-grp-"));
+    await writeFile(
+      join(root, "keyshelf.config.ts"),
+      [
+        'import { config, defineConfig } from "keyshelf/config";',
+        "",
+        "export default defineConfig({",
+        '  name: "v5grp",',
+        '  envs: ["test"],',
+        '  groups: ["app", "ci"],',
+        "  keys: {",
+        '    app: { host: config({ group: "app", value: "localhost" }) },',
+        '    ci: { token: config({ group: "ci", value: "ci-token" }) }',
+        "  }",
+        "});"
+      ].join("\n")
+    );
+    await writeFile(
+      join(root, ".env.keyshelf"),
+      ["APP_HOST=app/host", "CI_TOKEN=ci/token"].join("\n")
+    );
+
+    const githubEnvPath = join(root, "github-env");
+    await writeFile(githubEnvPath, "");
+
+    const res = spawnSync(process.execPath, [EMIT_ENV_V5], {
+      cwd: root,
+      env: {
+        ...process.env,
+        KEYSHELF_MAPS: ".env.keyshelf",
+        KEYSHELF_GROUPS: "app",
+        KEYSHELF_CWD: root,
+        GITHUB_ENV: githubEnvPath
+      },
+      encoding: "utf-8"
+    });
+
+    expect(res.status, res.stderr).toBe(0);
+    expect(res.stderr).toContain(
+      "keyshelf: skipping CI_TOKEN — referenced key 'ci/token' is filtered out by --group=app"
+    );
+    const env = await readFile(githubEnvPath, "utf-8");
+    expect(env).toMatch(/APP_HOST<<EOF_[a-f0-9]+\nlocalhost\nEOF_/);
+    expect(env).not.toContain("CI_TOKEN");
+  });
+
+  it("fails when neither GITHUB_ENV nor map are set", async () => {
+    const { root } = await setupV5AgeFixture();
+    const res = spawnSync(process.execPath, [EMIT_ENV_V5], {
+      cwd: root,
+      env: { ...process.env, KEYSHELF_MAPS: ".env.keyshelf", KEYSHELF_CWD: root, GITHUB_ENV: "" },
+      encoding: "utf-8"
+    });
+    expect(res.status).not.toBe(0);
+    expect(res.stderr).toContain("GITHUB_ENV is not set");
   });
 });
 

--- a/packages/action/tsup.config.ts
+++ b/packages/action/tsup.config.ts
@@ -1,15 +1,32 @@
 import { defineConfig } from "tsup";
 
+// The action ships a single bundle per entrypoint with all deps inlined,
+// EXCEPT for jiti and zod. Both ship as CJS (jiti uses dynamic require for
+// Node built-ins; zod is consumed via jiti's resolution path) and break under
+// ESM bundling. They are installed at action runtime via `npm install` in
+// action.yml's setup step.
+//
+// `keyshelf-config.mjs` is a sidecar bundle of the v5 factories module. The
+// loader resolves the user's `keyshelf/config` import to this file via
+// KEYSHELF_CONFIG_MODULE_PATH, set in action.yml. Without it, jiti would try
+// to read a sibling next to the bundled emit-env entry, which doesn't exist.
 export default defineConfig({
-  entry: ["scripts/write-identity.mjs", "scripts/emit-env.mjs"],
+  entry: {
+    "write-identity": "scripts/write-identity.mjs",
+    "emit-env": "scripts/emit-env.mjs",
+    "write-identity-v5": "scripts/write-identity-v5.mjs",
+    "emit-env-v5": "scripts/emit-env-v5.mjs",
+    "keyshelf-config": "../cli/dist/src/v5/config/index.js"
+  },
   format: ["esm"],
   target: "node20",
   outDir: "dist",
   outExtension: () => ({ js: ".mjs" }),
   clean: true,
   sourcemap: false,
-  noExternal: [/.*/],
+  external: ["jiti", "zod"],
+  noExternal: [/^(?!jiti|zod).*/],
   splitting: false,
   treeshake: true,
-  minify: true
+  minify: false
 });

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,6 +26,10 @@
       "types": "./dist/v5/config/index.d.ts",
       "import": "./dist/src/v5/config/index.js"
     },
+    "./v5": {
+      "types": "./dist/v5/runtime.d.ts",
+      "import": "./dist/src/v5/runtime.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [

--- a/packages/cli/src/v5/runtime.ts
+++ b/packages/cli/src/v5/runtime.ts
@@ -1,0 +1,40 @@
+// Public runtime surface for embedders (e.g. the keyshelf GitHub Action).
+// Stable contract for code that loads, resolves, and renders v5 configs at
+// runtime. `keyshelf/config` is for *user-authored* configs; this entry is
+// for *tooling that consumes them*.
+
+export {
+  findV5RootDir,
+  loadV5Config,
+  type LoadedV5Config,
+  type LoadV5ConfigOptions
+} from "./config/loader.js";
+
+export {
+  formatSkipCause,
+  renderAppMapping,
+  resolveWithStatus,
+  validate,
+  type ResolveV5Options
+} from "./resolver/index.js";
+
+export type {
+  RenderedV5EnvVar,
+  ResolvedV5Key,
+  V5KeyResolutionStatus,
+  V5Resolution,
+  V5SkipCause,
+  V5TopLevelError,
+  V5ValidationError,
+  V5ValidationResult
+} from "./resolver/types.js";
+
+export type { NormalizedConfig, NormalizedRecord } from "./config/types.js";
+
+export { isTemplateMapping, type AppMapping } from "../config/app-mapping.js";
+
+export { ProviderRegistry } from "../providers/registry.js";
+export { PlaintextProvider } from "../providers/plaintext.js";
+export { AgeProvider, generateIdentity, identityToRecipient } from "../providers/age.js";
+export { SopsProvider } from "../providers/sops.js";
+export type { Provider, ProviderContext } from "../providers/types.js";

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -7,5 +7,7 @@ export default defineConfig({
   bundle: false,
   clean: true,
   sourcemap: true,
-  dts: { entry: ["src/index.ts", "src/v5/config/index.ts"] }
+  dts: {
+    entry: ["src/index.ts", "src/v5/config/index.ts", "src/v5/runtime.ts"]
+  }
 });


### PR DESCRIPTION
## Summary

Lands phase 7 of #78 — the keyshelf GitHub Action now supports v5 \`keyshelf.config.ts\` configs end-to-end.

- New \`keyshelf/v5\` subpath export — focused public surface for embedders (loader, resolver, lean providers, types). Stable contract distinct from \`keyshelf/config\` (which is for *user-authored* configs).
- New \`scripts/emit-env-v5.mjs\` and \`scripts/write-identity-v5.mjs\` mirror the v4 scripts using v5 internals.
- \`action.yml\` auto-detects v5 vs v4 by file presence (\`keyshelf.config.ts\` or \`keyshelf.yaml\`) and dispatches to the matching scripts.
- New optional inputs \`groups\` / \`filters\` forward to the v5 resolver. \`env\` is now optional (only required when a selected key has env-specific values without a fallback).
- Three coordinated build changes from the phase 7 spike (#95):
  - **Lean provider registry**: age/sops/plaintext only — bundling \`@google-cloud/secret-manager\` pulls grpc-js which uses dynamic \`require()\` and breaks under ESM. Same constraint as v4.
  - **Sidecar \`keyshelf-config.mjs\`**: tsup emits a second bundle of the v5 factories module. \`action.yml\` sets \`KEYSHELF_CONFIG_MODULE_PATH\` to point jiti's \`keyshelf/config\` alias at it.
  - **Externalized jiti + zod**: both ship as CJS with dynamic-require landmines. \`action.yml\` installs them at runtime via a one-time \`npm install\` into the action checkout.

## Test plan

- [x] \`npm --prefix packages/action test\` — 12 passed (was 6 v4-only)
- [x] \`npm --prefix packages/cli test\` — 280 passed (5 skipped); no regressions
- [x] \`npm --prefix packages/cli run typecheck\` — clean
- [x] \`npm --prefix packages/action run typecheck\` — clean
- [x] Manual: bundled \`dist/emit-env-v5.mjs\` against a TS-config fixture (default + \`--env production\` env override) emits to GITHUB_ENV correctly with masking
- [x] Manual: \`KEYSHELF_GROUPS=app\` against a multi-group fixture skips \`ci/token\` with the expected stderr line and omits the env var
- [ ] Real CI: pending workflow that uses \`pantoninho/keyshelf/packages/action@worktree-v5-phase-7-action\` against a TS config

## Follow-ups (not in this PR)

- README update (documenting v5 inputs + setup) — phase 9 scope.
- Phase 7 issue checkbox: "Measure cold-start time impact" — first-run install of jiti+zod adds ~2-3s on a cold action runner; subsequent runs hit cache. Worth a dedicated benchmark before phase 8 cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)