### PR TITLE
feat(v5): add --group to import + polish CLI help text

### DIFF
--- a/packages/cli/src/v5/cli/import.ts
+++ b/packages/cli/src/v5/cli/import.ts
@@ -3,12 +3,14 @@ import { readFile } from "node:fs/promises";
 import { loadV5Config } from "../config/index.js";
 import { isTemplateMapping } from "../../config/app-mapping.js";
 import { createDefaultRegistry } from "../../providers/setup.js";
+import { splitList } from "./options.js";
 import type { BuiltinProviderRef, NormalizedRecord } from "../config/types.js";
 
 interface ImportOptions {
   env?: string;
   file: string;
   map?: string;
+  group?: string;
 }
 
 function parseDotEnv(content: string): Record<string, string> {
@@ -26,9 +28,12 @@ function parseDotEnv(content: string): Record<string, string> {
 }
 
 export const importCommand = new Command("import")
-  .description("Bulk import secret values from a .env file via their bound providers")
+  .description(
+    "Bulk-write secret values to their bound providers from a .env file (does not edit keyshelf.config.ts)"
+  )
   .requiredOption("--file <file>", "Path to .env file to import")
-  .option("--env <env>", "Environment name")
+  .option("--env <env>", "Environment to import into (selects per-env provider binding)")
+  .option("--group <names>", "Comma-separated group filter; keys outside the set are skipped")
   .option("--map <map>", "Path to app mapping file (default: .env.keyshelf)")
   .action(async (opts: ImportOptions) => {
     const appDir = process.cwd();
@@ -40,6 +45,9 @@ export const importCommand = new Command("import")
         .filter((mapping) => !isTemplateMapping(mapping))
         .map((mapping) => [mapping.envVar, (mapping as { keyPath: string }).keyPath])
     );
+
+    const groupList = splitList(opts.group);
+    const groupSet = groupList ? new Set(groupList) : undefined;
 
     const dotEnvContent = await readFile(opts.file, "utf-8");
     const dotEnvVars = parseDotEnv(dotEnvContent);
@@ -64,8 +72,14 @@ export const importCommand = new Command("import")
 
       if (record.kind === "config") {
         console.error(
-          `warning: ${envVar} -> ${keyPath} is a config key. v5 does not write config via import — edit keyshelf.config.ts directly.`
+          `warning: ${envVar} -> ${keyPath} is a config key; v5 does not write config via import (edit keyshelf.config.ts directly)`
         );
+        skipped++;
+        continue;
+      }
+
+      if (groupSet !== undefined && (record.group === undefined || !groupSet.has(record.group))) {
+        console.error(`warning: ${envVar} -> ${keyPath} filtered out by --group; skipping`);
         skipped++;
         continue;
       }

--- a/packages/cli/src/v5/cli/ls.ts
+++ b/packages/cli/src/v5/cli/ls.ts
@@ -39,12 +39,20 @@ interface JsonVar {
 }
 
 export const lsCommand = new Command("ls")
-  .description("List keys defined in the config")
-  .option("--env <env>", "Environment name")
-  .option("--group <names>", "Comma-separated group filter")
-  .option("--filter <prefixes>", "Comma-separated key-path prefix filter")
-  .option("--reveal", "Resolve and show actual values (requires --env)")
-  .option("--map <file>", "Path to app mapping file")
+  .description(
+    "List records declared in keyshelf.config.ts with their kind, group, and active binding"
+  )
+  .option("--env <env>", "Environment name; selects which per-env binding the detail column shows")
+  .option(
+    "--group <names>",
+    "Comma-separated group filter; keys outside the set are marked filtered"
+  )
+  .option(
+    "--filter <prefixes>",
+    "Comma-separated key-path prefix filter (e.g. db,log); non-matching keys are marked filtered"
+  )
+  .option("--reveal", "Resolve through bound providers and show resolved values (requires --env)")
+  .option("--map <file>", "Path to app mapping file (default: .env.keyshelf)")
   .option("--format <format>", "Output format: table (default) or json", "table")
   .action(async (opts: LsOptions) => {
     const format = parseFormat(opts.format);

--- a/packages/cli/src/v5/cli/run.ts
+++ b/packages/cli/src/v5/cli/run.ts
@@ -18,10 +18,18 @@ interface RunOptions {
 }
 
 export const runCommand = new Command("run")
-  .description("Resolve keys and run a command with env vars injected")
-  .option("--env <env>", "Environment name")
-  .option("--group <names>", "Comma-separated group filter")
-  .option("--filter <prefixes>", "Comma-separated key-path prefix filter")
+  .description(
+    "Resolve keys through their bound providers and run a command with the mapped env vars injected"
+  )
+  .option(
+    "--env <env>",
+    "Environment name (only required when a selected key has values without a fallback)"
+  )
+  .option("--group <names>", "Comma-separated group filter; keys outside the set are skipped")
+  .option(
+    "--filter <prefixes>",
+    "Comma-separated key-path prefix filter (e.g. db,log); non-matching keys are skipped"
+  )
   .option("--map <file>", "Path to app mapping file (default: .env.keyshelf)")
   .argument("<command...>", "Command to run")
   .allowExcessArguments(true)

--- a/packages/cli/src/v5/cli/set.ts
+++ b/packages/cli/src/v5/cli/set.ts
@@ -10,9 +10,14 @@ interface SetOptions {
 }
 
 export const setCommand = new Command("set")
-  .description("Store a secret value via its bound provider")
-  .option("--env <env>", "Environment name")
-  .option("--value <value>", "Value to set (non-interactive)")
+  .description(
+    "Write a secret value to its bound provider (does not edit keyshelf.config.ts; config keys are hand-edited)"
+  )
+  .option("--env <env>", "Environment to write into (selects per-env provider binding)")
+  .option(
+    "--value <value>",
+    "Value to set (non-interactive); otherwise prompts on TTY or reads stdin"
+  )
   .argument("<key>", "Key path (e.g. db/password)")
   .action(async (keyPath: string, opts: SetOptions) => {
     const appDir = process.cwd();

--- a/packages/cli/test/e2e/v5-import.test.ts
+++ b/packages/cli/test/e2e/v5-import.test.ts
@@ -94,4 +94,78 @@ describe("keyshelf-next import", () => {
     });
     expect(out).toContain("Imported 1 values, skipped 1");
   });
+
+  it("skips keys outside the --group filter", async () => {
+    const groupedRoot = await mkdtemp(join(tmpdir(), "keyshelf-v5-import-group-"));
+    const identityFile = join(groupedRoot, "key.txt");
+    const secretsDir = join(groupedRoot, ".keyshelf", "secrets");
+    await writeFile(identityFile, await generateIdentity());
+    await mkdir(secretsDir, { recursive: true });
+
+    await writeFile(
+      join(groupedRoot, "keyshelf.config.ts"),
+      [
+        `import { defineConfig, secret, age } from "keyshelf/config";`,
+        ``,
+        `export default defineConfig({`,
+        `  name: "demo",`,
+        `  envs: ["dev"],`,
+        `  groups: ["app", "ci"],`,
+        `  keys: {`,
+        `    db: {`,
+        `      password: secret({ group: "app", value: age({ identityFile: ${JSON.stringify(identityFile)}, secretsDir: ${JSON.stringify(secretsDir)} }) }),`,
+        `    },`,
+        `    github: {`,
+        `      token: secret({ group: "ci", value: age({ identityFile: ${JSON.stringify(identityFile)}, secretsDir: ${JSON.stringify(secretsDir)} }) }),`,
+        `    },`,
+        `  },`,
+        `});`,
+        ``
+      ].join("\n")
+    );
+    await writeFile(
+      join(groupedRoot, ".env.keyshelf"),
+      ["DB_PASSWORD=db/password", "GITHUB_TOKEN=github/token"].join("\n")
+    );
+
+    const envFile = join(groupedRoot, ".env.values");
+    writeFileSync(envFile, ["DB_PASSWORD=imported-pw", "GITHUB_TOKEN=imported-tok"]);
+
+    const result = execFileSync(
+      TSX,
+      [V5_CLI, "import", "--env", "dev", "--group", "app", "--file", envFile],
+      {
+        cwd: groupedRoot,
+        encoding: "utf-8",
+        stdio: ["inherit", "pipe", "pipe"]
+      }
+    );
+
+    expect(result).toContain("Imported 1 values, skipped 1");
+    expect(result).toContain("DB_PASSWORD -> db/password");
+    expect(result).not.toContain("GITHUB_TOKEN -> github/token");
+
+    const revealed = execFileSync(
+      TSX,
+      [
+        V5_CLI,
+        "ls",
+        "--env",
+        "dev",
+        "--group",
+        "app",
+        "--reveal",
+        "--map",
+        ".env.keyshelf",
+        "--format",
+        "json"
+      ],
+      { cwd: groupedRoot, encoding: "utf-8", stdio: ["inherit", "pipe", "pipe"] }
+    );
+    const parsed = JSON.parse(revealed) as {
+      vars: { envVar: string; value: string }[];
+    };
+    const dbVar = parsed.vars.find((v) => v.envVar === "DB_PASSWORD");
+    expect(dbVar?.value).toBe("imported-pw");
+  });
 });


### PR DESCRIPTION
## Summary
- Adds `--group <names>` filter to `keyshelf-next import`, mirroring `run`/`ls`. Keys whose group is outside the selected set are skipped with a warning, and never written to providers.
- Rewords `run` / `ls` / `set` / `import` descriptions and option blurbs around v5 vocabulary (records, bindings, providers). `set` and `import` now state explicitly that they write only to providers — never to `keyshelf.config.ts`.
- New e2e test for `import --group`.

Closes the remaining boxes under Phase 5 of #78.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test` — 281 passing (was 280 + 1 new)
- [ ] Manual: `keyshelf-next import --group app --env dev --file .env.values` skips ci-group keys with the documented warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)