### PR TITLE
feat(v5): action smoke workflow and benchmark

### DIFF
--- a/.github/workflows/action-smoke.yml
+++ b/.github/workflows/action-smoke.yml
@@ -95,6 +95,125 @@ jobs:
           echo "DB_PASSWORD length: ${#DB_PASSWORD}"
           echo "DB_URL length: ${#DB_URL}"
 
+  v5-ts-config-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install workspace deps
+        run: npm ci
+
+      - name: Build keyshelf and action
+        run: |
+          npm run build -w keyshelf
+          npm run build -w @keyshelf/action
+
+      - name: Generate v5 TS fixture
+        id: fixture
+        run: |
+          set -euo pipefail
+          mkdir -p fixture-v5/keys
+          cd fixture-v5
+
+          identity=$(node -e 'import("keyshelf").then(m => m.generateIdentity()).then(k => process.stdout.write(k))')
+
+          cat > keyshelf.config.ts <<'TS'
+          import { age, config, defineConfig, secret } from "keyshelf/config";
+
+          export default defineConfig({
+            name: "action-v5-smoke",
+            envs: ["test"],
+            groups: ["app", "ci"],
+            keys: {
+              app: {
+                host: config({ group: "app", value: "localhost" }),
+                name: config({ group: "app", value: "api" }),
+              },
+              db: {
+                password: secret({
+                  group: "app",
+                  value: age({
+                    identityFile: "./keys/age.txt",
+                    secretsDir: "./.keyshelf/secrets",
+                  }),
+                }),
+              },
+              ci: {
+                token: secret({
+                  group: "ci",
+                  value: age({
+                    identityFile: "./keys/age.txt",
+                    secretsDir: "./.keyshelf/secrets",
+                  }),
+                }),
+              },
+            },
+          });
+          TS
+
+          cat > .env.keyshelf <<'ENV'
+          APP_HOST=app/host
+          APP_NAME=app/name
+          DB_PASSWORD=db/password
+          DB_URL=postgres://${app/host}:${db/password}@srv/db
+          FILTERED_CI_TOKEN=ci/token
+          ENV
+
+          echo "$identity" > keys/age.txt
+          chmod 600 keys/age.txt
+
+          ../packages/cli/dist/bin/keyshelf-next.js set --env test --value 'hunter2' db/password
+          ../packages/cli/dist/bin/keyshelf-next.js set --env test --value 'ci-secret' ci/token
+
+          rm keys/age.txt
+
+          while IFS= read -r line; do
+            [ -n "$line" ] && echo "::add-mask::$line"
+          done <<<"$identity"
+
+          {
+            echo "identity<<EOF_IDENT"
+            echo "$identity"
+            echo "EOF_IDENT"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Invoke action against v5 TS config
+        uses: ./packages/action
+        with:
+          env: test
+          groups: app
+          identity: ${{ steps.fixture.outputs.identity }}
+          map: .env.keyshelf
+          working-directory: fixture-v5
+
+      - name: Verify v5 env vars and group filtering
+        run: |
+          set -euo pipefail
+          test "$APP_HOST" = "localhost"
+          test "$APP_NAME" = "api"
+          test "${DB_PASSWORD:-}" != ""
+          test "${DB_URL:-}" != ""
+          test "${FILTERED_CI_TOKEN:-}" = ""
+          echo "DB_PASSWORD length: ${#DB_PASSWORD}"
+          echo "DB_URL length: ${#DB_URL}"
+
+  v5-runtime-deps-benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Benchmark v5 runtime dependency install
+        run: node packages/action/scripts/benchmark-v5-runtime-deps.mjs
+
   # Reproduces the consumer scenario from issues #70 and #73:
   #   - The action source lives at a path separate from the consumer's working tree
   #     (mirroring how GitHub places `_actions/<owner>/<repo>/<ref>/...` on the runner).

--- a/packages/action/README.md
+++ b/packages/action/README.md
@@ -1,33 +1,58 @@
 # keyshelf-action
 
-GitHub Action that resolves [keyshelf](https://github.com/pantoninho/keyshelf)-managed config and secrets into `$GITHUB_ENV`, automatically masking values whose underlying schema key is `!secret`.
+GitHub Action that resolves [keyshelf](https://github.com/pantoninho/keyshelf)-managed config and secrets into `$GITHUB_ENV`, automatically masking secret-backed values.
 
 ## Usage
 
+v5 TypeScript config:
+
 ```yaml
-- uses: pantoninho/keyshelf/packages/action@keyshelf-action-v0.2.0
+- uses: pantoninho/keyshelf/packages/action@keyshelf-action-v0.4.0
+  with:
+    env: staging
+    groups: app
+    filters: db,github
+    identity: ${{ secrets.KEYSHELF_STAGING_IDENTITY }}
+    map: infra/.env.keyshelf
+```
+
+v4 YAML config:
+
+```yaml
+- uses: pantoninho/keyshelf/packages/action@keyshelf-action-v0.4.0
   with:
     env: staging
     identity: ${{ secrets.KEYSHELF_STAGING_IDENTITY }}
     map: infra/.env.keyshelf
 ```
 
-After this step, every variable declared in `infra/.env.keyshelf` is set in the workflow environment for subsequent steps. Values from `!secret` keys are passed through `::add-mask::` before being exported.
+After this step, every variable declared in `infra/.env.keyshelf` is set in the workflow environment for subsequent steps. Secret values are passed through `::add-mask::` before being exported.
 
 ## Inputs
 
-| Name                | Required | Description                                                                                                                                                      |
-| ------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `env`               | yes      | Environment name (matches `.keyshelf/<env>.yaml`).                                                                                                               |
-| `map`               | yes      | Path to a `.env.keyshelf` mapping file. Multiple files supported, one per line.                                                                                  |
-| `identity`          | no       | Raw identity material (e.g. an age private key). Written to the path declared in `.keyshelf/<env>.yaml` with mode `0600`. Pass via `secrets.*`; never hard-code. |
-| `working-directory` | no       | Directory containing `keyshelf.yaml` (defaults to the repo root).                                                                                                |
+| Name                | Required | Description                                                                                                                                                                                                                                       |
+| ------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `env`               | no       | Environment name. Required for v4 configs; for v5 configs only required when at least one selected key has env-specific `values` without a fallback.                                                                                              |
+| `map`               | yes      | Path to a `.env.keyshelf` mapping file. Multiple files supported, one per line.                                                                                                                                                                   |
+| `identity`          | no       | Raw identity material (e.g. an age private key). Written to the path declared by the matching provider with mode `0600`. For v5, the same identity is written to every unique `age()` `identityFile` path. Pass via `secrets.*`; never hard-code. |
+| `working-directory` | no       | Directory containing `keyshelf.config.ts` (v5) or `keyshelf.yaml` (v4), defaults to the repo root.                                                                                                                                                |
+| `groups`            | no       | v5 only. Comma- or newline-separated groups to include. Mapping entries that reference filtered-out keys are skipped with a workflow warning.                                                                                                     |
+| `filters`           | no       | v5 only. Comma- or newline-separated key-path prefixes to include. Mapping entries that reference filtered-out keys are skipped with a workflow warning.                                                                                          |
 
 ## Provider notes
 
-- **`age` / `sops`**: pass the identity material via `identity:`. The action reads the destination path from `.keyshelf/<env>.yaml`.
+- **`age` / `sops`**: pass the identity material via `identity:`. The action reads the destination path from `.keyshelf/<env>.yaml` for v4, or from provider bindings in `keyshelf.config.ts` for v5.
 - **`gcp`**: configure GCP credentials with [`google-github-actions/auth`](https://github.com/google-github-actions/auth) before this action runs. `identity` is not used; pass `gcp` mappings via `map:` as usual.
+- **v5 multi-identity age configs**: the current v5 identity writer writes the same `identity:` value to every unique `age()` `identityFile` path in the config.
 
 ## Masking
 
-For each resolved variable, if the underlying schema key is `!secret`, the action emits `::add-mask::<value>` before appending to `$GITHUB_ENV`. Template mappings (`${path/to/key}` interpolation) are masked if **any** referenced key is a secret — masking a non-secret is harmless; missing a secret is a leak.
+For each resolved variable, if the underlying key is secret-backed, the action emits `::add-mask::<value>` before appending to `$GITHUB_ENV`. Template mappings (`${path/to/key}` interpolation) are masked if **any** referenced key is a secret — masking a non-secret is harmless; missing a secret is a leak.
+
+## Runtime benchmark
+
+The v5 action installs `jiti` and `zod` at runtime when a TS config is detected. Measure cold and warm install time with:
+
+```sh
+npm run benchmark:v5-runtime-deps -w @keyshelf/action
+```

--- a/packages/action/package.json
+++ b/packages/action/package.json
@@ -15,6 +15,7 @@
   },
   "scripts": {
     "build": "tsup",
+    "benchmark:v5-runtime-deps": "node scripts/benchmark-v5-runtime-deps.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit"

--- a/packages/action/scripts/benchmark-v5-runtime-deps.mjs
+++ b/packages/action/scripts/benchmark-v5-runtime-deps.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { performance } from "node:perf_hooks";
+
+const packages = ["jiti@^2.6.1", "zod@^4.4.1"];
+const installArgs = ["install", "--no-save", "--no-audit", "--no-fund", "--no-package-lock"];
+
+const root = await mkdtemp(join(tmpdir(), "keyshelf-action-runtime-deps-"));
+const cacheDir = join(root, "npm-cache");
+
+try {
+  const cold = await runInstall("cold");
+  const warm = await runInstall("warm");
+  const result = {
+    packages,
+    coldMs: cold.durationMs,
+    warmMs: warm.durationMs
+  };
+
+  process.stdout.write(`v5 runtime dependency install benchmark\n`);
+  process.stdout.write(`cold: ${formatMs(result.coldMs)}\n`);
+  process.stdout.write(`warm: ${formatMs(result.warmMs)}\n`);
+
+  const summary = process.env.GITHUB_STEP_SUMMARY;
+  if (summary) {
+    await writeFile(
+      summary,
+      [
+        "## keyshelf action v5 runtime dependency benchmark",
+        "",
+        "| run | duration |",
+        "| --- | ---: |",
+        `| cold | ${formatMs(result.coldMs)} |`,
+        `| warm | ${formatMs(result.warmMs)} |`,
+        ""
+      ].join("\n"),
+      { flag: "a" }
+    );
+  }
+} finally {
+  if (process.env.KEYSHELF_KEEP_BENCHMARK_DIR !== "1") {
+    await rm(root, { recursive: true, force: true });
+  } else {
+    process.stdout.write(`kept benchmark directory: ${root}\n`);
+  }
+}
+
+async function runInstall(label) {
+  const cwd = await mkdtemp(join(root, `${label}-`));
+  await writeFile(
+    join(cwd, "package.json"),
+    JSON.stringify({ private: true, type: "module" }, null, 2) + "\n"
+  );
+
+  const start = performance.now();
+  const res = spawnSync("npm", [...installArgs, "--cache", cacheDir, ...packages], {
+    cwd,
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"]
+  });
+  const durationMs = performance.now() - start;
+
+  if (res.status !== 0) {
+    process.stderr.write(res.stdout);
+    process.stderr.write(res.stderr);
+    throw new Error(`npm ${installArgs.join(" ")} failed with status ${res.status}`);
+  }
+
+  return { durationMs };
+}
+
+function formatMs(ms) {
+  return `${Math.round(ms)}ms`;
+}


### PR DESCRIPTION
## Summary
- add a GitHub Actions smoke job that invokes the action against a real v5 TypeScript config fixture with group filtering
- add a cold/warm runtime dependency benchmark for the action's v5 jiti/zod install path
- update the action README with v5 inputs, filtering behavior, benchmark command, and the current multi-identity age limitation

## Verification
- npm run build -w keyshelf
- npm run build -w @keyshelf/action
- npm test -w @keyshelf/action
- npm run typecheck -w @keyshelf/action
- npx prettier --check .github/workflows/action-smoke.yml packages/action/README.md packages/action/package.json packages/action/scripts/benchmark-v5-runtime-deps.mjs
- npm run benchmark:v5-runtime-deps -w @keyshelf/action (cold: 453ms, warm: 235ms)

Closes the unfinished Phase 7 action follow-ups from #78.