### PR TITLE
docs(v5): rewrite READMEs and add migration guide (phase 9 in #78)

### DIFF
--- a/docs/migrating-from-v4.md
+++ b/docs/migrating-from-v4.md
@@ -1,0 +1,95 @@
+# Migrating from keyshelf v4
+
+v5 is a clean rewrite. Configs are TypeScript, every key is a self-contained record, and `set` no longer touches the config file. There is no in-place upgrade — generate a starter config with the migrator, then review.
+
+## Run the migrator
+
+From the repo root that contains your v4 `keyshelf.yaml`:
+
+```sh
+npx @keyshelf/migrate
+```
+
+This reads `keyshelf.yaml`, every `.keyshelf/<env>.yaml`, and the root `.env.keyshelf` (if present), and writes a starter `keyshelf.config.ts`. The v4 YAML files are left in place. App-level `.env.keyshelf` mappings keep working as-is.
+
+Useful flags:
+
+```sh
+npx @keyshelf/migrate --dry-run                 # print the generated config to stdout
+npx @keyshelf/migrate --out ./keyshelf.config.ts --force
+npx @keyshelf/migrate --accept-renamed-name     # if your v4 name has underscores
+```
+
+## What changed
+
+### Config file
+
+| v4                                                     | v5                                                       |
+| ------------------------------------------------------ | -------------------------------------------------------- |
+| `keyshelf.yaml` + `.keyshelf/<env>.yaml` (one per env) | One `keyshelf.config.ts`                                 |
+| `default-provider:` block per env file                 | Provider binding lives on each `secret(...)` record      |
+| `!secret`, `!age`, `!gcp`, `!sops` YAML tags           | `secret(...)`, `age(...)`, `gcp(...)`, `sops(...)` calls |
+| Plaintext values in env files override schema defaults | `values: { <env>: ... }` on the record itself            |
+| `name:` introduced in v4.6 to namespace GCP secrets    | `name:` is required and validated as `lower-kebab-case`  |
+
+Every key's full story is now local to its declaration. There are no env-file-level overrides — to override a value per env, set `values` on the record:
+
+```ts
+db: {
+  host: config({
+    default: "localhost",
+    values: { production: "prod-db.internal" }
+  });
+}
+```
+
+### `keyshelf set`
+
+v4: `set` could write a plaintext value into `.keyshelf/<env>.yaml` _or_ encrypt through a provider. The CLI picked based on `--provider`.
+
+v5: `set` only writes to providers. Config keys are hand-edited in `keyshelf.config.ts`. The provider used is the one bound on the record (`values[env]` or `default`/`value`); there is no `--provider` flag.
+
+```sh
+# v4
+keyshelf set --env production --provider age db/password --value "s3cret"
+
+# v5
+keyshelf set --env production db/password --value "s3cret"
+```
+
+If you used `set` to update plaintext config values in v4, edit `keyshelf.config.ts` directly in v5.
+
+### `--env` is optional
+
+Required only when at least one selected key has a `values` map without a fallback. A fully envless config (e.g. only shared CI tokens) runs without `--env`.
+
+### Groups and filters
+
+v5 introduces two new selectors. Both live on the CLI; nothing in `.env.keyshelf` changes.
+
+- `--group <name[,name...]>` — only keys whose `group:` is in the set
+- `--filter <prefix[,prefix...]>` — only keys whose path starts with one of the prefixes
+
+When a filter excludes a key referenced by an `.env.keyshelf` template, that env var is skipped with a stderr warning, not failed and not emitted as empty. Same rule for optional unresolved keys.
+
+### Editor setup
+
+v4 needed YAML custom-tag configuration to silence `unknown tag !secret` warnings. v5 doesn't — `keyshelf.config.ts` is a normal TypeScript module. You can delete the `yaml.customTags` and `yamllint custom-tags` entries from your editor config.
+
+## Review checklist after running the migrator
+
+1. **`name`** — confirm the generated value. v4 names with underscores are converted to kebab-case (`my_app` → `my-app`) only with `--accept-renamed-name`.
+2. **`groups: []`** — placeholder. Add group names if you want `--group` filtering, then assign `group:` on each record.
+3. **Provider paths** — `identityFile`, `secretsDir`, `secretsFile` are copied from v4 verbatim. They must resolve from the directory containing `keyshelf.config.ts`.
+4. **Secrets are not migrated automatically.** The migrator prints a list of `keyshelf set` commands at the end of its run; copy those out and re-bind each secret with the value from your old store. (Drop any `--provider <name>` flag — v5 picks the provider from the record's binding.)
+5. **`.env.keyshelf` references** — load-time validation rejects references to keys that don't exist in the new config. Run `keyshelf ls` once to confirm.
+
+## Best-effort caveats
+
+The migrator is best-effort, not exact. Known limitations:
+
+- Per-key provider overrides spread across multiple v4 env files collapse into one `secret(...)` declaration. If a single key was bound to providers with conflicting options, the migrator picks one and reports the rest in the migration log.
+- Multi-mapping `.env.keyshelf` files in subdirectories aren't relocated — they keep working from their existing paths.
+- Comments in v4 YAML are not preserved.
+
+When in doubt, run `keyshelf ls --env <env>` against the migrated config and compare to `keyshelf ls --env <env>` on the old install before deleting v4 YAML.

--- a/packages/action/README.md
+++ b/packages/action/README.md
@@ -2,6 +2,8 @@
 
 GitHub Action that resolves [keyshelf](https://github.com/pantoninho/keyshelf)-managed config and secrets into `$GITHUB_ENV`, automatically masking secret-backed values.
 
+Requires a v5 `keyshelf.config.ts` at the repo root (or under `working-directory`). v4 YAML configs are not supported — run [`@keyshelf/migrate`](../migrate) first.
+
 ## Usage
 
 ```yaml
@@ -20,18 +22,54 @@ After this step, every variable declared in `infra/.env.keyshelf` is set in the 
 
 | Name                | Required | Description                                                                                                                                                                 |
 | ------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `env`               | no       | Environment name. Required only when at least one selected key has env-specific `values` without a fallback.                                                                |
+| `env`               | no       | Environment name. Required only when at least one selected key has env-specific `values` without a fallback. A fully envless config can run without it.                     |
 | `map`               | yes      | Path to a `.env.keyshelf` mapping file. Multiple files supported, one per line.                                                                                             |
 | `identity`          | no       | Raw identity material (e.g. an age private key). Written to every unique `age()` `identityFile` path in the config with mode `0600`. Pass via `secrets.*`; never hard-code. |
 | `working-directory` | no       | Directory containing `keyshelf.config.ts`. Defaults to the repo root.                                                                                                       |
 | `groups`            | no       | Comma- or newline-separated groups to include. Mapping entries that reference filtered-out keys are skipped with a workflow warning.                                        |
 | `filters`           | no       | Comma- or newline-separated key-path prefixes to include. Mapping entries that reference filtered-out keys are skipped with a workflow warning.                             |
 
+### Filtering
+
+`groups` and `filters` are independent — pass either or both. With both set, a key must match _both_ to be included.
+
+```yaml
+# Only secrets used by CI; other groups are skipped
+- uses: pantoninho/keyshelf/packages/action@keyshelf-action-v1.0.0
+  with:
+    groups: ci
+    map: .env.keyshelf
+
+# Only db/* keys, regardless of group
+- uses: pantoninho/keyshelf/packages/action@keyshelf-action-v1.0.0
+  with:
+    env: production
+    filters: db
+    identity: ${{ secrets.KEYSHELF_PROD_IDENTITY }}
+    map: apps/api/.env.keyshelf
+```
+
+When a `.env.keyshelf` template (e.g. `DB_URL=postgres://${db/host}:${db/password}@...`) references a key that's been filtered out, the entire env var is **skipped** with a `::warning::` notice — never emitted as empty, never failed silently. Same rule applies to optional secrets that don't resolve in the active env.
+
+### `env` is now optional
+
+In v5, `--env` is only required when at least one selected key has a `values` map without a fallback. Configs whose secrets all live in shared/envless bindings (e.g. CI tokens) work without it:
+
+```yaml
+- uses: pantoninho/keyshelf/packages/action@keyshelf-action-v1.0.0
+  with:
+    groups: ci
+    identity: ${{ secrets.KEYSHELF_CI_IDENTITY }}
+    map: .env.keyshelf
+```
+
+If you do pass `env`, it must match a name from the config's top-level `envs: [...]` list.
+
 ## Provider notes
 
-- **`age` / `sops`**: pass the identity material via `identity:`. The action reads the destination path from provider bindings in `keyshelf.config.ts`.
+- **`age` / `sops`**: pass the identity material via `identity:`. The action reads the destination path from each `age()` provider binding in `keyshelf.config.ts`.
 - **`gcp`**: configure GCP credentials with [`google-github-actions/auth`](https://github.com/google-github-actions/auth) before this action runs. `identity` is not used; pass `gcp` mappings via `map:` as usual.
-- **Multi-identity age configs**: the identity writer writes the same `identity:` value to every unique `age()` `identityFile` path in the config.
+- **Multi-identity age configs**: the identity writer writes the same `identity:` value to every unique `age()` `identityFile` path in the config. Configs that legitimately need multiple distinct age keys are not supported yet.
 
 ## Masking
 
@@ -39,7 +77,7 @@ For each resolved variable, if the underlying key is secret-backed, the action e
 
 ## Runtime benchmark
 
-The action installs `jiti` and `zod` at runtime. Measure cold and warm install time with:
+The action installs `jiti` and `zod` at runtime (they ship as CJS with dynamic `require()` and can't be bundled into the action's ESM build). Measure cold and warm install time with:
 
 ```sh
 npm run benchmark:runtime-deps -w @keyshelf/action

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,412 +1,403 @@
 # keyshelf
 
-Config and secrets management for monorepos. Declarative schema, per-environment overrides, pluggable secret providers.
+Config and secrets management for monorepos. One TypeScript file declares every key in your project: where its value comes from, which environments override it, which group it belongs to, and which provider holds the secret.
 
-## How it works
+## Mental model
 
-1. **Root schema** (`keyshelf.yaml`) — defines all keys, their defaults, and which are secrets
-2. **Environment files** (`.keyshelf/<env>.yaml`) — override values and bind secrets to providers
-3. **App mapping** (`.env.keyshelf`) — maps key paths to `ENV_VAR` names per app
+Every key is a **record**. A record has:
 
+- a **kind** — `config` (plaintext) or `secret` (must come from a provider)
+- an optional **group** — `app`, `ci`, `ops`, … a label you can filter on at runtime
+- a **default binding** (`value` / `default`) — what to use when no env-specific override applies
+- an optional **`values` map** — per-env overrides, keyed by names from your `envs` list
+
+There is one declaration per key, in one file. No cross-file overrides, no per-env defaults — the full story for every key is local to its declaration.
+
+```ts
+db: {
+  host: "localhost",                                  // plaintext config, default for every env
+  port: 5432,
+  password: secret({                                  // secret, env-specific provider bindings
+    group: "app",
+    default: age({ identityFile: "./keys/dev.txt", secretsDir: "./secrets" }),
+    values: {
+      production: gcp({ project: "myproj" })
+    }
+  })
+}
 ```
-monorepo/
-├── keyshelf.yaml            # schema + defaults
-├── .keyshelf/
-│   ├── dev.yaml             # dev environment
-│   └── production.yaml      # production environment
-├── apps/
-│   ├── api/
-│   │   └── .env.keyshelf    # API app mapping
-│   └── worker/
-│       └── .env.keyshelf    # Worker app mapping
-```
 
-## Quick start
+## Install
 
-```bash
+```sh
 npm install keyshelf
 ```
 
-### 1. Define your schema
+Requires Node 20+. The CLI is invoked as `keyshelf`.
 
-```yaml
-# keyshelf.yaml
-keys:
-  db:
-    host: localhost
-    port: 5432
-    password: !secret
-  api:
-    key: !secret
-    url: https://api.example.com
-  analytics:
-    key: !secret
-      optional: true
+## Quick start
+
+### 1. Declare your config
+
+```ts
+// keyshelf.config.ts (at the repo root)
+import { defineConfig, config, secret, age, gcp } from "keyshelf/config";
+
+export default defineConfig({
+  name: "myapp",
+  envs: ["dev", "staging", "production"],
+  groups: ["app", "ci"],
+
+  keys: {
+    log: {
+      level: "info",
+      format: "json"
+    },
+    db: {
+      host: config({
+        default: "localhost",
+        values: { production: "prod-db.internal" }
+      }),
+      port: 5432,
+      password: secret({
+        group: "app",
+        default: age({ identityFile: "./keys/dev.txt", secretsDir: "./secrets" }),
+        values: {
+          production: gcp({ project: "myproj" })
+        }
+      })
+    },
+    github: {
+      token: secret({
+        group: "ci",
+        value: age({ identityFile: "./keys/ci.txt", secretsDir: "./secrets" })
+      })
+    }
+  }
+});
 ```
 
-The `keys:` block declares every key in your project. Plain values (`localhost`, `5432`) are config with defaults. `!secret` marks values that must come from a provider at resolve time. Add `optional: true` to allow a secret to be missing without erroring.
-
-### 2. Create an environment file
-
-```yaml
-# .keyshelf/dev.yaml
-default-provider:
-  name: age
-  identityFile: ./keys/dev.txt
-  secretsDir: ./.keyshelf/secrets/dev
-
-db:
-  host: dev-db.local
-```
-
-The `default-provider` block tells keyshelf how to resolve any `!secret` key that doesn't have an explicit override. Config values (like `db/host` above) can be overridden as plaintext.
-
-You can also bind individual secrets to a specific provider, overriding the default:
-
-```yaml
-db:
-  password: !age
-    identityFile: ./keys/other.txt
-    secretsDir: ./other-secrets
-```
-
-### 3. Create an app mapping
+### 2. Map keys to env-var names per app
 
 ```ini
 # apps/api/.env.keyshelf
 DB_HOST=db/host
 DB_PORT=db/port
 DB_PASSWORD=db/password
-API_KEY=api/key
-API_URL=api/url
+LOG_LEVEL=log/level
 
-# Template syntax — combine multiple keys into one env var
+# Templates compose multiple keys into one env var
 DB_URL=postgres://${db/host}:${db/port}/mydb
 ```
 
-Each app declares exactly which keys it consumes and what env var names to use. The `.env.keyshelf` file is required — it controls which keys are injected into your app.
+Each app declares exactly which keys it consumes and what env var names to use.
 
-Values can be either a direct key path (`db/host`) or a template with `${key/path}` references that get interpolated at resolve time. Templates can mix literal text with any number of key references.
+### 3. Run your app
 
-### 4. Run your app
-
-```bash
+```sh
 cd apps/api
 keyshelf run --env dev -- node server.js
 ```
 
-This resolves all mapped values, injects them as environment variables, and spawns the command.
+This loads the config, resolves every mapped key (decrypting secrets through their bound providers), and spawns the command with those values injected as env vars.
 
-## Resolution order
+## Records
 
-For each key, values are resolved in this order:
+### `config({ ... })` — plaintext values
 
-1. **Env file explicit override** — plaintext value in `.keyshelf/<env>.yaml`
-2. **Env file provider override** — tagged value (e.g. `!age`) in `.keyshelf/<env>.yaml`
-3. **Default provider** — unbound `!secret` keys use the env's `default-provider`
-4. **Schema default** — plain config keys only (not secrets)
-5. **Error or skip** — required keys error, optional secrets are skipped
+```ts
+config({
+  group?: string;
+  optional?: boolean;
+  description?: string;
+  value?: string | number | boolean;        // envless binding; alias of default
+  default?: string | number | boolean;      // base binding; overridden by values entries
+  values?: { [env]: string | number | boolean };
+});
+```
 
-## CLI commands
+A bare scalar is sugar for `config({ value: <scalar> })`:
 
-### `keyshelf run`
+```ts
+log: {
+  level: "info";
+}
+// equivalent to
+log: {
+  level: config({ value: "info" });
+}
+```
 
-Resolve all values, map through `.env.keyshelf`, and run a command with env vars injected. Forwards the child process exit code.
+Use the explicit factory whenever you need `group`, `values`, `optional`, or `description`.
 
-Environment variables already set in your shell take precedence over resolved values. This means you can always override any key by setting the corresponding env var explicitly:
+### `secret({ ... })` — values backed by a provider
 
-```bash
-keyshelf run --env dev -- npm start
-keyshelf run --env production -- node server.js
-keyshelf run --env dev --map ./custom-mapping.env.keyshelf -- npm start
+```ts
+secret({
+  group?: string;
+  optional?: boolean;
+  description?: string;
+  value?: ProviderRef;                      // envless binding; alias of default
+  default?: ProviderRef;
+  values?: { [env]: ProviderRef };
+});
+```
 
-# Override a resolved value
+Every binding on a `secret` record must be a provider call (`age(...)`, `gcp(...)`, `sops(...)`). Plaintext secrets are not supported — if you want a non-sensitive value, use `config(...)`.
+
+`secret(...)` with no binding at all is rejected at validation time. A binding must be reachable for the active env (either via `values[env]`, or via `default`/`value`), unless the record is `optional: true`.
+
+### Namespaces
+
+Object literals are **namespaces**, not records. They flatten into `/`-joined paths:
+
+```ts
+keys: {
+  db: { host: "localhost", port: 5432 }
+}
+// declares db/host and db/port
+```
+
+You can also write paths inline as strings — handy for shallow configs:
+
+```ts
+keys: {
+  "db/host": "localhost",
+  "db/port": 5432
+}
+```
+
+A path is either a leaf (a record) or a namespace (a nested object), never both. `foo: 'bar'` and `foo: { x: 'y' }` declared together is a duplicate-path error.
+
+## Resolution
+
+For each key, given an active `envName`:
+
+1. If `values[envName]` is set → use that binding.
+2. Else if `value` / `default` is set → use that binding.
+3. Else if `optional: true` → skip (no value emitted).
+4. Else → error.
+
+`value` and `default` are aliases. Setting both on the same record is a validation error. The two names exist purely for legibility — `value:` reads naturally for envless records, `default:` reads naturally when paired with `values:`.
+
+`--env` is **only required** when at least one selected key has a `values` map without a fallback. A fully envless config can run without `--env`.
+
+## Templates
+
+A `config` binding can interpolate other keys with `${path/to/key}`:
+
+```ts
+db: {
+  host: "localhost",
+  port: 5432,
+  user: "app",
+  password: secret({ value: age({ ... }) }),
+  url: config({
+    default: "postgres://${db/user}:${db/password}@${db/host}:${db/port}/mydb"
+  })
+}
+```
+
+References are resolved after group/filter selection. Cyclic references are rejected at validation time. Templates can reference both config and secret keys — referencing a secret means the rendered string is itself sensitive. Use `$${...}` to emit a literal `${...}`.
+
+Templates are only valid inside `config(...)` bindings. Use them in `.env.keyshelf` mappings as well; see below.
+
+## Groups and filters
+
+Groups label keys; filters select by path prefix. Both are runtime selectors, not part of resolution semantics.
+
+```sh
+keyshelf run --group app -- node server.js          # only keys with group: 'app'
+keyshelf run --group app,ci -- ...                  # union
+keyshelf run --filter db,log -- ...                 # only keys whose path starts with db/ or log/
+keyshelf run --group app --filter db -- ...         # intersection of both
+```
+
+When a filter excludes a key referenced by an `.env.keyshelf` template (or by another template), that env var is **skipped** with a stderr warning, not failed and not emitted as empty:
+
+```
+keyshelf: skipping DB_URL — referenced key 'db/password' was filtered out by --group
+```
+
+Same rule applies to optional secrets that don't resolve in the active env.
+
+## App mapping (`.env.keyshelf`)
+
+Each app declares which keys it consumes and the env var names to use:
+
+```ini
+# apps/api/.env.keyshelf
+DB_HOST=db/host
+DB_URL=postgres://${db/host}:${db/port}/mydb
+```
+
+- **Direct mapping:** `ENV_VAR=key/path` — emits the resolved key value.
+- **Template mapping:** `ENV_VAR=...${key/path}...` — substitutes each reference and emits the composed string.
+
+A host shell env var that is already set takes precedence over the resolved value, so you can always override anything by exporting the env var first:
+
+```sh
 DB_HOST=localhost keyshelf run --env production -- node server.js
 ```
 
-### `keyshelf set`
+Template mappings are skipped during `keyshelf import` because composite values cannot be decomposed back into individual keys.
 
-Set a value in an environment file.
+## CLI
 
-```bash
-# Plaintext override (stored in .keyshelf/<env>.yaml)
-keyshelf set --env dev db/host --value dev-db.local
+### `keyshelf run`
 
-# Via provider
-keyshelf set --env production --provider age db/password --value "s3cret"
+Resolve every key referenced by the local `.env.keyshelf`, inject them as env vars, and spawn a command.
 
-# Interactive (prompts for value)
-keyshelf set --env production --provider age db/password
-
-# From pipe
-echo "s3cret" | keyshelf set --env production --provider age db/password
+```sh
+keyshelf run --env dev -- npm start
+keyshelf run --env production --group app -- node server.js
+keyshelf run --filter db -- ./scripts/check-db.sh
+keyshelf run --map ./infra/.env.keyshelf -- terraform apply
 ```
+
+Forwards the child process exit code.
 
 ### `keyshelf ls`
 
-List keys defined in the schema. Shows key paths, types (config/secret), and source info.
+List declared records with their kind, group, and active binding source.
 
-```bash
-# Schema only (no environment context)
-keyshelf ls
-
-# With environment — shows where each value comes from
-keyshelf ls --env dev
-
-# Reveal actual resolved values (requires --env)
-keyshelf ls --env production --reveal
-
-# With a specific mapping file
-keyshelf ls --env dev --map ./custom-mapping.env.keyshelf
+```sh
+keyshelf ls                                          # schema only, no env context
+keyshelf ls --env dev                                # show which binding applies for dev
+keyshelf ls --env production --reveal                # resolve through providers and print values
+keyshelf ls --env dev --reveal --map ./apps/api/.env.keyshelf --format json
 ```
+
+`--reveal` decrypts secrets — guard accordingly. `--format json` is intended for programmatic consumers (e.g. the GitHub Action) and requires `--reveal`, `--env`, and `--map`.
+
+### `keyshelf set`
+
+Write a secret value through its bound provider. Does **not** edit `keyshelf.config.ts` — config keys are hand-edited.
+
+```sh
+keyshelf set --env production db/password --value "s3cret"
+keyshelf set --env production db/password                 # interactive prompt on TTY
+echo "s3cret" | keyshelf set --env production db/password # from pipe
+keyshelf set github/token --value "..."                   # envless secret
+```
+
+The provider used is the one bound at `values[env]`, or the record's `default`/`value` if no env-specific binding exists. Trying to `set` a config key is rejected — change `keyshelf.config.ts` directly.
 
 ### `keyshelf import`
 
-Bulk import from a `.env` file. Uses `.env.keyshelf` as a reverse lookup to map `ENV_VAR` names back to key paths.
+Bulk-write secret values from a `.env` file by reverse-mapping env-var names through `.env.keyshelf`.
 
-```bash
-keyshelf import --env dev --file .env
-keyshelf import --env production --provider age --file .env.production
+```sh
+keyshelf import --env production --file .env.production
+keyshelf import --env staging --group app --file .env.staging
 ```
 
-With `--provider`, keys marked as `!secret` in the schema are stored via the provider. Config keys are always written as plaintext to the env file.
+Only secret keys are written. Config keys mapped in the file are skipped (with a warning) — edit `keyshelf.config.ts` to change config defaults.
 
 ## Providers
 
-### age
+### `age({ identityFile, secretsDir })`
 
-Local encrypted secrets using [age](https://age-encryption.org/). Each secret is stored as a separate `.age` file on disk.
+Local encrypted secrets using [age](https://age-encryption.org/). Each secret is one `.age` file in `secretsDir`, named after the key path (`/` mangled to `_`). The identity at `identityFile` decrypts on `run` and derives the recipient on `set`.
 
-```yaml
-# .keyshelf/production.yaml
-default-provider:
-  name: age
-  identityFile: ./keys/production.txt
-  secretsDir: ./.keyshelf/secrets/production
+```ts
+secret({
+  default: age({ identityFile: "./keys/dev.txt", secretsDir: "./secrets" }),
+  values: {
+    ci: age({ identityFile: "./keys/ci.txt", secretsDir: "./secrets" })
+  }
+});
 ```
 
-| Option         | Description                                       |
-| -------------- | ------------------------------------------------- |
-| `identityFile` | Path to the age identity (private key) file       |
-| `secretsDir`   | Directory where `.age` encrypted files are stored |
+Relative paths resolve from the directory containing `keyshelf.config.ts`. Absolute paths and `~`-prefixed paths are used as-is.
 
-Relative paths are resolved from the project root (the directory containing `keyshelf.yaml`), so `./keys/production.txt` always refers to the same file regardless of where you run the command. Absolute paths and `~`-prefixed paths are used as-is.
+Generate a new identity programmatically:
 
-Generate a new identity:
-
-```javascript
+```ts
 import { generateIdentity, identityToRecipient } from "keyshelf";
 
 const identity = await generateIdentity();
 const recipient = await identityToRecipient(identity);
-// Save identity to file, share recipient with team
 ```
 
-### gcp (Google Cloud Secret Manager)
+### `gcp({ project })`
 
-Stores secrets in GCP Secret Manager. Secret names follow the convention `keyshelf__<env>__<key>` (slashes replaced with `__`).
+Google Cloud Secret Manager. Secrets are namespaced with the keyshelf project `name` so multiple keyshelf configs can share one GCP project without colliding:
 
-```yaml
-# .keyshelf/production.yaml
-default-provider:
-  name: gcp
-  project: my-gcp-project
-```
+- env-scoped: `keyshelf__<name>__<env>__<keyPath>`
+- envless: `keyshelf__<name>__<keyPath>`
 
-| Option    | Description               |
-| --------- | ------------------------- |
-| `project` | GCP project ID (required) |
+`/` in key paths is mangled to `__` (Secret Manager doesn't allow `/`).
 
-Secrets are created automatically on first `keyshelf set`. Requires GCP credentials configured in the environment (e.g. `GOOGLE_APPLICATION_CREDENTIALS` or `gcloud auth`).
+Requires GCP credentials in the environment (`GOOGLE_APPLICATION_CREDENTIALS`, `gcloud auth`, or workload identity). Secrets are created automatically on first `keyshelf set`.
 
-### sops
+### `sops({ identityFile, secretsFile })`
 
-SOPS-inspired single-file encrypted secrets using [age](https://age-encryption.org/) encryption. All secrets for an environment are stored in one JSON file, with each value individually encrypted using AES-256-GCM and a shared data key that is itself encrypted with age.
+SOPS-style single-file encrypted secrets. All secrets for the bound config live in one JSON document, each value encrypted with AES-256-GCM under a shared data key that is itself age-encrypted. Tamper-detected via HMAC.
 
-```yaml
-# .keyshelf/production.yaml
-default-provider:
-  name: sops
-  identityFile: ./keys/production.txt
-  secretsFile: ./.keyshelf/secrets/production.json
-```
-
-| Option         | Description                                              |
-| -------------- | -------------------------------------------------------- |
-| `identityFile` | Path to the age identity (private key) file              |
-| `secretsFile`  | Path to the JSON file where encrypted secrets are stored |
-
-Relative paths are resolved from the project root (the directory containing `keyshelf.yaml`). Absolute paths and `~`-prefixed paths are used as-is.
-
-The secrets file is created automatically on first `keyshelf set`. It contains all encrypted entries, the age-encrypted data key, and an HMAC for tamper detection. Unlike the `age` provider (one file per secret), `sops` keeps everything in a single file, which can be easier to manage and commit.
-
-## Schema reference
-
-### `keyshelf.yaml`
-
-```yaml
-# Optional: global default provider (used if env file doesn't set one)
-default-provider:
-  name: age
-  identityFile: ./keys/default.txt
-  secretsDir: ./.keyshelf/secrets/default
-
-keys:
-  # Config key with default value
-  db/host: localhost
-
-  # Nested keys (equivalent to db/host, db/port)
-  db:
-    host: localhost
-    port: 5432
-
-  # Required secret (must be resolved via provider)
-  db:
-    password: !secret
-
-  # Optional secret (skipped if no value available)
-  analytics:
-    key: !secret
-      optional: true
-```
-
-### `.keyshelf/<env>.yaml`
-
-```yaml
-# Default provider for all unbound secrets in this env
-default-provider:
-  name: age
-  identityFile: ./keys/production.txt
-  secretsDir: ./.keyshelf/secrets/production
-
-# Plaintext overrides
-db:
-  host: prod-db.example.com
-
-# Per-key provider override
-db:
-  password: !gcp
-    project: my-gcp-project
-```
-
-### `.env.keyshelf`
-
-```ini
-# Maps key paths to environment variable names
-DB_HOST=db/host
-DB_PORT=db/port
-DB_PASSWORD=db/password
-API_KEY=api/key
-
-# Template syntax — interpolate multiple keys into one value
-DB_URL=postgres://${db/host}:${db/port}/mydb
-CLIENT_IDS=${google/web-client-id},${google/ios-client-id}
-```
-
-Each line is either a **direct mapping** (`ENV_VAR=key/path`) or a **template** (`ENV_VAR=...${key/path}...`). Templates replace each `${key/path}` with its resolved value, allowing you to compose connection strings, comma-separated lists, or any other derived value.
-
-> **Note:** Template mappings are skipped during `keyshelf import` because a composite value cannot be decomposed back into individual keys.
+Useful when you'd rather commit one file per env than a directory full of `.age` blobs.
 
 ## What to commit
 
-| Path                   | Commit? | Notes                                                                                |
-| ---------------------- | ------- | ------------------------------------------------------------------------------------ |
-| `keyshelf.yaml`        | Yes     | Key declarations and defaults                                                        |
-| `.keyshelf/<env>.yaml` | Depends | Safe if it only has plaintext config. Avoid committing if it has sensitive overrides |
-| `.keyshelf/secrets/`   | No      | Contains encrypted `.age` files — add to `.gitignore`                                |
-| `keys/*.txt`           | No      | Age identity (private key) files — add to `.gitignore`                               |
-| `.env.keyshelf`        | Yes     | App-level key mappings, no secret values                                             |
+| Path                    | Commit? | Notes                                                  |
+| ----------------------- | ------- | ------------------------------------------------------ |
+| `keyshelf.config.ts`    | Yes     | Schema, defaults, and provider bindings                |
+| `apps/*/​.env.keyshelf` | Yes     | App-level key mappings, no secret values               |
+| `secrets/*.age`         | Depends | Encrypted; safe to commit if your threat model allows  |
+| `secrets/*.json` (sops) | Depends | Encrypted; safe to commit if your threat model allows  |
+| `keys/*.txt`            | No      | Age identity (private key) files — add to `.gitignore` |
 
 ## Programmatic API
 
-```javascript
-import { loadConfig, resolve, validate, createDefaultRegistry } from "keyshelf";
+`keyshelf/config` is for _user-authored_ configs. The package root is for _tooling that consumes them_ (e.g. the GitHub Action):
 
-const config = await loadConfig("./apps/api", "production");
-const registry = createDefaultRegistry();
+```ts
+import { loadConfig, resolveWithStatus, validate, renderAppMapping } from "keyshelf";
+import { ProviderRegistry, AgeProvider } from "keyshelf";
 
-// Check for errors first
-const errors = await validate({
-  schema: config.schema,
-  env: config.env,
+const loaded = await loadConfig(process.cwd());
+const registry = new ProviderRegistry();
+registry.register(new AgeProvider());
+
+const result = await validate({
+  config: loaded.config,
   envName: "production",
-  rootDir: config.rootDir,
+  rootDir: loaded.rootDir,
   registry
 });
-if (errors.length > 0) {
-  console.error(errors);
-}
+if (result.topLevelErrors.length || result.keyErrors.length) throw new Error("invalid config");
 
-// Resolve all values
-const resolved = await resolve({
-  schema: config.schema,
-  env: config.env,
+const resolution = await resolveWithStatus({
+  config: loaded.config,
   envName: "production",
-  rootDir: config.rootDir,
+  rootDir: loaded.rootDir,
   registry
 });
-// [{ path: 'db/host', value: 'prod-db.example.com' }, ...]
+
+const rendered = renderAppMapping(loaded.appMapping, resolution);
 ```
 
 ## Editor setup
 
-YAML editors and linters may report `unknown tag !secret` (or `!age`, `!gcp`, `!sops`) warnings on keyshelf files. This is expected — these are custom YAML tags that keyshelf handles at parse time.
+`keyshelf.config.ts` is a regular TypeScript module. Type inference from `defineConfig` autocompletes `envs`, `groups`, and `values` keys; no editor configuration is needed.
 
-### VS Code (YAML extension by Red Hat)
+## Migrating from v4
 
-Add to `.vscode/settings.json`:
+v5 is a clean rewrite. There is no implicit upgrade path — run the migrator to generate a starter `keyshelf.config.ts` from your existing YAML, then review.
 
-```json
-{
-  "yaml.customTags": [
-    "!secret",
-    "!secret mapping",
-    "!age",
-    "!age mapping",
-    "!gcp",
-    "!gcp mapping",
-    "!aws",
-    "!aws mapping",
-    "!sops",
-    "!sops mapping"
-  ]
-}
+```sh
+npx @keyshelf/migrate
 ```
 
-### JetBrains (IntelliJ, WebStorm)
-
-Custom YAML tags are recognized automatically — no configuration needed.
-
-### yamllint
-
-Add to `.yamllint.yml`:
-
-```yaml
-rules:
-  truthy:
-    allowed-values: ["true", "false"]
-  custom-tags:
-    - "!secret"
-    - "!secret mapping"
-    - "!age"
-    - "!age mapping"
-    - "!gcp"
-    - "!gcp mapping"
-    - "!aws"
-    - "!aws mapping"
-    - "!sops"
-    - "!sops mapping"
-```
+See the [migration guide](https://github.com/pantoninho/keyshelf/blob/main/docs/migrating-from-v4.md) for the full walk-through.
 
 ## Development
 
-```bash
+```sh
 npm install
-npm test           # run tests
+npm test           # vitest
 npm run dev        # run CLI via tsx
-npm run build      # build with tsup
-npm run lint       # eslint
-npm run format     # prettier
+npm run build      # tsup
 npm run typecheck  # tsc --noEmit
 ```
 


### PR DESCRIPTION
## Summary
- Rewrite `packages/cli/README.md` around the v5 mental model — every key is a record with optional group, values, and provider binding. Drops v4 YAML / custom-tags content; documents `defineConfig`, factories, `--group` / `--filter`, optional `--env`, and the four CLI commands.
- Add `docs/migrating-from-v4.md` — single-page guide covering the migrator, the v4→v5 deltas (`set` is provider-only, `--env` is optional, groups/filters are new), and a post-migration review checklist.
- Refresh `packages/action/README.md` for v5 inputs: explicit `keyshelf.config.ts` requirement, dedicated examples for groups/filters, and an envless-config example showing `env` is now optional.

Closes phase 9 of #78.

## Test plan
- [ ] Skim the rendered CLI README on GitHub for navigation flow
- [ ] Confirm migration guide examples match `keyshelf set` v5 syntax (no `--provider` flag)
- [ ] Confirm action README examples align with `action.yml` inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)