### PR TITLE
chore(release-please): separate PRs and pin migrate component

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
   "include-component-in-tag": true,
-  "separate-pull-requests": false,
+  "separate-pull-requests": true,
   "packages": {
     "packages/cli": {
       "package-name": "keyshelf"
@@ -11,7 +11,8 @@
       "package-name": "keyshelf-action"
     },
     "packages/migrate": {
-      "package-name": "@keyshelf/migrate"
+      "package-name": "@keyshelf/migrate",
+      "component": "migrate"
     }
   }
 }


### PR DESCRIPTION
## Summary

- Switch release-please to `separate-pull-requests: true` so each package gets its own release PR, eliminating the prefix-collision body-attribution failure that orphaned the `keyshelf-action` and `migrate` components when PR #94 merged.
- Pin migrate's component to `migrate` so the package-name (`@keyshelf/migrate`) and the tag prefix (`migrate-v…`) agree — matches the prefix already used in #94's CHANGELOG and the backfilled tag.

## Background

When PR #94 (v5 cutover release) merged, release-please's post-merge run only created `keyshelf-v5.0.0`. Its log:

```
✔ Building release for path: packages/action
✔ Pull request contains releases, but not for component: keyshelf-action
✔ Building release for path: packages/migrate
✔ Pull request contains releases, but not for component: migrate
✔ Creating 1 releases for pull #94
```

The manifest got bumped to `1.0.0` for both packages anyway, but no tags existed → next workflow tick opened phantom PR #103 proposing `2.0.0` bumps with re-listed commits.

Root causes of the body-attribution failure:

1. **Prefix collision:** `keyshelf` is a strict prefix of `keyshelf-action`. In mono-PR mode, release-please's per-component matcher attributed the action's body section to the cli component.
2. **package-name vs. tag-prefix mismatch:** release-please normalizes `@scope/x` → `x` when building tag prefixes (PR body uses `migrate-v0.1.0...migrate-v1.0.0`) but checks the raw package-name when resolving releases — so `@keyshelf/migrate` ≠ `migrate`.

## State repair (already done out-of-band, before this PR)

- Closed #103 (would have falsely double-bumped action and migrate to 2.0.0).
- Backfilled `keyshelf-action-v1.0.0` and `migrate-v1.0.0` tags + GitHub releases at `b76b05f` (the merge commit of #94) to anchor release-please's component history.

## Test plan

- [ ] Merge this PR. The release-please job should run on push to main and now scan each package independently.
- [ ] Confirm no phantom release PR opens (the manifest is at 5.0.0 / 1.0.0 / 1.0.0 and matching tags now exist).
- [ ] Next time a `feat`/`fix` lands in any package, release-please should open a per-package PR (e.g. `release-please--branches--main--components--keyshelf-action`) instead of the previous shared `release-please--branches--main` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)