### PR TITLE
test(providers): extract shared common provider test cases

### DIFF
--- a/packages/cli/test/unit/providers/_shared.ts
+++ b/packages/cli/test/unit/providers/_shared.ts
@@ -1,0 +1,115 @@
+import { it, expect, beforeEach } from "vitest";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { homedir, tmpdir } from "node:os";
+import type { Provider, ProviderContext } from "../../../src/providers/types.js";
+import { generateIdentity } from "../../../src/providers/age.js";
+
+interface SharedTestOptions<P extends Provider> {
+  prefix: string;
+  createProvider: () => P;
+  buildConfig: (paths: { tmpDir: string; identityFile: string }) => Record<string, string>;
+}
+
+interface SharedTestState<P extends Provider> {
+  tmpDir: string;
+  identityFile: string;
+  provider: P;
+  ctx: (keyPath: string) => ProviderContext;
+}
+
+export function shareCommonProviderTests<P extends Provider>(
+  opts: SharedTestOptions<P>
+): SharedTestState<P> {
+  const state = {} as SharedTestState<P>;
+
+  beforeEach(async () => {
+    state.tmpDir = await mkdtemp(join(tmpdir(), opts.prefix));
+    state.identityFile = join(state.tmpDir, "key.txt");
+    const identity = await generateIdentity();
+    await writeFile(state.identityFile, identity);
+    state.provider = opts.createProvider();
+    const config = opts.buildConfig({ tmpDir: state.tmpDir, identityFile: state.identityFile });
+    state.ctx = (keyPath: string) => ({
+      keyPath,
+      envName: "test",
+      rootDir: state.tmpDir,
+      config: { ...config }
+    });
+  });
+
+  it("roundtrips set + resolve", async () => {
+    await state.provider.set(state.ctx("db/password"), "supersecret");
+    expect(await state.provider.resolve(state.ctx("db/password"))).toBe("supersecret");
+  });
+
+  it("roundtrips multiple keys", async () => {
+    await state.provider.set(state.ctx("db/password"), "dbpass");
+    await state.provider.set(state.ctx("api/key"), "apikey123");
+    expect(await state.provider.resolve(state.ctx("db/password"))).toBe("dbpass");
+    expect(await state.provider.resolve(state.ctx("api/key"))).toBe("apikey123");
+  });
+
+  it("overwrites existing secret", async () => {
+    await state.provider.set(state.ctx("db/password"), "old");
+    await state.provider.set(state.ctx("db/password"), "new");
+    expect(await state.provider.resolve(state.ctx("db/password"))).toBe("new");
+  });
+
+  it("validate returns true for existing secret", async () => {
+    await state.provider.set(state.ctx("db/password"), "value");
+    expect(await state.provider.validate(state.ctx("db/password"))).toBe(true);
+  });
+
+  it("validate returns false for missing secret", async () => {
+    expect(await state.provider.validate(state.ctx("missing/key"))).toBe(false);
+  });
+
+  it("handles empty string values", async () => {
+    await state.provider.set(state.ctx("empty"), "");
+    expect(await state.provider.resolve(state.ctx("empty"))).toBe("");
+  });
+
+  it("handles special characters", async () => {
+    const special = 'p@$$w0rd!#%^&*()_+{}|:"<>?`~';
+    await state.provider.set(state.ctx("special"), special);
+    expect(await state.provider.resolve(state.ctx("special"))).toBe(special);
+  });
+
+  it("expands ~ in config paths", async () => {
+    const home = homedir();
+    if (!state.tmpDir.startsWith(home)) return;
+    const baseConfig = opts.buildConfig({ tmpDir: state.tmpDir, identityFile: state.identityFile });
+    const tildeConfig: Record<string, string> = {};
+    for (const [k, v] of Object.entries(baseConfig)) {
+      tildeConfig[k] = v.replace(home, "~");
+    }
+    const tildeCtx: ProviderContext = {
+      keyPath: "tilde/test",
+      envName: "test",
+      rootDir: state.tmpDir,
+      config: tildeConfig
+    };
+    await state.provider.set(tildeCtx, "tilde-value");
+    expect(await state.provider.resolve(tildeCtx)).toBe("tilde-value");
+  });
+
+  return state;
+}
+
+export function testRequiredConfigKey<P extends Provider>(
+  state: SharedTestState<P>,
+  missingKey: string,
+  remainingConfig: () => Record<string, string>
+) {
+  it(`throws when ${missingKey} is missing from config`, async () => {
+    await expect(
+      state.provider.resolve({
+        keyPath: "k",
+        envName: "test",
+        rootDir: state.tmpDir,
+        config: remainingConfig()
+      })
+    ).rejects.toThrow(missingKey);
+  });
+}

--- a/packages/cli/test/unit/providers/age.test.ts
+++ b/packages/cli/test/unit/providers/age.test.ts
@@ -1,112 +1,25 @@
-import { describe, it, expect, beforeEach } from "vitest";
-import { mkdtemp, writeFile } from "node:fs/promises";
-import { join } from "node:path";
-import { homedir, tmpdir } from "node:os";
-import { AgeProvider, generateIdentity } from "../../../src/providers/age.js";
+import { describe, it, expect } from "vitest";
+import { AgeProvider } from "../../../src/providers/age.js";
+import { shareCommonProviderTests, testRequiredConfigKey } from "./_shared.js";
 
 describe("AgeProvider", () => {
-  let tmpDir: string;
-  let identityFile: string;
-  let secretsDir: string;
-  let provider: AgeProvider;
-
-  beforeEach(async () => {
-    tmpDir = await mkdtemp(join(tmpdir(), "keyshelf-age-"));
-    identityFile = join(tmpDir, "key.txt");
-    secretsDir = join(tmpDir, "secrets");
-
-    const identity = await generateIdentity();
-    await writeFile(identityFile, identity);
-
-    provider = new AgeProvider();
+  const state = shareCommonProviderTests({
+    prefix: "keyshelf-age-",
+    createProvider: () => new AgeProvider(),
+    buildConfig: ({ tmpDir, identityFile }) => ({
+      identityFile,
+      secretsDir: `${tmpDir}/secrets`
+    })
   });
 
-  function ctx(keyPath: string) {
-    return { keyPath, envName: "test", rootDir: tmpDir, config: { identityFile, secretsDir } };
-  }
-
-  it("roundtrips set + resolve", async () => {
-    await provider.set(ctx("db/password"), "supersecret");
-    const result = await provider.resolve(ctx("db/password"));
-    expect(result).toBe("supersecret");
-  });
-
-  it("roundtrips multiple keys", async () => {
-    await provider.set(ctx("db/password"), "dbpass");
-    await provider.set(ctx("api/key"), "apikey123");
-
-    expect(await provider.resolve(ctx("db/password"))).toBe("dbpass");
-    expect(await provider.resolve(ctx("api/key"))).toBe("apikey123");
-  });
-
-  it("overwrites existing secret", async () => {
-    await provider.set(ctx("db/password"), "old");
-    await provider.set(ctx("db/password"), "new");
-    expect(await provider.resolve(ctx("db/password"))).toBe("new");
-  });
-
-  it("validate returns true for existing secret", async () => {
-    await provider.set(ctx("db/password"), "value");
-    expect(await provider.validate(ctx("db/password"))).toBe(true);
-  });
-
-  it("validate returns false for missing secret", async () => {
-    expect(await provider.validate(ctx("missing/key"))).toBe(false);
-  });
+  testRequiredConfigKey(state, "identityFile", () => ({
+    secretsDir: `${state.tmpDir}/secrets`
+  }));
+  testRequiredConfigKey(state, "secretsDir", () => ({
+    identityFile: state.identityFile
+  }));
 
   it("resolve throws for missing secret", async () => {
-    await expect(provider.resolve(ctx("missing/key"))).rejects.toThrow();
-  });
-
-  it("throws when identityFile is missing from config", async () => {
-    await expect(
-      provider.resolve({
-        keyPath: "k",
-        envName: "test",
-        rootDir: tmpDir,
-        config: { secretsDir }
-      })
-    ).rejects.toThrow("identityFile");
-  });
-
-  it("throws when secretsDir is missing from config", async () => {
-    await expect(
-      provider.resolve({
-        keyPath: "k",
-        envName: "test",
-        rootDir: tmpDir,
-        config: { identityFile }
-      })
-    ).rejects.toThrow("secretsDir");
-  });
-
-  it("handles empty string values", async () => {
-    await provider.set(ctx("empty"), "");
-    expect(await provider.resolve(ctx("empty"))).toBe("");
-  });
-
-  it("handles special characters", async () => {
-    const special = 'p@$$w0rd!#%^&*()_+{}|:"<>?`~';
-    await provider.set(ctx("special"), special);
-    expect(await provider.resolve(ctx("special"))).toBe(special);
-  });
-
-  it("expands ~ in identityFile and secretsDir", async () => {
-    const home = homedir();
-    const relIdentity = identityFile.replace(home, "~");
-    const relSecrets = secretsDir.replace(home, "~");
-
-    // only run when tmpdir is under home (true on macOS/Linux)
-    if (!identityFile.startsWith(home)) return;
-
-    const tildeCtx = {
-      keyPath: "tilde/test",
-      envName: "test",
-      rootDir: tmpDir,
-      config: { identityFile: relIdentity, secretsDir: relSecrets }
-    };
-
-    await provider.set(tildeCtx, "tilde-value");
-    expect(await provider.resolve(tildeCtx)).toBe("tilde-value");
+    await expect(state.provider.resolve(state.ctx("missing/key"))).rejects.toThrow();
   });
 });

--- a/packages/cli/test/unit/providers/sops.test.ts
+++ b/packages/cli/test/unit/providers/sops.test.ts
@@ -1,163 +1,86 @@
-import { describe, it, expect, beforeEach } from "vitest";
-import { mkdtemp, writeFile, readFile } from "node:fs/promises";
+import { describe, it, expect } from "vitest";
+import { writeFile, readFile } from "node:fs/promises";
 import { join } from "node:path";
-import { homedir, tmpdir } from "node:os";
 import { SopsProvider } from "../../../src/providers/sops.js";
-import { generateIdentity } from "../../../src/providers/age.js";
+import { shareCommonProviderTests, testRequiredConfigKey } from "./_shared.js";
 
 describe("SopsProvider", () => {
-  let tmpDir: string;
-  let identityFile: string;
-  let secretsFile: string;
-  let provider: SopsProvider;
-
-  beforeEach(async () => {
-    tmpDir = await mkdtemp(join(tmpdir(), "keyshelf-sops-"));
-    identityFile = join(tmpDir, "key.txt");
-    secretsFile = join(tmpDir, "secrets.json");
-
-    const identity = await generateIdentity();
-    await writeFile(identityFile, identity);
-
-    provider = new SopsProvider();
+  const state = shareCommonProviderTests({
+    prefix: "keyshelf-sops-",
+    createProvider: () => new SopsProvider(),
+    buildConfig: ({ tmpDir, identityFile }) => ({
+      identityFile,
+      secretsFile: join(tmpDir, "secrets.json")
+    })
   });
 
-  function ctx(keyPath: string) {
-    return { keyPath, envName: "test", rootDir: tmpDir, config: { identityFile, secretsFile } };
+  testRequiredConfigKey(state, "identityFile", () => ({
+    secretsFile: join(state.tmpDir, "secrets.json")
+  }));
+  testRequiredConfigKey(state, "secretsFile", () => ({
+    identityFile: state.identityFile
+  }));
+
+  function secretsFilePath() {
+    return join(state.tmpDir, "secrets.json");
   }
 
-  it("roundtrips set + resolve", async () => {
-    await provider.set(ctx("db/password"), "supersecret");
-    const result = await provider.resolve(ctx("db/password"));
-    expect(result).toBe("supersecret");
-  });
-
-  it("roundtrips multiple keys", async () => {
-    await provider.set(ctx("db/password"), "dbpass");
-    await provider.set(ctx("api/key"), "apikey123");
-
-    expect(await provider.resolve(ctx("db/password"))).toBe("dbpass");
-    expect(await provider.resolve(ctx("api/key"))).toBe("apikey123");
-  });
-
   it("stores all secrets in a single file", async () => {
-    await provider.set(ctx("db/password"), "dbpass");
-    await provider.set(ctx("api/key"), "apikey123");
+    await state.provider.set(state.ctx("db/password"), "dbpass");
+    await state.provider.set(state.ctx("api/key"), "apikey123");
 
-    const content = JSON.parse(await readFile(secretsFile, "utf-8"));
+    const content = JSON.parse(await readFile(secretsFilePath(), "utf-8"));
     expect(Object.keys(content.entries)).toEqual(
       expect.arrayContaining(["db/password", "api/key"])
     );
-  });
-
-  it("overwrites existing secret", async () => {
-    await provider.set(ctx("db/password"), "old");
-    await provider.set(ctx("db/password"), "new");
-    expect(await provider.resolve(ctx("db/password"))).toBe("new");
-  });
-
-  it("validate returns true for existing secret", async () => {
-    await provider.set(ctx("db/password"), "value");
-    expect(await provider.validate(ctx("db/password"))).toBe(true);
-  });
-
-  it("validate returns false for missing secret", async () => {
-    expect(await provider.validate(ctx("missing/key"))).toBe(false);
   });
 
   it("validate returns false for missing file", async () => {
     const missingCtx = {
       keyPath: "k",
       envName: "test",
-      rootDir: tmpDir,
-      config: { identityFile, secretsFile: join(tmpDir, "nope.json") }
+      rootDir: state.tmpDir,
+      config: { identityFile: state.identityFile, secretsFile: join(state.tmpDir, "nope.json") }
     };
-    expect(await provider.validate(missingCtx)).toBe(false);
+    expect(await state.provider.validate(missingCtx)).toBe(false);
   });
 
   it("resolve throws for missing secret", async () => {
-    await provider.set(ctx("other"), "val");
-    await expect(provider.resolve(ctx("missing/key"))).rejects.toThrow(
+    await state.provider.set(state.ctx("other"), "val");
+    await expect(state.provider.resolve(state.ctx("missing/key"))).rejects.toThrow(
       'secret "missing/key" not found'
     );
   });
 
   it("resolve throws for missing file", async () => {
-    await expect(provider.resolve(ctx("missing/key"))).rejects.toThrow();
-  });
-
-  it("throws when identityFile is missing from config", async () => {
-    await expect(
-      provider.resolve({
-        keyPath: "k",
-        envName: "test",
-        rootDir: tmpDir,
-        config: { secretsFile }
-      })
-    ).rejects.toThrow("identityFile");
-  });
-
-  it("throws when secretsFile is missing from config", async () => {
-    await expect(
-      provider.resolve({
-        keyPath: "k",
-        envName: "test",
-        rootDir: tmpDir,
-        config: { identityFile }
-      })
-    ).rejects.toThrow("secretsFile");
-  });
-
-  it("handles empty string values", async () => {
-    await provider.set(ctx("empty"), "");
-    expect(await provider.resolve(ctx("empty"))).toBe("");
-  });
-
-  it("handles special characters", async () => {
-    const special = 'p@$$w0rd!#%^&*()_+{}|:"<>?`~';
-    await provider.set(ctx("special"), special);
-    expect(await provider.resolve(ctx("special"))).toBe(special);
+    await expect(state.provider.resolve(state.ctx("missing/key"))).rejects.toThrow();
   });
 
   it("detects tampering via MAC", async () => {
-    await provider.set(ctx("db/password"), "secret");
+    await state.provider.set(state.ctx("db/password"), "secret");
 
-    const content = JSON.parse(await readFile(secretsFile, "utf-8"));
-    content.entries["db/password"].data = "dGFtcGVyZWQ="; // "tampered" in base64
-    await writeFile(secretsFile, JSON.stringify(content));
+    const content = JSON.parse(await readFile(secretsFilePath(), "utf-8"));
+    content.entries["db/password"].data = "dGFtcGVyZWQ=";
+    await writeFile(secretsFilePath(), JSON.stringify(content));
 
-    await expect(provider.resolve(ctx("db/password"))).rejects.toThrow("MAC verification failed");
+    await expect(state.provider.resolve(state.ctx("db/password"))).rejects.toThrow(
+      "MAC verification failed"
+    );
   });
 
   it("detects key injection via MAC", async () => {
-    await provider.set(ctx("db/password"), "secret");
+    await state.provider.set(state.ctx("db/password"), "secret");
 
-    const content = JSON.parse(await readFile(secretsFile, "utf-8"));
+    const content = JSON.parse(await readFile(secretsFilePath(), "utf-8"));
     content.entries["injected/key"] = {
       data: "ZmFrZQ==",
       iv: "AAAAAAAAAAAAAAAA",
       tag: "AAAAAAAAAAAAAAAAAAAAAA=="
     };
-    await writeFile(secretsFile, JSON.stringify(content));
+    await writeFile(secretsFilePath(), JSON.stringify(content));
 
-    await expect(provider.resolve(ctx("db/password"))).rejects.toThrow("MAC verification failed");
-  });
-
-  it("expands ~ in identityFile and secretsFile", async () => {
-    const home = homedir();
-    const relIdentity = identityFile.replace(home, "~");
-    const relSecrets = secretsFile.replace(home, "~");
-
-    if (!identityFile.startsWith(home)) return;
-
-    const tildeCtx = {
-      keyPath: "tilde/test",
-      envName: "test",
-      rootDir: tmpDir,
-      config: { identityFile: relIdentity, secretsFile: relSecrets }
-    };
-
-    await provider.set(tildeCtx, "tilde-value");
-    expect(await provider.resolve(tildeCtx)).toBe("tilde-value");
+    await expect(state.provider.resolve(state.ctx("db/password"))).rejects.toThrow(
+      "MAC verification failed"
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Extracts a `shareCommonProviderTests` helper plus `testRequiredConfigKey` helper into `packages/cli/test/unit/providers/_shared.ts` so the age and sops provider unit tests stop hand-rolling identical setup and the same set of common assertions.
- Each test file now keeps only the provider-specific cases (sops MAC/tampering/single-file behavior; age throws-for-missing-key flavor).

Addresses the clone family fallow flagged across `age.test.ts` and `sops.test.ts` (4 groups, 64 lines). Re-running `npx fallow` after this change drops duplication from 15 clone groups (419 lines) to 12 (315 lines).

## Test plan
- [x] `npm test` (cli + migrate + action)
- [x] `tsc --noEmit` in `packages/cli`
- [x] `npx fallow` reports fewer duplicates and no new findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)