### PR TITLE
refactor(cli): share provider-binding helpers between set and import

### DIFF
--- a/packages/cli/src/cli/import.ts
+++ b/packages/cli/src/cli/import.ts
@@ -4,7 +4,7 @@ import { loadConfig } from "../config/index.js";
 import { isTemplateMapping } from "../config/app-mapping.js";
 import { createDefaultRegistry } from "../providers/setup.js";
 import { splitList } from "./options.js";
-import type { BuiltinProviderRef, NormalizedRecord } from "../config/types.js";
+import { pickProviderRef, writeSecret } from "./secret-binding.js";
 
 interface ImportOptions {
   env?: string;
@@ -94,34 +94,10 @@ export const importCommand = new Command("import")
         continue;
       }
 
-      const provider = registry.get(providerRef.name);
-      await provider.set(
-        {
-          keyPath,
-          envName: opts.env,
-          rootDir: loaded.rootDir,
-          config: { ...(providerRef.options as unknown as Record<string, unknown>) },
-          keyshelfName: loaded.config.name
-        },
-        value
-      );
+      await writeSecret(registry, loaded, providerRef, keyPath, opts.env, value);
       console.log(`  secret: ${envVar} -> ${keyPath} (via ${providerRef.name})`);
       imported++;
     }
 
     console.log(`\nImported ${imported} values, skipped ${skipped}`);
   });
-
-function pickProviderRef(
-  record: NormalizedRecord & { kind: "secret" },
-  envName: string | undefined
-): BuiltinProviderRef | undefined {
-  if (
-    envName !== undefined &&
-    record.values !== undefined &&
-    Object.hasOwn(record.values, envName)
-  ) {
-    return record.values[envName];
-  }
-  return record.value;
-}

--- a/packages/cli/src/cli/secret-binding.ts
+++ b/packages/cli/src/cli/secret-binding.ts
@@ -1,0 +1,38 @@
+import type { ProviderRegistry } from "../providers/registry.js";
+import type { BuiltinProviderRef, NormalizedRecord } from "../config/types.js";
+import type { LoadedConfig } from "../config/loader.js";
+
+export function pickProviderRef(
+  record: NormalizedRecord & { kind: "secret" },
+  envName: string | undefined
+): BuiltinProviderRef | undefined {
+  if (
+    envName !== undefined &&
+    record.values !== undefined &&
+    Object.hasOwn(record.values, envName)
+  ) {
+    return record.values[envName];
+  }
+  return record.value;
+}
+
+export async function writeSecret(
+  registry: ProviderRegistry,
+  loaded: LoadedConfig,
+  providerRef: BuiltinProviderRef,
+  keyPath: string,
+  envName: string | undefined,
+  value: string
+): Promise<void> {
+  const provider = registry.get(providerRef.name);
+  await provider.set(
+    {
+      keyPath,
+      envName,
+      rootDir: loaded.rootDir,
+      config: { ...(providerRef.options as unknown as Record<string, unknown>) },
+      keyshelfName: loaded.config.name
+    },
+    value
+  );
+}

--- a/packages/cli/src/cli/set.ts
+++ b/packages/cli/src/cli/set.ts
@@ -2,7 +2,7 @@ import { Command } from "commander";
 import { createInterface } from "node:readline";
 import { loadConfig } from "../config/index.js";
 import { createDefaultRegistry } from "../providers/setup.js";
-import type { BuiltinProviderRef, NormalizedRecord } from "../config/types.js";
+import { pickProviderRef, writeSecret } from "./secret-binding.js";
 
 interface SetOptions {
   env?: string;
@@ -47,36 +47,12 @@ export const setCommand = new Command("set")
 
     const value = await readValue(keyPath, opts.value);
     const registry = createDefaultRegistry();
-    const provider = registry.get(providerRef.name);
 
-    await provider.set(
-      {
-        keyPath,
-        envName: opts.env,
-        rootDir: loaded.rootDir,
-        config: { ...(providerRef.options as unknown as Record<string, unknown>) },
-        keyshelfName: loaded.config.name
-      },
-      value
-    );
+    await writeSecret(registry, loaded, providerRef, keyPath, opts.env, value);
 
     const where = opts.env ? ` for ${opts.env}` : "";
     console.log(`Stored "${keyPath}" via ${providerRef.name} provider${where}`);
   });
-
-function pickProviderRef(
-  record: NormalizedRecord & { kind: "secret" },
-  envName: string | undefined
-): BuiltinProviderRef | undefined {
-  if (
-    envName !== undefined &&
-    record.values !== undefined &&
-    Object.hasOwn(record.values, envName)
-  ) {
-    return record.values[envName];
-  }
-  return record.value;
-}
 
 async function readValue(keyPath: string, explicit: string | undefined): Promise<string> {
   if (explicit !== undefined) return explicit;


### PR DESCRIPTION
## Summary
- Pulls the duplicated `pickProviderRef` (per-env binding lookup) out of `cli/import.ts` and `cli/set.ts` into `cli/secret-binding.ts`.
- Adds a small `writeSecret(registry, loaded, providerRef, keyPath, env, value)` helper so both commands share the `provider.set({ ... })` argument construction.

Addresses the import.ts/set.ts clone family fallow flagged (2 groups, 27 lines). Re-running `npx fallow` after this change drops total clone groups from 15 to 13 and duplicated lines from 419 to 366.

## Test plan
- [x] `npm test` (cli + migrate + action)
- [x] `tsc --noEmit` in `packages/cli`
- [x] `npx fallow` reports fewer duplicates and no new findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)