### PR TITLE
refactor(providers): share path/identity helpers between age and sops

### DIFF
--- a/packages/action/dist/emit-env.mjs
+++ b/packages/action/dist/emit-env.mjs
@@ -9355,14 +9355,6 @@ function compareBytes(a, b) {
 function isCryptoKey3(key) {
   return typeof CryptoKey !== "undefined" && key instanceof CryptoKey;
 }
-
-// ../cli/dist/src/providers/age.js
-function keyPathToFileName(keyPath) {
-  return keyPath.replace(/\//g, "_");
-}
-function secretFilePath(secretsDir, keyPath) {
-  return join(secretsDir, `${keyPathToFileName(keyPath)}.age`);
-}
 function resolvePath(filePath, rootDir) {
   if (filePath.startsWith("~/") || filePath === "~") {
     return join(homedir(), filePath.slice(1));
@@ -9376,20 +9368,27 @@ async function readIdentity(identityFile) {
   const content = await readFile(identityFile, "utf-8");
   return content.trim();
 }
+function requireStringConfig(providerName, ctx, key) {
+  const value = ctx.config[key];
+  if (typeof value !== "string") {
+    throw new Error(`${providerName} provider requires "${key}" config for "${ctx.keyPath}"`);
+  }
+  return value;
+}
+
+// ../cli/dist/src/providers/age.js
+function keyPathToFileName(keyPath) {
+  return keyPath.replace(/\//g, "_");
+}
+function secretFilePath(secretsDir, keyPath) {
+  return join(secretsDir, `${keyPathToFileName(keyPath)}.age`);
+}
 var AgeProvider = class {
   name = "age";
   resolveOptions(ctx) {
-    const identityFile = ctx.config.identityFile;
-    const secretsDir = ctx.config.secretsDir;
-    if (typeof identityFile !== "string") {
-      throw new Error(`age provider requires "identityFile" config for "${ctx.keyPath}"`);
-    }
-    if (typeof secretsDir !== "string") {
-      throw new Error(`age provider requires "secretsDir" config for "${ctx.keyPath}"`);
-    }
     return {
-      identityFile: resolvePath(identityFile, ctx.rootDir),
-      secretsDir: resolvePath(secretsDir, ctx.rootDir)
+      identityFile: resolvePath(requireStringConfig("age", ctx, "identityFile"), ctx.rootDir),
+      secretsDir: resolvePath(requireStringConfig("age", ctx, "secretsDir"), ctx.rootDir)
     };
   }
   async resolve(ctx) {
@@ -9423,19 +9422,6 @@ var AgeProvider = class {
     await writeFile(filePath, ciphertext);
   }
 };
-function resolvePath2(filePath, rootDir) {
-  if (filePath.startsWith("~/") || filePath === "~") {
-    return join(homedir(), filePath.slice(1));
-  }
-  if (isAbsolute(filePath)) {
-    return filePath;
-  }
-  return resolve(rootDir, filePath);
-}
-async function readIdentity2(identityFile) {
-  const content = await readFile(identityFile, "utf-8");
-  return content.trim();
-}
 function generateDataKey() {
   return randomBytes$1(32);
 }
@@ -9496,23 +9482,15 @@ async function writeSecretsFile(path, file) {
 var SopsProvider = class {
   name = "sops";
   resolveOptions(ctx) {
-    const identityFile = ctx.config.identityFile;
-    const secretsFile = ctx.config.secretsFile;
-    if (typeof identityFile !== "string") {
-      throw new Error(`sops provider requires "identityFile" config for "${ctx.keyPath}"`);
-    }
-    if (typeof secretsFile !== "string") {
-      throw new Error(`sops provider requires "secretsFile" config for "${ctx.keyPath}"`);
-    }
     return {
-      identityFile: resolvePath2(identityFile, ctx.rootDir),
-      secretsFile: resolvePath2(secretsFile, ctx.rootDir)
+      identityFile: resolvePath(requireStringConfig("sops", ctx, "identityFile"), ctx.rootDir),
+      secretsFile: resolvePath(requireStringConfig("sops", ctx, "secretsFile"), ctx.rootDir)
     };
   }
   async resolve(ctx) {
     const opts2 = this.resolveOptions(ctx);
     const file = await readSecretsFile(opts2.secretsFile);
-    const identity = await readIdentity2(opts2.identityFile);
+    const identity = await readIdentity(opts2.identityFile);
     const dataKey = await decryptDataKey(file.sops.dataKey, identity);
     verifyMac(dataKey, file);
     const entry = file.entries[ctx.keyPath];
@@ -9532,7 +9510,7 @@ var SopsProvider = class {
   }
   async set(ctx, value) {
     const opts2 = this.resolveOptions(ctx);
-    const identity = await readIdentity2(opts2.identityFile);
+    const identity = await readIdentity(opts2.identityFile);
     const recipient = await identityToRecipient(identity);
     let file;
     let dataKey;

--- a/packages/cli/src/providers/_paths.ts
+++ b/packages/cli/src/providers/_paths.ts
@@ -1,0 +1,31 @@
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { isAbsolute, join, resolve } from "node:path";
+import type { ProviderContext } from "./types.js";
+
+export function resolvePath(filePath: string, rootDir: string): string {
+  if (filePath.startsWith("~/") || filePath === "~") {
+    return join(homedir(), filePath.slice(1));
+  }
+  if (isAbsolute(filePath)) {
+    return filePath;
+  }
+  return resolve(rootDir, filePath);
+}
+
+export async function readIdentity(identityFile: string): Promise<string> {
+  const content = await readFile(identityFile, "utf-8");
+  return content.trim();
+}
+
+export function requireStringConfig(
+  providerName: string,
+  ctx: ProviderContext,
+  key: string
+): string {
+  const value = ctx.config[key];
+  if (typeof value !== "string") {
+    throw new Error(`${providerName} provider requires "${key}" config for "${ctx.keyPath}"`);
+  }
+  return value;
+}

--- a/packages/cli/src/providers/age.ts
+++ b/packages/cli/src/providers/age.ts
@@ -1,8 +1,8 @@
 import { readFile, writeFile, mkdir } from "node:fs/promises";
-import { homedir } from "node:os";
-import { dirname, join, resolve, isAbsolute } from "node:path";
+import { dirname, join } from "node:path";
 import { Encrypter, Decrypter, generateIdentity, identityToRecipient } from "age-encryption";
 import type { Provider, ProviderContext } from "./types.js";
+import { readIdentity, requireStringConfig, resolvePath } from "./_paths.js";
 
 export interface AgeProviderOptions {
   identityFile: string;
@@ -17,38 +17,13 @@ function secretFilePath(secretsDir: string, keyPath: string): string {
   return join(secretsDir, `${keyPathToFileName(keyPath)}.age`);
 }
 
-function resolvePath(filePath: string, rootDir: string): string {
-  if (filePath.startsWith("~/") || filePath === "~") {
-    return join(homedir(), filePath.slice(1));
-  }
-  if (isAbsolute(filePath)) {
-    return filePath;
-  }
-  return resolve(rootDir, filePath);
-}
-
-async function readIdentity(identityFile: string): Promise<string> {
-  const content = await readFile(identityFile, "utf-8");
-  return content.trim();
-}
-
 export class AgeProvider implements Provider {
   name = "age";
 
   private resolveOptions(ctx: ProviderContext): AgeProviderOptions {
-    const identityFile = ctx.config.identityFile;
-    const secretsDir = ctx.config.secretsDir;
-
-    if (typeof identityFile !== "string") {
-      throw new Error(`age provider requires "identityFile" config for "${ctx.keyPath}"`);
-    }
-    if (typeof secretsDir !== "string") {
-      throw new Error(`age provider requires "secretsDir" config for "${ctx.keyPath}"`);
-    }
-
     return {
-      identityFile: resolvePath(identityFile, ctx.rootDir),
-      secretsDir: resolvePath(secretsDir, ctx.rootDir)
+      identityFile: resolvePath(requireStringConfig("age", ctx, "identityFile"), ctx.rootDir),
+      secretsDir: resolvePath(requireStringConfig("age", ctx, "secretsDir"), ctx.rootDir)
     };
   }
 

--- a/packages/cli/src/providers/sops.ts
+++ b/packages/cli/src/providers/sops.ts
@@ -1,9 +1,9 @@
 import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { randomBytes, createCipheriv, createDecipheriv, createHmac } from "node:crypto";
-import { homedir } from "node:os";
-import { dirname, join, resolve, isAbsolute } from "node:path";
+import { dirname } from "node:path";
 import { Encrypter, Decrypter, identityToRecipient } from "age-encryption";
 import type { Provider, ProviderContext } from "./types.js";
+import { readIdentity, requireStringConfig, resolvePath } from "./_paths.js";
 
 export interface SopsProviderOptions {
   identityFile: string;
@@ -22,21 +22,6 @@ interface SecretsFile {
     dataKey: string;
     mac: string;
   };
-}
-
-function resolvePath(filePath: string, rootDir: string): string {
-  if (filePath.startsWith("~/") || filePath === "~") {
-    return join(homedir(), filePath.slice(1));
-  }
-  if (isAbsolute(filePath)) {
-    return filePath;
-  }
-  return resolve(rootDir, filePath);
-}
-
-async function readIdentity(identityFile: string): Promise<string> {
-  const content = await readFile(identityFile, "utf-8");
-  return content.trim();
 }
 
 function generateDataKey(): Buffer {
@@ -110,19 +95,9 @@ export class SopsProvider implements Provider {
   name = "sops";
 
   private resolveOptions(ctx: ProviderContext): SopsProviderOptions {
-    const identityFile = ctx.config.identityFile;
-    const secretsFile = ctx.config.secretsFile;
-
-    if (typeof identityFile !== "string") {
-      throw new Error(`sops provider requires "identityFile" config for "${ctx.keyPath}"`);
-    }
-    if (typeof secretsFile !== "string") {
-      throw new Error(`sops provider requires "secretsFile" config for "${ctx.keyPath}"`);
-    }
-
     return {
-      identityFile: resolvePath(identityFile, ctx.rootDir),
-      secretsFile: resolvePath(secretsFile, ctx.rootDir)
+      identityFile: resolvePath(requireStringConfig("sops", ctx, "identityFile"), ctx.rootDir),
+      secretsFile: resolvePath(requireStringConfig("sops", ctx, "secretsFile"), ctx.rootDir)
     };
   }
 


### PR DESCRIPTION
## Summary
- Pulls the duplicated `resolvePath` (handles `~/`, absolute, relative-to-rootDir) and `readIdentity` helpers out of `providers/age.ts` and `providers/sops.ts` into a shared `providers/_paths.ts` module.
- Adds a small `requireStringConfig(providerName, ctx, key)` helper so both providers' `resolveOptions` collapses to a one-liner per config key.

Addresses the age.ts/sops.ts clone family fallow flagged (2 groups, 27 lines). Re-running `npx fallow` after this change drops total clone groups from 15 to 14.

## Test plan
- [x] `npm test` (cli + migrate + action)
- [x] `tsc --noEmit` in `packages/cli`
- [x] `npx fallow` reports the family is gone and no new findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)