### PR TITLE
test(e2e): share fixture setup helpers across set/import/ls/run

### DIFF
--- a/packages/cli/test/e2e/helpers/fixture.ts
+++ b/packages/cli/test/e2e/helpers/fixture.ts
@@ -1,0 +1,34 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { generateIdentity } from "../../../src/providers/age.js";
+
+export interface AgeFixturePaths {
+  identityFile: string;
+  secretsDir: string;
+}
+
+export async function setupAgeFixtureDir(root: string): Promise<AgeFixturePaths> {
+  const identityFile = join(root, "key.txt");
+  const secretsDir = join(root, ".keyshelf", "secrets");
+  await writeFile(identityFile, await generateIdentity());
+  await mkdir(secretsDir, { recursive: true });
+  return { identityFile, secretsDir };
+}
+
+export async function writeKeyshelfConfig(root: string, body: string[]): Promise<void> {
+  await writeFile(
+    join(root, "keyshelf.config.ts"),
+    [
+      `import { defineConfig, config, secret, age } from "keyshelf/config";`,
+      ``,
+      `export default defineConfig({`,
+      ...body.map((line) => `  ${line}`),
+      `});`,
+      ``
+    ].join("\n")
+  );
+}
+
+export async function writeEnvKeyshelf(root: string, mappings: string[]): Promise<void> {
+  await writeFile(join(root, ".env.keyshelf"), mappings.join("\n"));
+}

--- a/packages/cli/test/e2e/import.test.ts
+++ b/packages/cli/test/e2e/import.test.ts
@@ -1,45 +1,34 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { mkdtemp } from "node:fs/promises";
 import { writeFileSync as fsWriteFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { execFileSync } from "node:child_process";
-import { generateIdentity } from "../../src/providers/age.js";
 import { CLI, TSX } from "./helpers/cli.js";
+import { setupAgeFixtureDir, writeEnvKeyshelf, writeKeyshelfConfig } from "./helpers/fixture.js";
 
 function writeFileSync(path: string, lines: string[]): void {
   fsWriteFileSync(path, lines.join("\n") + "\n");
 }
 
 async function writeFixture(root: string) {
-  const identityFile = join(root, "key.txt");
-  const secretsDir = join(root, ".keyshelf", "secrets");
-  await writeFile(identityFile, await generateIdentity());
-  await mkdir(secretsDir, { recursive: true });
-
-  await writeFile(
-    join(root, "keyshelf.config.ts"),
-    [
-      `import { defineConfig, config, secret, age } from "keyshelf/config";`,
-      ``,
-      `export default defineConfig({`,
-      `  name: "demo",`,
-      `  envs: ["dev"],`,
-      `  keys: {`,
-      `    db: {`,
-      `      host: config({ default: "localhost" }),`,
-      `      password: secret({ value: age({ identityFile: ${JSON.stringify(identityFile)}, secretsDir: ${JSON.stringify(secretsDir)} }) }),`,
-      `      apiKey: secret({ value: age({ identityFile: ${JSON.stringify(identityFile)}, secretsDir: ${JSON.stringify(secretsDir)} }) }),`,
-      `    },`,
-      `  },`,
-      `});`,
-      ``
-    ].join("\n")
-  );
-  await writeFile(
-    join(root, ".env.keyshelf"),
-    ["DB_HOST=db/host", "DB_PASSWORD=db/password", "DB_API_KEY=db/apiKey"].join("\n")
-  );
+  const { identityFile, secretsDir } = await setupAgeFixtureDir(root);
+  await writeKeyshelfConfig(root, [
+    `name: "demo",`,
+    `envs: ["dev"],`,
+    `keys: {`,
+    `  db: {`,
+    `    host: config({ default: "localhost" }),`,
+    `    password: secret({ value: age({ identityFile: ${JSON.stringify(identityFile)}, secretsDir: ${JSON.stringify(secretsDir)} }) }),`,
+    `    apiKey: secret({ value: age({ identityFile: ${JSON.stringify(identityFile)}, secretsDir: ${JSON.stringify(secretsDir)} }) }),`,
+    `  },`,
+    `},`
+  ]);
+  await writeEnvKeyshelf(root, [
+    "DB_HOST=db/host",
+    "DB_PASSWORD=db/password",
+    "DB_API_KEY=db/apiKey"
+  ]);
 }
 
 describe("keyshelf-next import", () => {
@@ -97,36 +86,22 @@ describe("keyshelf-next import", () => {
 
   it("skips keys outside the --group filter", async () => {
     const groupedRoot = await mkdtemp(join(tmpdir(), "keyshelf-import-group-"));
-    const identityFile = join(groupedRoot, "key.txt");
-    const secretsDir = join(groupedRoot, ".keyshelf", "secrets");
-    await writeFile(identityFile, await generateIdentity());
-    await mkdir(secretsDir, { recursive: true });
+    const { identityFile, secretsDir } = await setupAgeFixtureDir(groupedRoot);
 
-    await writeFile(
-      join(groupedRoot, "keyshelf.config.ts"),
-      [
-        `import { defineConfig, secret, age } from "keyshelf/config";`,
-        ``,
-        `export default defineConfig({`,
-        `  name: "demo",`,
-        `  envs: ["dev"],`,
-        `  groups: ["app", "ci"],`,
-        `  keys: {`,
-        `    db: {`,
-        `      password: secret({ group: "app", value: age({ identityFile: ${JSON.stringify(identityFile)}, secretsDir: ${JSON.stringify(secretsDir)} }) }),`,
-        `    },`,
-        `    github: {`,
-        `      token: secret({ group: "ci", value: age({ identityFile: ${JSON.stringify(identityFile)}, secretsDir: ${JSON.stringify(secretsDir)} }) }),`,
-        `    },`,
-        `  },`,
-        `});`,
-        ``
-      ].join("\n")
-    );
-    await writeFile(
-      join(groupedRoot, ".env.keyshelf"),
-      ["DB_PASSWORD=db/password", "GITHUB_TOKEN=github/token"].join("\n")
-    );
+    await writeKeyshelfConfig(groupedRoot, [
+      `name: "demo",`,
+      `envs: ["dev"],`,
+      `groups: ["app", "ci"],`,
+      `keys: {`,
+      `  db: {`,
+      `    password: secret({ group: "app", value: age({ identityFile: ${JSON.stringify(identityFile)}, secretsDir: ${JSON.stringify(secretsDir)} }) }),`,
+      `  },`,
+      `  github: {`,
+      `    token: secret({ group: "ci", value: age({ identityFile: ${JSON.stringify(identityFile)}, secretsDir: ${JSON.stringify(secretsDir)} }) }),`,
+      `  },`,
+      `},`
+    ]);
+    await writeEnvKeyshelf(groupedRoot, ["DB_PASSWORD=db/password", "GITHUB_TOKEN=github/token"]);
 
     const envFile = join(groupedRoot, ".env.values");
     writeFileSync(envFile, ["DB_PASSWORD=imported-pw", "GITHUB_TOKEN=imported-tok"]);

--- a/packages/cli/test/e2e/ls.test.ts
+++ b/packages/cli/test/e2e/ls.test.ts
@@ -1,43 +1,28 @@
 import { describe, it, expect, beforeAll, beforeEach } from "vitest";
-import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { execFileSync } from "node:child_process";
-import { generateIdentity } from "../../src/providers/age.js";
 import { CLI, TSX } from "./helpers/cli.js";
+import { setupAgeFixtureDir, writeEnvKeyshelf, writeKeyshelfConfig } from "./helpers/fixture.js";
 
 async function writeAgeFixture(root: string) {
-  const identityFile = join(root, "key.txt");
-  const secretsDir = join(root, ".keyshelf", "secrets");
-  await writeFile(identityFile, await generateIdentity());
-  await mkdir(secretsDir, { recursive: true });
-
-  await writeFile(
-    join(root, "keyshelf.config.ts"),
-    [
-      `import { defineConfig, config, secret, age } from "keyshelf/config";`,
-      ``,
-      `export default defineConfig({`,
-      `  name: "demo",`,
-      `  envs: ["dev", "production"],`,
-      `  groups: ["app", "ci"],`,
-      `  keys: {`,
-      `    db: {`,
-      `      host: config({ group: "app", default: "localhost", values: { production: "prod-db" } }),`,
-      `      password: secret({ group: "app", value: age({ identityFile: ${JSON.stringify(identityFile)}, secretsDir: ${JSON.stringify(secretsDir)} }) }),`,
-      `    },`,
-      `    ci: {`,
-      `      token: secret({ group: "ci", value: age({ identityFile: ${JSON.stringify(identityFile)}, secretsDir: ${JSON.stringify(secretsDir)} }) }),`,
-      `    },`,
-      `  },`,
-      `});`,
-      ``
-    ].join("\n")
-  );
-  await writeFile(
-    join(root, ".env.keyshelf"),
-    ["DB_HOST=db/host", "DB_PASSWORD=db/password", "CI_TOKEN=ci/token"].join("\n")
-  );
+  const { identityFile, secretsDir } = await setupAgeFixtureDir(root);
+  await writeKeyshelfConfig(root, [
+    `name: "demo",`,
+    `envs: ["dev", "production"],`,
+    `groups: ["app", "ci"],`,
+    `keys: {`,
+    `  db: {`,
+    `    host: config({ group: "app", default: "localhost", values: { production: "prod-db" } }),`,
+    `    password: secret({ group: "app", value: age({ identityFile: ${JSON.stringify(identityFile)}, secretsDir: ${JSON.stringify(secretsDir)} }) }),`,
+    `  },`,
+    `  ci: {`,
+    `    token: secret({ group: "ci", value: age({ identityFile: ${JSON.stringify(identityFile)}, secretsDir: ${JSON.stringify(secretsDir)} }) }),`,
+    `  },`,
+    `},`
+  ]);
+  await writeEnvKeyshelf(root, ["DB_HOST=db/host", "DB_PASSWORD=db/password", "CI_TOKEN=ci/token"]);
 }
 
 describe("keyshelf-next ls", () => {

--- a/packages/cli/test/e2e/run.test.ts
+++ b/packages/cli/test/e2e/run.test.ts
@@ -1,67 +1,47 @@
 import { describe, it, expect, beforeEach, beforeAll } from "vitest";
-import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { execFileSync, spawnSync } from "node:child_process";
-import { generateIdentity } from "../../src/providers/age.js";
 import { CLI, TSX } from "./helpers/cli.js";
+import {
+  setupAgeFixtureDir,
+  writeEnvKeyshelf,
+  writeKeyshelfConfig,
+  type AgeFixturePaths
+} from "./helpers/fixture.js";
 
 async function writeBaseFixture(root: string) {
-  await writeFile(
-    join(root, "keyshelf.config.ts"),
-    [
-      `import { defineConfig, config } from "keyshelf/config";`,
-      ``,
-      `export default defineConfig({`,
-      `  name: "demo",`,
-      `  envs: ["dev", "production"],`,
-      `  keys: {`,
-      `    db: {`,
-      `      host: config({ default: "localhost", values: { production: "prod-db" } }),`,
-      `      port: 5432,`,
-      `    },`,
-      `  },`,
-      `});`,
-      ``
-    ].join("\n")
-  );
-  await writeFile(join(root, ".env.keyshelf"), ["DB_HOST=db/host", "DB_PORT=db/port"].join("\n"));
+  await writeKeyshelfConfig(root, [
+    `name: "demo",`,
+    `envs: ["dev", "production"],`,
+    `keys: {`,
+    `  db: {`,
+    `    host: config({ default: "localhost", values: { production: "prod-db" } }),`,
+    `    port: 5432,`,
+    `  },`,
+    `},`
+  ]);
+  await writeEnvKeyshelf(root, ["DB_HOST=db/host", "DB_PORT=db/port"]);
 }
 
-async function writeGroupFixture(root: string) {
-  const identityFile = join(root, "key.txt");
-  const secretsDir = join(root, ".keyshelf", "secrets");
-  await writeFile(identityFile, await generateIdentity());
-  await mkdir(secretsDir, { recursive: true });
-
-  await writeFile(
-    join(root, "keyshelf.config.ts"),
-    [
-      `import { defineConfig, config, secret, age } from "keyshelf/config";`,
-      ``,
-      `export default defineConfig({`,
-      `  name: "demo",`,
-      `  envs: ["dev"],`,
-      `  groups: ["app", "ci"],`,
-      `  keys: {`,
-      `    app: {`,
-      `      host: config({ group: "app", value: "localhost" }),`,
-      `    },`,
-      `    ci: {`,
-      `      token: secret({ group: "ci", value: age({ identityFile: ${JSON.stringify(identityFile)}, secretsDir: ${JSON.stringify(secretsDir)} }) }),`,
-      `    },`,
-      `  },`,
-      `});`,
-      ``
-    ].join("\n")
-  );
-
-  await writeFile(
-    join(root, ".env.keyshelf"),
-    ["APP_HOST=app/host", "CI_TOKEN=ci/token"].join("\n")
-  );
-
-  return { identityFile, secretsDir };
+async function writeGroupFixture(root: string): Promise<AgeFixturePaths> {
+  const paths = await setupAgeFixtureDir(root);
+  await writeKeyshelfConfig(root, [
+    `name: "demo",`,
+    `envs: ["dev"],`,
+    `groups: ["app", "ci"],`,
+    `keys: {`,
+    `  app: {`,
+    `    host: config({ group: "app", value: "localhost" }),`,
+    `  },`,
+    `  ci: {`,
+    `    token: secret({ group: "ci", value: age({ identityFile: ${JSON.stringify(paths.identityFile)}, secretsDir: ${JSON.stringify(paths.secretsDir)} }) }),`,
+    `  },`,
+    `},`
+  ]);
+  await writeEnvKeyshelf(root, ["APP_HOST=app/host", "CI_TOKEN=ci/token"]);
+  return paths;
 }
 
 describe("keyshelf-next run", () => {

--- a/packages/cli/test/e2e/set.test.ts
+++ b/packages/cli/test/e2e/set.test.ts
@@ -1,39 +1,24 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { execFileSync } from "node:child_process";
-import { generateIdentity } from "../../src/providers/age.js";
 import { CLI, TSX } from "./helpers/cli.js";
+import { setupAgeFixtureDir, writeEnvKeyshelf, writeKeyshelfConfig } from "./helpers/fixture.js";
 
 async function writeFixture(root: string) {
-  const identityFile = join(root, "key.txt");
-  const secretsDir = join(root, ".keyshelf", "secrets");
-  await writeFile(identityFile, await generateIdentity());
-  await mkdir(secretsDir, { recursive: true });
-
-  await writeFile(
-    join(root, "keyshelf.config.ts"),
-    [
-      `import { defineConfig, config, secret, age } from "keyshelf/config";`,
-      ``,
-      `export default defineConfig({`,
-      `  name: "demo",`,
-      `  envs: ["dev"],`,
-      `  keys: {`,
-      `    db: {`,
-      `      host: config({ default: "localhost" }),`,
-      `      password: secret({ value: age({ identityFile: ${JSON.stringify(identityFile)}, secretsDir: ${JSON.stringify(secretsDir)} }) }),`,
-      `    },`,
-      `  },`,
-      `});`,
-      ``
-    ].join("\n")
-  );
-  await writeFile(
-    join(root, ".env.keyshelf"),
-    ["DB_HOST=db/host", "DB_PASSWORD=db/password"].join("\n")
-  );
+  const { identityFile, secretsDir } = await setupAgeFixtureDir(root);
+  await writeKeyshelfConfig(root, [
+    `name: "demo",`,
+    `envs: ["dev"],`,
+    `keys: {`,
+    `  db: {`,
+    `    host: config({ default: "localhost" }),`,
+    `    password: secret({ value: age({ identityFile: ${JSON.stringify(identityFile)}, secretsDir: ${JSON.stringify(secretsDir)} }) }),`,
+    `  },`,
+    `},`
+  ]);
+  await writeEnvKeyshelf(root, ["DB_HOST=db/host", "DB_PASSWORD=db/password"]);
 }
 
 describe("keyshelf-next set", () => {


### PR DESCRIPTION
## Summary
- Extracts `setupAgeFixtureDir`, `writeKeyshelfConfig`, and `writeEnvKeyshelf` into `test/e2e/helpers/fixture.ts`.
- Refactors `set.test.ts`, `import.test.ts`, `ls.test.ts`, and `run.test.ts` to use the helpers — each per-suite fixture function now only describes the config body that actually differs.

Addresses the clones fallow flagged across these four e2e files (three groups, ~58 lines). Re-running `npx fallow` after this change drops total clone groups from 15 to 13 and duplicated lines from 419 to 332.

## Test plan
- [x] `npm test` in `packages/cli` (128/128 pass)
- [x] `npx fallow` reports the e2e clones are gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)