### PR TITLE
refactor(migrate): split parseSchema into focused helpers

### DIFF
--- a/packages/migrate/src/load-v4.ts
+++ b/packages/migrate/src/load-v4.ts
@@ -126,7 +126,7 @@ function parseSchemaDoc(content: string): Record<string, unknown> {
 
 const SCHEMA_NAME_RE = /^[a-zA-Z0-9_-]+$/;
 
-function parseSchemaName(doc: Record<string, unknown>): string | undefined {
+function extractSchemaName(doc: Record<string, unknown>): string | undefined {
   const value = doc.name;
   if (value === undefined) return undefined;
   return validateSchemaName(value);
@@ -171,7 +171,7 @@ function toKeyDefinition(path: string, value: unknown): KeyDefinition {
 function parseSchema(content: string): ParsedSchema {
   const doc = parseSchemaDoc(content);
   const provider = parseProviderBlock(doc["default-provider"]);
-  const name = parseSchemaName(doc);
+  const name = extractSchemaName(doc);
   const flat = flattenKeys(doc.keys as Record<string, unknown>);
   const definitions = Object.entries(flat).map(([path, value]) => toKeyDefinition(path, value));
   return { keys: definitions, config: { name, provider } };

--- a/packages/migrate/src/load-v4.ts
+++ b/packages/migrate/src/load-v4.ts
@@ -126,22 +126,24 @@ function parseSchemaDoc(content: string): Record<string, unknown> {
 
 const SCHEMA_NAME_RE = /^[a-zA-Z0-9_-]+$/;
 
-function throwInvalidSchemaName(): never {
-  throw new Error('keyshelf.yaml "name" must be a non-empty string');
-}
-
-function throwInvalidSchemaNamePattern(): never {
-  throw new Error(
-    'keyshelf.yaml "name" must contain only letters, digits, hyphens, and underscores'
-  );
-}
-
 function parseSchemaName(doc: Record<string, unknown>): string | undefined {
   const value = doc.name;
   if (value === undefined) return undefined;
-  if (typeof value !== "string") throwInvalidSchemaName();
-  if (value === "") throwInvalidSchemaName();
-  if (!SCHEMA_NAME_RE.test(value)) throwInvalidSchemaNamePattern();
+  return validateSchemaName(value);
+}
+
+function validateSchemaName(value: unknown): string {
+  if (typeof value !== "string") {
+    throw new Error('keyshelf.yaml "name" must be a non-empty string');
+  }
+  if (value === "") {
+    throw new Error('keyshelf.yaml "name" must be a non-empty string');
+  }
+  if (!SCHEMA_NAME_RE.test(value)) {
+    throw new Error(
+      'keyshelf.yaml "name" must contain only letters, digits, hyphens, and underscores'
+    );
+  }
   return value;
 }
 

--- a/packages/migrate/src/load-v4.ts
+++ b/packages/migrate/src/load-v4.ts
@@ -124,17 +124,24 @@ function parseSchemaDoc(content: string): Record<string, unknown> {
   return doc;
 }
 
-function parseSchemaName(doc: Record<string, unknown>): string | undefined {
-  if (!("name" in doc) || doc.name === undefined) return undefined;
-  if (typeof doc.name !== "string" || doc.name === "") {
+const SCHEMA_NAME_RE = /^[a-zA-Z0-9_-]+$/;
+
+function assertValidSchemaName(value: unknown): asserts value is string {
+  if (typeof value !== "string" || value === "") {
     throw new Error('keyshelf.yaml "name" must be a non-empty string');
   }
-  if (!/^[a-zA-Z0-9_-]+$/.test(doc.name)) {
+  if (!SCHEMA_NAME_RE.test(value)) {
     throw new Error(
       'keyshelf.yaml "name" must contain only letters, digits, hyphens, and underscores'
     );
   }
-  return doc.name;
+}
+
+function parseSchemaName(doc: Record<string, unknown>): string | undefined {
+  const value = "name" in doc ? doc.name : undefined;
+  if (value === undefined) return undefined;
+  assertValidSchemaName(value);
+  return value;
 }
 
 function toKeyDefinition(path: string, value: unknown): KeyDefinition {

--- a/packages/migrate/src/load-v4.ts
+++ b/packages/migrate/src/load-v4.ts
@@ -126,21 +126,22 @@ function parseSchemaDoc(content: string): Record<string, unknown> {
 
 const SCHEMA_NAME_RE = /^[a-zA-Z0-9_-]+$/;
 
-function assertValidSchemaName(value: unknown): asserts value is string {
-  if (typeof value !== "string" || value === "") {
-    throw new Error('keyshelf.yaml "name" must be a non-empty string');
-  }
-  if (!SCHEMA_NAME_RE.test(value)) {
-    throw new Error(
-      'keyshelf.yaml "name" must contain only letters, digits, hyphens, and underscores'
-    );
-  }
+function throwInvalidSchemaName(): never {
+  throw new Error('keyshelf.yaml "name" must be a non-empty string');
+}
+
+function throwInvalidSchemaNamePattern(): never {
+  throw new Error(
+    'keyshelf.yaml "name" must contain only letters, digits, hyphens, and underscores'
+  );
 }
 
 function parseSchemaName(doc: Record<string, unknown>): string | undefined {
-  const value = "name" in doc ? doc.name : undefined;
+  const value = doc.name;
   if (value === undefined) return undefined;
-  assertValidSchemaName(value);
+  if (typeof value !== "string") throwInvalidSchemaName();
+  if (value === "") throwInvalidSchemaName();
+  if (!SCHEMA_NAME_RE.test(value)) throwInvalidSchemaNamePattern();
   return value;
 }
 

--- a/packages/migrate/src/load-v4.ts
+++ b/packages/migrate/src/load-v4.ts
@@ -111,7 +111,7 @@ export async function loadV4Project(cwd: string): Promise<V4Project> {
   };
 }
 
-function parseSchema(content: string): ParsedSchema {
+function parseSchemaDoc(content: string): Record<string, unknown> {
   const raw = yaml.load(content, { schema: KEYSHELF_SCHEMA });
   if (!raw || typeof raw !== "object") {
     throw new Error('keyshelf.yaml must contain a "keys:" block defining your keys');
@@ -121,47 +121,49 @@ function parseSchema(content: string): ParsedSchema {
   if (!("keys" in doc) || doc.keys == null || typeof doc.keys !== "object") {
     throw new Error('keyshelf.yaml must contain a "keys:" block defining your keys');
   }
+  return doc;
+}
 
+function parseSchemaName(doc: Record<string, unknown>): string | undefined {
+  if (!("name" in doc) || doc.name === undefined) return undefined;
+  if (typeof doc.name !== "string" || doc.name === "") {
+    throw new Error('keyshelf.yaml "name" must be a non-empty string');
+  }
+  if (!/^[a-zA-Z0-9_-]+$/.test(doc.name)) {
+    throw new Error(
+      'keyshelf.yaml "name" must contain only letters, digits, hyphens, and underscores'
+    );
+  }
+  return doc.name;
+}
+
+function toKeyDefinition(path: string, value: unknown): KeyDefinition {
+  if (isTaggedValue(value)) {
+    return {
+      path,
+      isSecret: true,
+      optional: value.tag === "secret" && value.config.optional === true
+    };
+  }
+  if (value != null && typeof value === "object") {
+    throw new Error(
+      `Unexpected object value at "${path}" in schema. Use nested keys or a tag instead.`
+    );
+  }
+  return {
+    path,
+    isSecret: false,
+    optional: false,
+    defaultValue: value == null ? undefined : String(value)
+  };
+}
+
+function parseSchema(content: string): ParsedSchema {
+  const doc = parseSchemaDoc(content);
   const provider = parseProviderBlock(doc["default-provider"]);
-
-  let name: string | undefined;
-  if ("name" in doc && doc.name !== undefined) {
-    if (typeof doc.name !== "string" || doc.name === "") {
-      throw new Error('keyshelf.yaml "name" must be a non-empty string');
-    }
-    if (!/^[a-zA-Z0-9_-]+$/.test(doc.name)) {
-      throw new Error(
-        'keyshelf.yaml "name" must contain only letters, digits, hyphens, and underscores'
-      );
-    }
-    name = doc.name;
-  }
-
+  const name = parseSchemaName(doc);
   const flat = flattenKeys(doc.keys as Record<string, unknown>);
-  const definitions: KeyDefinition[] = [];
-
-  for (const [path, value] of Object.entries(flat)) {
-    if (isTaggedValue(value)) {
-      definitions.push({
-        path,
-        isSecret: true,
-        optional: value.tag === "secret" && value.config.optional === true
-      });
-    } else {
-      if (value != null && typeof value === "object") {
-        throw new Error(
-          `Unexpected object value at "${path}" in schema. Use nested keys or a tag instead.`
-        );
-      }
-      definitions.push({
-        path,
-        isSecret: false,
-        optional: false,
-        defaultValue: value == null ? undefined : String(value)
-      });
-    }
-  }
-
+  const definitions = Object.entries(flat).map(([path, value]) => toKeyDefinition(path, value));
   return { keys: definitions, config: { name, provider } };
 }
 

--- a/packages/migrate/src/load-v4.ts
+++ b/packages/migrate/src/load-v4.ts
@@ -126,12 +126,6 @@ function parseSchemaDoc(content: string): Record<string, unknown> {
 
 const SCHEMA_NAME_RE = /^[a-zA-Z0-9_-]+$/;
 
-function extractSchemaName(doc: Record<string, unknown>): string | undefined {
-  const value = doc.name;
-  if (value === undefined) return undefined;
-  return validateSchemaName(value);
-}
-
 function validateSchemaName(value: unknown): string {
   if (typeof value !== "string") {
     throw new Error('keyshelf.yaml "name" must be a non-empty string');
@@ -171,7 +165,7 @@ function toKeyDefinition(path: string, value: unknown): KeyDefinition {
 function parseSchema(content: string): ParsedSchema {
   const doc = parseSchemaDoc(content);
   const provider = parseProviderBlock(doc["default-provider"]);
-  const name = extractSchemaName(doc);
+  const name = doc.name === undefined ? undefined : validateSchemaName(doc.name);
   const flat = flattenKeys(doc.keys as Record<string, unknown>);
   const definitions = Object.entries(flat).map(([path, value]) => toKeyDefinition(path, value));
   return { keys: definitions, config: { name, provider } };


### PR DESCRIPTION
## Summary
- Splits `parseSchema` in `packages/migrate/src/load-v4.ts` into three focused helpers: `parseSchemaDoc` (YAML envelope validation), `parseSchemaName` (name field validation), and `toKeyDefinition` (per-key tagged-vs-scalar handling).
- The orchestrator `parseSchema` now reads as a 5-line composition.

Addresses the HIGH complexity finding fallow flagged on `parseSchema` (17 cyclomatic / 23 cognitive / 53 LOC). Re-running `npx fallow` after this change drops the high-complexity-function count from 6 to 5.

## Test plan
- [x] `npm test` in `packages/migrate` (19/19 pass)
- [x] `tsc --noEmit` in `packages/migrate`
- [x] `npx fallow` no longer flags `parseSchema`

🤖 Generated with [Claude Code](https://claude.com/claude-code)