### PR TITLE
test(integration): share gcp client mock factory

### DIFF
--- a/packages/cli/test/integration/providers.test.ts
+++ b/packages/cli/test/integration/providers.test.ts
@@ -18,6 +18,19 @@ async function ageFixture() {
   return { dir, identityFile, secretsDir };
 }
 
+function gcpClientMock(secretValue: string) {
+  const accessSecretVersion = vi
+    .fn()
+    .mockResolvedValue([{ payload: { data: Buffer.from(secretValue) } }]);
+  const client = {
+    accessSecretVersion,
+    getSecret: vi.fn(),
+    createSecret: vi.fn(),
+    addSecretVersion: vi.fn()
+  };
+  return { client: client as unknown as SecretManagerServiceClient, accessSecretVersion };
+}
+
 describe("resolver → providers", () => {
   it("resolves an age secret end-to-end through the resolver", async () => {
     const { dir, identityFile, secretsDir } = await ageFixture();
@@ -60,18 +73,10 @@ describe("resolver → providers", () => {
   });
 
   it("uses keyshelf name + env in the gcp secret id", async () => {
-    const accessSecretVersion = vi
-      .fn()
-      .mockResolvedValue([{ payload: { data: Buffer.from("dbpass") } }]);
-    const client = {
-      accessSecretVersion,
-      getSecret: vi.fn(),
-      createSecret: vi.fn(),
-      addSecretVersion: vi.fn()
-    };
+    const { client, accessSecretVersion } = gcpClientMock("dbpass");
 
     const registry = new ProviderRegistry();
-    registry.register(new GcpSmProvider(client as unknown as SecretManagerServiceClient));
+    registry.register(new GcpSmProvider(client));
 
     const normalized = normalizeConfig(
       defineConfig({
@@ -101,18 +106,10 @@ describe("resolver → providers", () => {
   });
 
   it("omits the env segment for envless gcp secrets", async () => {
-    const accessSecretVersion = vi
-      .fn()
-      .mockResolvedValue([{ payload: { data: Buffer.from("ghp_xxx") } }]);
-    const client = {
-      accessSecretVersion,
-      getSecret: vi.fn(),
-      createSecret: vi.fn(),
-      addSecretVersion: vi.fn()
-    };
+    const { client, accessSecretVersion } = gcpClientMock("ghp_xxx");
 
     const registry = new ProviderRegistry();
-    registry.register(new GcpSmProvider(client as unknown as SecretManagerServiceClient));
+    registry.register(new GcpSmProvider(client));
 
     const normalized = normalizeConfig(
       defineConfig({


### PR DESCRIPTION
## Summary
- Extracts a `gcpClientMock(secretValue)` helper in `test/integration/providers.test.ts` so the two GCP tests no longer hand-roll the same `accessSecretVersion`/`getSecret`/`createSecret`/`addSecretVersion` `vi.fn()` mock object.

Addresses the in-file clone fallow flagged at `:65-79` ↔ `:106-120` (15 lines). Re-running `npx fallow` after this change drops total clone groups from 15 to 14.

## Test plan
- [x] `vitest run test/integration/providers.test.ts` (3/3 pass)
- [x] `npx fallow` reports the in-file duplicate is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)