### PR TITLE
refactor(cli): switch describeStatus to a discriminated switch

### DIFF
--- a/packages/cli/src/cli/ls.ts
+++ b/packages/cli/src/cli/ls.ts
@@ -165,14 +165,19 @@ function buildRevealedRows(records: NormalizedRecord[], resolution: Resolution):
 }
 
 function describeStatus(record: NormalizedRecord, status: KeyResolutionStatus | undefined): string {
-  if (status?.status === "resolved") return status.value;
-  if (status?.status === "filtered") return "(filtered)";
-  if (status?.status === "skipped") {
-    if (record.optional) return "(optional, no value)";
-    return `key '${record.path}' ${formatSkipCause(status.cause)}`;
+  if (status === undefined) return "(missing)";
+  switch (status.status) {
+    case "resolved":
+      return status.value;
+    case "filtered":
+      return "(filtered)";
+    case "skipped":
+      return record.optional
+        ? "(optional, no value)"
+        : `key '${record.path}' ${formatSkipCause(status.cause)}`;
+    case "error":
+      return `error: ${status.message}`;
   }
-  if (status?.status === "error") return `error: ${status.message}`;
-  return "(missing)";
 }
 
 function describeSource(record: NormalizedRecord, envName: string | undefined): string {


### PR DESCRIPTION
## Summary
- Rewrites `describeStatus` in `packages/cli/src/cli/ls.ts` from a chain of `if (status?.status === "...")` checks into an `undefined` short-circuit + a `switch (status.status)` over the discriminated union.
- TypeScript narrows each case for free, so the cause/value/message access stays type-safe.

Addresses the complexity finding fallow flagged on `describeStatus` (10 cyclomatic, CRAP 31.6). Each `?.` short-circuit was being counted; the new shape collapses them into one.

## Test plan
- [x] `npm test` in `packages/cli` (128/128 pass)
- [x] `tsc --noEmit` in `packages/cli`
- [x] `npx fallow` no longer flags `describeStatus`

🤖 Generated with [Claude Code](https://claude.com/claude-code)