### PR TITLE
refactor(action): split resolveMap in emit-env.mjs

### DIFF
--- a/packages/action/dist/emit-env.mjs
+++ b/packages/action/dist/emit-env.mjs
@@ -9589,6 +9589,36 @@ for (const mapFile of maps) {
     appendEnv(v.envVar, v.value);
   }
 }
+function failIfInvalid(validation) {
+  if (validation.topLevelErrors.length > 0) {
+    fail(validation.topLevelErrors.map((e) => e.message).join("; "));
+  }
+  if (validation.keyErrors.length > 0) {
+    const lines = validation.keyErrors.map((e) => `  - ${e.path}: ${e.message}`).join("\n");
+    fail(`Validation errors:
+${lines}`);
+  }
+}
+function isSecretMapping(mapping, recordByPath) {
+  if ("template" in mapping) {
+    return mapping.keyPaths.some((p) => recordByPath.get(p)?.kind === "secret");
+  }
+  return recordByPath.get(mapping.keyPath)?.kind === "secret";
+}
+function renderResultToVar(result, recordByPath) {
+  if (result.status === "skipped") {
+    process.stderr.write(
+      `keyshelf: skipping ${result.envVar} \u2014 referenced key '${result.keyPath}' ${formatSkipCause(result.cause)}
+`
+    );
+    return void 0;
+  }
+  return {
+    envVar: result.envVar,
+    value: result.value,
+    secret: isSecretMapping(result.mapping, recordByPath)
+  };
+}
 async function resolveMap(appDir, envName2, mapFile) {
   const loaded = await loadConfig(appDir, { mappingFile: mapFile });
   const resolveOpts = {
@@ -9599,31 +9629,11 @@ async function resolveMap(appDir, envName2, mapFile) {
     groups,
     filters
   };
-  const validation = await validate(resolveOpts);
-  if (validation.topLevelErrors.length > 0) {
-    fail(validation.topLevelErrors.map((e) => e.message).join("; "));
-  }
-  if (validation.keyErrors.length > 0) {
-    const lines = validation.keyErrors.map((e) => `  - ${e.path}: ${e.message}`).join("\n");
-    fail(`Validation errors:
-${lines}`);
-  }
+  failIfInvalid(await validate(resolveOpts));
   const resolution = await resolveWithStatus(resolveOpts);
   const rendered = renderAppMapping(loaded.appMapping, resolution);
   const recordByPath = new Map(loaded.config.keys.map((k) => [k.path, k]));
-  const vars = [];
-  for (const result of rendered) {
-    if (result.status === "skipped") {
-      process.stderr.write(
-        `keyshelf: skipping ${result.envVar} \u2014 referenced key '${result.keyPath}' ${formatSkipCause(result.cause)}
-`
-      );
-      continue;
-    }
-    const secret = "template" in result.mapping ? result.mapping.keyPaths.some((p) => recordByPath.get(p)?.kind === "secret") : recordByPath.get(result.mapping.keyPath)?.kind === "secret";
-    vars.push({ envVar: result.envVar, value: result.value, secret });
-  }
-  return vars;
+  return rendered.map((result) => renderResultToVar(result, recordByPath)).filter((v) => v !== void 0);
 }
 function splitList(raw) {
   return raw.split(/[\n,]/).map((s) => s.trim()).filter(Boolean);

--- a/packages/action/scripts/emit-env.mjs
+++ b/packages/action/scripts/emit-env.mjs
@@ -52,6 +52,37 @@ for (const mapFile of maps) {
   }
 }
 
+function failIfInvalid(validation) {
+  if (validation.topLevelErrors.length > 0) {
+    fail(validation.topLevelErrors.map((e) => e.message).join("; "));
+  }
+  if (validation.keyErrors.length > 0) {
+    const lines = validation.keyErrors.map((e) => `  - ${e.path}: ${e.message}`).join("\n");
+    fail(`Validation errors:\n${lines}`);
+  }
+}
+
+function isSecretMapping(mapping, recordByPath) {
+  if ("template" in mapping) {
+    return mapping.keyPaths.some((p) => recordByPath.get(p)?.kind === "secret");
+  }
+  return recordByPath.get(mapping.keyPath)?.kind === "secret";
+}
+
+function renderResultToVar(result, recordByPath) {
+  if (result.status === "skipped") {
+    process.stderr.write(
+      `keyshelf: skipping ${result.envVar} — referenced key '${result.keyPath}' ${formatSkipCause(result.cause)}\n`
+    );
+    return undefined;
+  }
+  return {
+    envVar: result.envVar,
+    value: result.value,
+    secret: isSecretMapping(result.mapping, recordByPath)
+  };
+}
+
 async function resolveMap(appDir, envName, mapFile) {
   const loaded = await loadConfig(appDir, { mappingFile: mapFile });
   const resolveOpts = {
@@ -63,35 +94,15 @@ async function resolveMap(appDir, envName, mapFile) {
     filters
   };
 
-  const validation = await validate(resolveOpts);
-  if (validation.topLevelErrors.length > 0) {
-    fail(validation.topLevelErrors.map((e) => e.message).join("; "));
-  }
-  if (validation.keyErrors.length > 0) {
-    const lines = validation.keyErrors.map((e) => `  - ${e.path}: ${e.message}`).join("\n");
-    fail(`Validation errors:\n${lines}`);
-  }
+  failIfInvalid(await validate(resolveOpts));
 
   const resolution = await resolveWithStatus(resolveOpts);
   const rendered = renderAppMapping(loaded.appMapping, resolution);
   const recordByPath = new Map(loaded.config.keys.map((k) => [k.path, k]));
 
-  const vars = [];
-  for (const result of rendered) {
-    if (result.status === "skipped") {
-      process.stderr.write(
-        `keyshelf: skipping ${result.envVar} — referenced key '${result.keyPath}' ${formatSkipCause(result.cause)}\n`
-      );
-      continue;
-    }
-
-    const secret =
-      "template" in result.mapping
-        ? result.mapping.keyPaths.some((p) => recordByPath.get(p)?.kind === "secret")
-        : recordByPath.get(result.mapping.keyPath)?.kind === "secret";
-    vars.push({ envVar: result.envVar, value: result.value, secret });
-  }
-  return vars;
+  return rendered
+    .map((result) => renderResultToVar(result, recordByPath))
+    .filter((v) => v !== undefined);
 }
 
 function splitList(raw) {


### PR DESCRIPTION
## Summary
- Extracts `failIfInvalid` (validation gating), `isSecretMapping` (template-vs-direct mapping secret check), and `renderResultToVar` (the per-rendered-result transformation) out of the inline body of `resolveMap` in `packages/action/scripts/emit-env.mjs`.
- The orchestrator now reads as a flat sequence of named steps.

Addresses the HIGH complexity finding fallow flagged on `resolveMap` (7 cyclomatic / 7 cognitive / 41 LOC). Re-running `npx fallow` after this change drops the high-complexity-function count from 6 to 5.

## Test plan
- [x] `npm test` in `packages/action` (7/7 pass)
- [x] `npx fallow` no longer flags `resolveMap`

🤖 Generated with [Claude Code](https://claude.com/claude-code)