### PR TITLE
refactor(action): extract identity-paths module from write-identity script

### DIFF
--- a/packages/action/dist/write-identity.mjs
+++ b/packages/action/dist/write-identity.mjs
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 import { mkdir, writeFile, chmod, readFile } from 'fs/promises';
-import { dirname, join, isAbsolute, resolve } from 'path';
-import { homedir } from 'os';
+import { dirname, resolve, join, isAbsolute } from 'path';
 import { existsSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { performance } from 'perf_hooks';
 import { createJiti } from 'jiti';
 import { z } from 'zod';
+import { homedir } from 'os';
 
 // ../cli/dist/src/config/app-mapping.js
 var TEMPLATE_RE = /\$\{([^}]+)\}/g;
@@ -417,6 +417,34 @@ async function loadAppMapping(mappingPath, required) {
     throw err;
   }
 }
+function ageIdentityFile(binding) {
+  if (binding?.__kind !== "provider:age") return void 0;
+  const file = binding.options?.identityFile;
+  return typeof file === "string" && file.length > 0 ? file : void 0;
+}
+function collectAgeIdentityFiles(config) {
+  const seen = /* @__PURE__ */ new Set();
+  for (const record of config.keys) {
+    if (record.kind !== "secret") continue;
+    addIfAge(seen, record.value);
+    for (const v of Object.values(record.values ?? {})) addIfAge(seen, v);
+  }
+  return [...seen];
+}
+function addIfAge(seen, binding) {
+  const file = ageIdentityFile(binding);
+  if (file !== void 0) seen.add(file);
+}
+function resolveIdentityPath(filePath, rootDir) {
+  if (filePath === "~" || filePath.startsWith("~/")) {
+    return join(homedir(), filePath.slice(1));
+  }
+  if (isAbsolute(filePath)) return filePath;
+  return resolve(rootDir, filePath);
+}
+function ensureTrailingNewline(content) {
+  return content.endsWith("\n") ? content : content + "\n";
+}
 
 // scripts/write-identity.mjs
 var identity = process.env.KEYSHELF_IDENTITY;
@@ -441,30 +469,4 @@ for (const filePath of identityFiles) {
   await chmod(target, 384);
   process.stdout.write(`Wrote identity to ${target} (mode 0600)
 `);
-}
-function collectAgeIdentityFiles(config) {
-  const seen = /* @__PURE__ */ new Set();
-  for (const record of config.keys) {
-    if (record.kind !== "secret") continue;
-    visitBinding(record.value);
-    for (const v of Object.values(record.values ?? {})) visitBinding(v);
-  }
-  return [...seen];
-  function visitBinding(binding) {
-    if (binding === void 0) return;
-    if (typeof binding !== "object" || binding === null) return;
-    if (binding.__kind !== "provider:age") return;
-    const file = binding.options?.identityFile;
-    if (typeof file === "string" && file.length > 0) seen.add(file);
-  }
-}
-function resolveIdentityPath(filePath, rootDir) {
-  if (filePath === "~" || filePath.startsWith("~/")) {
-    return join(homedir(), filePath.slice(1));
-  }
-  if (isAbsolute(filePath)) return filePath;
-  return resolve(rootDir, filePath);
-}
-function ensureTrailingNewline(content) {
-  return content.endsWith("\n") ? content : content + "\n";
 }

--- a/packages/action/scripts/identity-paths.mjs
+++ b/packages/action/scripts/identity-paths.mjs
@@ -1,0 +1,35 @@
+import { homedir } from "node:os";
+import { isAbsolute, join, resolve as pathResolve } from "node:path";
+
+export function ageIdentityFile(binding) {
+  if (binding?.__kind !== "provider:age") return undefined;
+  const file = binding.options?.identityFile;
+  return typeof file === "string" && file.length > 0 ? file : undefined;
+}
+
+export function collectAgeIdentityFiles(config) {
+  const seen = new Set();
+  for (const record of config.keys) {
+    if (record.kind !== "secret") continue;
+    addIfAge(seen, record.value);
+    for (const v of Object.values(record.values ?? {})) addIfAge(seen, v);
+  }
+  return [...seen];
+}
+
+function addIfAge(seen, binding) {
+  const file = ageIdentityFile(binding);
+  if (file !== undefined) seen.add(file);
+}
+
+export function resolveIdentityPath(filePath, rootDir) {
+  if (filePath === "~" || filePath.startsWith("~/")) {
+    return join(homedir(), filePath.slice(1));
+  }
+  if (isAbsolute(filePath)) return filePath;
+  return pathResolve(rootDir, filePath);
+}
+
+export function ensureTrailingNewline(content) {
+  return content.endsWith("\n") ? content : content + "\n";
+}

--- a/packages/action/scripts/write-identity.mjs
+++ b/packages/action/scripts/write-identity.mjs
@@ -1,8 +1,12 @@
 #!/usr/bin/env node
 import { writeFile, mkdir, chmod } from "node:fs/promises";
-import { dirname, isAbsolute, join, resolve as pathResolve } from "node:path";
-import { homedir } from "node:os";
+import { dirname } from "node:path";
 import { loadConfig } from "keyshelf";
+import {
+  collectAgeIdentityFiles,
+  ensureTrailingNewline,
+  resolveIdentityPath
+} from "./identity-paths.mjs";
 
 const identity = process.env.KEYSHELF_IDENTITY;
 const cwd = process.env.KEYSHELF_CWD || process.cwd();
@@ -28,34 +32,4 @@ for (const filePath of identityFiles) {
   await writeFile(target, ensureTrailingNewline(identity), { mode: 0o600 });
   await chmod(target, 0o600);
   process.stdout.write(`Wrote identity to ${target} (mode 0600)\n`);
-}
-
-function collectAgeIdentityFiles(config) {
-  const seen = new Set();
-  for (const record of config.keys) {
-    if (record.kind !== "secret") continue;
-    visitBinding(record.value);
-    for (const v of Object.values(record.values ?? {})) visitBinding(v);
-  }
-  return [...seen];
-
-  function visitBinding(binding) {
-    if (binding === undefined) return;
-    if (typeof binding !== "object" || binding === null) return;
-    if (binding.__kind !== "provider:age") return;
-    const file = binding.options?.identityFile;
-    if (typeof file === "string" && file.length > 0) seen.add(file);
-  }
-}
-
-function resolveIdentityPath(filePath, rootDir) {
-  if (filePath === "~" || filePath.startsWith("~/")) {
-    return join(homedir(), filePath.slice(1));
-  }
-  if (isAbsolute(filePath)) return filePath;
-  return pathResolve(rootDir, filePath);
-}
-
-function ensureTrailingNewline(content) {
-  return content.endsWith("\n") ? content : content + "\n";
 }

--- a/packages/action/test/identity-paths.test.ts
+++ b/packages/action/test/identity-paths.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from "vitest";
+import { homedir } from "node:os";
+import { join, isAbsolute } from "node:path";
+import {
+  ageIdentityFile,
+  collectAgeIdentityFiles,
+  ensureTrailingNewline,
+  resolveIdentityPath
+  // @ts-expect-error mjs has no types
+} from "../scripts/identity-paths.mjs";
+
+describe("ageIdentityFile", () => {
+  it("returns the identityFile when binding is an age provider with a string path", () => {
+    expect(
+      ageIdentityFile({ __kind: "provider:age", options: { identityFile: "./key.txt" } })
+    ).toBe("./key.txt");
+  });
+
+  it("returns undefined for non-age providers", () => {
+    expect(
+      ageIdentityFile({ __kind: "provider:gcp", options: { identityFile: "./key.txt" } })
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for null/undefined/non-object bindings", () => {
+    expect(ageIdentityFile(null)).toBeUndefined();
+    expect(ageIdentityFile(undefined)).toBeUndefined();
+    expect(ageIdentityFile("string")).toBeUndefined();
+    expect(ageIdentityFile(42)).toBeUndefined();
+  });
+
+  it("returns undefined when identityFile is missing or empty", () => {
+    expect(ageIdentityFile({ __kind: "provider:age", options: {} })).toBeUndefined();
+    expect(
+      ageIdentityFile({ __kind: "provider:age", options: { identityFile: "" } })
+    ).toBeUndefined();
+    expect(
+      ageIdentityFile({ __kind: "provider:age", options: { identityFile: 123 } })
+    ).toBeUndefined();
+    expect(ageIdentityFile({ __kind: "provider:age" })).toBeUndefined();
+  });
+});
+
+describe("collectAgeIdentityFiles", () => {
+  it("returns empty array when there are no secret records", () => {
+    const config = {
+      keys: [{ kind: "config", path: "db/host" }]
+    };
+    expect(collectAgeIdentityFiles(config)).toEqual([]);
+  });
+
+  it("collects identityFile from a record's `value` binding", () => {
+    const config = {
+      keys: [
+        {
+          kind: "secret",
+          path: "db/password",
+          value: { __kind: "provider:age", options: { identityFile: "./a.txt" } }
+        }
+      ]
+    };
+    expect(collectAgeIdentityFiles(config)).toEqual(["./a.txt"]);
+  });
+
+  it("collects identityFile from per-env `values` bindings", () => {
+    const config = {
+      keys: [
+        {
+          kind: "secret",
+          path: "db/password",
+          values: {
+            dev: { __kind: "provider:age", options: { identityFile: "./dev.txt" } },
+            prod: { __kind: "provider:age", options: { identityFile: "./prod.txt" } }
+          }
+        }
+      ]
+    };
+    expect(collectAgeIdentityFiles(config).sort()).toEqual(["./dev.txt", "./prod.txt"]);
+  });
+
+  it("deduplicates repeated paths across records and envs", () => {
+    const same = { __kind: "provider:age", options: { identityFile: "./shared.txt" } };
+    const config = {
+      keys: [
+        { kind: "secret", path: "a", value: same },
+        { kind: "secret", path: "b", value: same, values: { dev: same } }
+      ]
+    };
+    expect(collectAgeIdentityFiles(config)).toEqual(["./shared.txt"]);
+  });
+
+  it("ignores non-age provider bindings and config keys", () => {
+    const config = {
+      keys: [
+        { kind: "config", path: "db/host", value: "localhost" },
+        {
+          kind: "secret",
+          path: "db/password",
+          value: { __kind: "provider:gcp", options: { project: "p" } }
+        }
+      ]
+    };
+    expect(collectAgeIdentityFiles(config)).toEqual([]);
+  });
+});
+
+describe("resolveIdentityPath", () => {
+  it("expands ~ to the home directory", () => {
+    expect(resolveIdentityPath("~/key.txt", "/repo")).toBe(join(homedir(), "key.txt"));
+    expect(resolveIdentityPath("~", "/repo")).toBe(homedir());
+  });
+
+  it("returns absolute paths unchanged", () => {
+    const abs = isAbsolute("/etc/key") ? "/etc/key" : "C:/etc/key";
+    expect(resolveIdentityPath(abs, "/repo")).toBe(abs);
+  });
+
+  it("resolves relative paths against rootDir", () => {
+    expect(resolveIdentityPath("./key.txt", "/repo")).toBe(join("/repo", "key.txt"));
+    expect(resolveIdentityPath("keys/age.txt", "/repo")).toBe(join("/repo", "keys", "age.txt"));
+  });
+});
+
+describe("ensureTrailingNewline", () => {
+  it("appends a newline when missing", () => {
+    expect(ensureTrailingNewline("abc")).toBe("abc\n");
+  });
+
+  it("leaves content with trailing newline alone", () => {
+    expect(ensureTrailingNewline("abc\n")).toBe("abc\n");
+  });
+});

--- a/packages/action/test/identity-paths.test.ts
+++ b/packages/action/test/identity-paths.test.ts
@@ -6,7 +6,6 @@ import {
   collectAgeIdentityFiles,
   ensureTrailingNewline,
   resolveIdentityPath
-  // @ts-expect-error mjs has no types
 } from "../scripts/identity-paths.mjs";
 
 describe("ageIdentityFile", () => {


### PR DESCRIPTION
## Summary
- Splits the age identity discovery + path resolution helpers out of `scripts/write-identity.mjs` into `scripts/identity-paths.mjs` so they are import-reachable instead of only subprocess-reachable.
- Adds `test/identity-paths.test.ts` with 14 unit assertions covering `ageIdentityFile`, `collectAgeIdentityFiles`, `resolveIdentityPath`, and `ensureTrailingNewline`.
- Also refactors `collectAgeIdentityFiles` to drop the nested closure and call a small `addIfAge` helper instead.

Addresses the `visitBinding HIGH` and `collectAgeIdentityFiles` complexity findings fallow flagged on `write-identity.mjs`. The CRAP scores were inflated because `scripts.test.ts` exercises these functions only via `spawnSync`, which fallow's static-analysis coverage doesn't see. Re-running `npx fallow` after this change drops the high-complexity-function count from 6 to 4.

## Test plan
- [x] `npm test` in `packages/action` (21/21 pass — 14 new + 7 existing)
- [x] `npx fallow` no longer flags the write-identity helpers

🤖 Generated with [Claude Code](https://claude.com/claude-code)