### PR TITLE
feat: detect v4 config and migrate gcp ids before emitting v5 config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5295,7 +5295,7 @@
     },
     "packages/action": {
       "name": "@keyshelf/action",
-      "version": "0.4.0",
+      "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.5.0",
@@ -5310,7 +5310,7 @@
     },
     "packages/cli": {
       "name": "keyshelf",
-      "version": "4.6.0",
+      "version": "5.0.0",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/secret-manager": "^6.1.1",
@@ -5337,9 +5337,10 @@
     },
     "packages/migrate": {
       "name": "@keyshelf/migrate",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@google-cloud/secret-manager": "^6.1.1",
         "commander": "^14.0.3",
         "js-yaml": "^4.1.1"
       },

--- a/packages/action/dist/emit-env.mjs
+++ b/packages/action/dist/emit-env.mjs
@@ -354,7 +354,21 @@ function getKind(value) {
 
 // ../cli/dist/src/config/loader.js
 var CONFIG_FILE = "keyshelf.config.ts";
+var V4_SCHEMA_FILE = "keyshelf.yaml";
 var APP_MAPPING_FILE = ".env.keyshelf";
+var V4ConfigDetectedError = class extends Error {
+  v4SchemaPath;
+  v4RootDir;
+  constructor(v4RootDir) {
+    const v4SchemaPath = join(v4RootDir, V4_SCHEMA_FILE);
+    super(
+      `Detected v4 keyshelf.yaml at ${v4SchemaPath} but no ${CONFIG_FILE} in any parent directory. Run \`npx @keyshelf/migrate\` from ${v4RootDir} to migrate to v5.`
+    );
+    this.name = "V4ConfigDetectedError";
+    this.v4SchemaPath = v4SchemaPath;
+    this.v4RootDir = v4RootDir;
+  }
+};
 var cachedJiti;
 function getJiti() {
   if (cachedJiti === void 0) {
@@ -370,12 +384,19 @@ function getJiti() {
 }
 function findRootDir(from) {
   let dir = resolve(from);
+  let v4RootDir;
   while (true) {
     if (existsSync(join(dir, CONFIG_FILE))) {
       return dir;
     }
+    if (v4RootDir === void 0 && existsSync(join(dir, V4_SCHEMA_FILE))) {
+      v4RootDir = dir;
+    }
     const parent = dirname(dir);
     if (parent === dir) {
+      if (v4RootDir !== void 0) {
+        throw new V4ConfigDetectedError(v4RootDir);
+      }
       throw new Error(`Could not find ${CONFIG_FILE} in ${from} or any parent directory`);
     }
     dir = parent;

--- a/packages/action/dist/write-identity.mjs
+++ b/packages/action/dist/write-identity.mjs
@@ -353,7 +353,21 @@ function getKind(value) {
 
 // ../cli/dist/src/config/loader.js
 var CONFIG_FILE = "keyshelf.config.ts";
+var V4_SCHEMA_FILE = "keyshelf.yaml";
 var APP_MAPPING_FILE = ".env.keyshelf";
+var V4ConfigDetectedError = class extends Error {
+  v4SchemaPath;
+  v4RootDir;
+  constructor(v4RootDir) {
+    const v4SchemaPath = join(v4RootDir, V4_SCHEMA_FILE);
+    super(
+      `Detected v4 keyshelf.yaml at ${v4SchemaPath} but no ${CONFIG_FILE} in any parent directory. Run \`npx @keyshelf/migrate\` from ${v4RootDir} to migrate to v5.`
+    );
+    this.name = "V4ConfigDetectedError";
+    this.v4SchemaPath = v4SchemaPath;
+    this.v4RootDir = v4RootDir;
+  }
+};
 var cachedJiti;
 function getJiti() {
   if (cachedJiti === void 0) {
@@ -369,12 +383,19 @@ function getJiti() {
 }
 function findRootDir(from) {
   let dir = resolve(from);
+  let v4RootDir;
   while (true) {
     if (existsSync(join(dir, CONFIG_FILE))) {
       return dir;
     }
+    if (v4RootDir === void 0 && existsSync(join(dir, V4_SCHEMA_FILE))) {
+      v4RootDir = dir;
+    }
     const parent = dirname(dir);
     if (parent === dir) {
+      if (v4RootDir !== void 0) {
+        throw new V4ConfigDetectedError(v4RootDir);
+      }
       throw new Error(`Could not find ${CONFIG_FILE} in ${from} or any parent directory`);
     }
     dir = parent;

--- a/packages/cli/bin/keyshelf.ts
+++ b/packages/cli/bin/keyshelf.ts
@@ -1,9 +1,16 @@
 #!/usr/bin/env node
 
 import { createProgram } from "../src/cli/index.js";
+import { V4ConfigDetectedError } from "../src/config/index.js";
+import { handleV4ConfigDetected } from "../src/cli/v4-prompt.js";
 
 const program = createProgram();
-program.parseAsync(process.argv).catch((err) => {
+program.parseAsync(process.argv).catch(async (err) => {
+  if (err instanceof V4ConfigDetectedError) {
+    await handleV4ConfigDetected(err);
+    console.error("\nkeyshelf: migration complete. Re-run your command.");
+    process.exit(0);
+  }
   console.error(`error: ${err.message}`);
   process.exit(1);
 });

--- a/packages/cli/src/cli/v4-prompt.ts
+++ b/packages/cli/src/cli/v4-prompt.ts
@@ -1,0 +1,64 @@
+import { createInterface } from "node:readline/promises";
+import { stdin, stderr, stdout } from "node:process";
+import spawn from "cross-spawn";
+import type { V4ConfigDetectedError } from "../config/index.js";
+
+export interface V4PromptIO {
+  readonly input: NodeJS.ReadableStream & { isTTY?: boolean };
+  readonly output: NodeJS.WritableStream;
+  readonly errorOutput: NodeJS.WritableStream;
+}
+
+const defaultIO: V4PromptIO = {
+  input: stdin,
+  output: stdout,
+  errorOutput: stderr
+};
+
+export async function handleV4ConfigDetected(
+  err: V4ConfigDetectedError,
+  io: V4PromptIO = defaultIO
+): Promise<void> {
+  io.errorOutput.write(
+    `keyshelf: detected v4 keyshelf.yaml at ${err.v4SchemaPath}.\n` +
+      `v5 expects keyshelf.config.ts in a parent directory.\n`
+  );
+
+  if (io.input.isTTY !== true) {
+    io.errorOutput.write(
+      `Run \`npx @keyshelf/migrate\` in ${err.v4RootDir} to migrate, then re-run this command.\n`
+    );
+    process.exit(1);
+  }
+
+  if (!(await ask(io, "Run @keyshelf/migrate now? [y/N] "))) {
+    process.exit(1);
+  }
+
+  const migrateCode = await runSubprocess("npx", ["-y", "@keyshelf/migrate"], err.v4RootDir, io);
+  if (migrateCode !== 0) {
+    io.errorOutput.write(`@keyshelf/migrate exited with code ${migrateCode}.\n`);
+    process.exit(migrateCode);
+  }
+}
+
+async function ask(io: V4PromptIO, prompt: string): Promise<boolean> {
+  const rl = createInterface({ input: io.input, output: io.output });
+  try {
+    const answer = (await rl.question(prompt)).trim().toLowerCase();
+    return answer === "y" || answer === "yes";
+  } finally {
+    rl.close();
+  }
+}
+
+function runSubprocess(cmd: string, args: string[], cwd: string, io: V4PromptIO): Promise<number> {
+  return new Promise((resolveSpawn) => {
+    const child = spawn(cmd, args, { stdio: "inherit", cwd });
+    child.on("exit", (code) => resolveSpawn(code ?? 1));
+    child.on("error", (spawnErr) => {
+      io.errorOutput.write(`Failed to run ${cmd}: ${spawnErr.message}\n`);
+      resolveSpawn(1);
+    });
+  });
+}

--- a/packages/cli/src/config/index.ts
+++ b/packages/cli/src/config/index.ts
@@ -1,5 +1,11 @@
 export { defineConfig, config, secret, age, gcp, sops } from "./factories.js";
-export { findRootDir, loadConfig, type LoadedConfig, type LoadConfigOptions } from "./loader.js";
+export {
+  findRootDir,
+  loadConfig,
+  V4ConfigDetectedError,
+  type LoadedConfig,
+  type LoadConfigOptions
+} from "./loader.js";
 export {
   isProviderRef,
   keyshelfConfigSchema,

--- a/packages/cli/src/config/loader.ts
+++ b/packages/cli/src/config/loader.ts
@@ -9,7 +9,24 @@ import { normalizeConfig, validateAppMappingReferences } from "./schema.js";
 import type { KeyshelfConfig, NormalizedConfig } from "./types.js";
 
 const CONFIG_FILE = "keyshelf.config.ts";
+const V4_SCHEMA_FILE = "keyshelf.yaml";
 const APP_MAPPING_FILE = ".env.keyshelf";
+
+export class V4ConfigDetectedError extends Error {
+  readonly v4SchemaPath: string;
+  readonly v4RootDir: string;
+
+  constructor(v4RootDir: string) {
+    const v4SchemaPath = join(v4RootDir, V4_SCHEMA_FILE);
+    super(
+      `Detected v4 keyshelf.yaml at ${v4SchemaPath} but no ${CONFIG_FILE} in any parent directory. ` +
+        `Run \`npx @keyshelf/migrate\` from ${v4RootDir} to migrate to v5.`
+    );
+    this.name = "V4ConfigDetectedError";
+    this.v4SchemaPath = v4SchemaPath;
+    this.v4RootDir = v4RootDir;
+  }
+}
 
 let cachedJiti: Jiti | undefined;
 
@@ -57,13 +74,20 @@ export interface LoadConfigOptions {
 
 export function findRootDir(from: string): string {
   let dir = resolve(from);
+  let v4RootDir: string | undefined;
 
   while (true) {
     if (existsSync(join(dir, CONFIG_FILE))) {
       return dir;
     }
+    if (v4RootDir === undefined && existsSync(join(dir, V4_SCHEMA_FILE))) {
+      v4RootDir = dir;
+    }
     const parent = dirname(dir);
     if (parent === dir) {
+      if (v4RootDir !== undefined) {
+        throw new V4ConfigDetectedError(v4RootDir);
+      }
       throw new Error(`Could not find ${CONFIG_FILE} in ${from} or any parent directory`);
     }
     dir = parent;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,6 +6,7 @@
 export {
   findRootDir,
   loadConfig,
+  V4ConfigDetectedError,
   type LoadedConfig,
   type LoadConfigOptions
 } from "./config/loader.js";

--- a/packages/cli/test/integration/loader.test.ts
+++ b/packages/cli/test/integration/loader.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
-import { findRootDir, loadConfig } from "../../src/config/index.js";
+import { findRootDir, loadConfig, V4ConfigDetectedError } from "../../src/config/index.js";
 
 async function createFixture() {
   const root = await mkdtemp(join(tmpdir(), "keyshelf-loader-"));
@@ -106,6 +106,35 @@ describe("config loader", () => {
       await expect(mod.loadConfig(appDir)).rejects.toThrow(
         new RegExp(expectedAbs.replace(/[\\/]/g, "[\\\\/]"))
       );
+    });
+  });
+
+  describe("v4 detection", () => {
+    it("throws V4ConfigDetectedError when only keyshelf.yaml is present in a parent dir", async () => {
+      const root = await mkdtemp(join(tmpdir(), "keyshelf-v4-detect-"));
+      await writeFile(join(root, "keyshelf.yaml"), "name: legacy\nkeys: {}\n");
+      const appDir = join(root, "apps", "api");
+      await mkdir(appDir, { recursive: true });
+
+      let caught: unknown;
+      try {
+        findRootDir(appDir);
+      } catch (err) {
+        caught = err;
+      }
+
+      expect(caught).toBeInstanceOf(V4ConfigDetectedError);
+      const v4Err = caught as V4ConfigDetectedError;
+      expect(v4Err.v4RootDir).toBe(root);
+      expect(v4Err.v4SchemaPath).toBe(join(root, "keyshelf.yaml"));
+      expect(v4Err.message).toContain("@keyshelf/migrate");
+    });
+
+    it("prefers a keyshelf.config.ts even when a keyshelf.yaml is also present", async () => {
+      const { root, appDir } = await createFixture();
+      await writeFile(join(root, "keyshelf.yaml"), "name: legacy\nkeys: {}\n");
+
+      expect(findRootDir(appDir)).toBe(root);
     });
   });
 

--- a/packages/cli/test/unit/v4-prompt.test.ts
+++ b/packages/cli/test/unit/v4-prompt.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Readable, Writable } from "node:stream";
+import { handleV4ConfigDetected } from "../../src/cli/v4-prompt.js";
+import { V4ConfigDetectedError } from "../../src/config/index.js";
+
+class CollectingWritable extends Writable {
+  chunks: string[] = [];
+
+  override _write(
+    chunk: Buffer | string,
+    _encoding: string,
+    callback: (err?: Error | null) => void
+  ): void {
+    this.chunks.push(typeof chunk === "string" ? chunk : chunk.toString("utf-8"));
+    callback();
+  }
+
+  text(): string {
+    return this.chunks.join("");
+  }
+}
+
+function nonTtyStdin(): Readable & { isTTY?: boolean } {
+  const stream = Readable.from([]) as Readable & { isTTY?: boolean };
+  stream.isTTY = false;
+  return stream;
+}
+
+describe("handleV4ConfigDetected (non-TTY)", () => {
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number): never => {
+      throw new Error(`__exit:${code ?? 0}`);
+    }) as never);
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+  });
+
+  it("writes a non-interactive instruction and exits with code 1", async () => {
+    const errorOutput = new CollectingWritable();
+    const output = new CollectingWritable();
+    const err = new V4ConfigDetectedError("/tmp/legacy");
+
+    await expect(
+      handleV4ConfigDetected(err, {
+        input: nonTtyStdin(),
+        output,
+        errorOutput
+      })
+    ).rejects.toThrow("__exit:1");
+
+    const text = errorOutput.text();
+    expect(text).toContain("/tmp/legacy/keyshelf.yaml");
+    expect(text).toContain("npx @keyshelf/migrate");
+    expect(text).toContain("/tmp/legacy");
+  });
+});

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -21,6 +21,7 @@
     "node": ">=18"
   },
   "dependencies": {
+    "@google-cloud/secret-manager": "^6.1.1",
     "commander": "^14.0.3",
     "js-yaml": "^4.1.1"
   },

--- a/packages/migrate/src/cli.ts
+++ b/packages/migrate/src/cli.ts
@@ -4,14 +4,17 @@ import { resolve } from "node:path";
 import { Command } from "commander";
 import { emitConfig } from "./emit.js";
 import { loadV4Project } from "./load-v4.js";
-import { normalizeProject } from "./normalize.js";
+import { normalizeProject, type NormalizedMigration } from "./normalize.js";
 import { buildReport } from "./report.js";
+import { formatGcpRows, hasGcpBindings, migrateGcpSecrets } from "./migrate-gcp.js";
 
 interface CliOptions {
   out: string;
   dryRun?: boolean;
   force?: boolean;
   acceptRenamedName?: boolean;
+  skipGcp?: boolean;
+  deleteLegacyGcp?: boolean;
 }
 
 const program = new Command();
@@ -20,9 +23,17 @@ program
   .name("keyshelf-migrate")
   .description("Migrate keyshelf v4 YAML files to keyshelf.config.ts")
   .option("--out <path>", "Output path", "keyshelf.config.ts")
-  .option("--dry-run", "Write generated config to stdout")
+  .option("--dry-run", "Write generated config to stdout (also dry-runs GCP secret-id migration)")
   .option("--force", "Overwrite the output file if it already exists")
   .option("--accept-renamed-name", "Accept converting v4 names with underscores to v5 kebab-case")
+  .option(
+    "--skip-gcp",
+    "Skip the GCP secret-id namespacing step (use only if you have already migrated or are not using gcp)"
+  )
+  .option(
+    "--delete-legacy-gcp",
+    "Delete legacy un-namespaced GCP secrets after copying (use with care)"
+  )
   .action(async (options: CliOptions) => {
     try {
       await run(options);
@@ -39,6 +50,16 @@ async function run(options: CliOptions): Promise<void> {
   const migration = normalizeProject(project, {
     acceptRenamedName: options.acceptRenamedName
   });
+
+  if (!options.dryRun) {
+    const outPath = resolve(process.cwd(), options.out);
+    if (existsSync(outPath) && !options.force) {
+      throw new Error(`${outPath} already exists. Re-run with --force to overwrite it.`);
+    }
+  }
+
+  await runGcpStep(migration, options);
+
   const source = emitConfig(migration);
   const report = buildReport(migration);
 
@@ -49,11 +70,30 @@ async function run(options: CliOptions): Promise<void> {
   }
 
   const outPath = resolve(process.cwd(), options.out);
-  if (existsSync(outPath) && !options.force) {
-    throw new Error(`${outPath} already exists. Re-run with --force to overwrite it.`);
-  }
-
   await writeFile(outPath, source, "utf-8");
   process.stderr.write(report);
   process.stderr.write(`Wrote ${outPath}\n`);
+}
+
+async function runGcpStep(migration: NormalizedMigration, options: CliOptions): Promise<void> {
+  if (options.skipGcp) return;
+  if (!hasGcpBindings(migration)) return;
+
+  process.stderr.write(
+    "Migrating GCP secret ids to be namespaced by config name (this runs before keyshelf.config.ts is written so v4 stays usable on failure).\n"
+  );
+  const result = await migrateGcpSecrets(migration, {
+    dryRun: options.dryRun,
+    deleteLegacy: options.deleteLegacyGcp
+  });
+
+  const formatted = formatGcpRows(result.rows);
+  if (formatted.length > 0) {
+    process.stderr.write(`${formatted}\n`);
+  }
+  if (result.hadError) {
+    throw new Error(
+      "GCP secret-id migration finished with errors (see rows above). Resolve the conflicts or re-run with a different --out, then re-run keyshelf-migrate. v4 keyshelf.yaml was left untouched."
+    );
+  }
 }

--- a/packages/migrate/src/migrate-gcp.ts
+++ b/packages/migrate/src/migrate-gcp.ts
@@ -1,0 +1,235 @@
+import { SecretManagerServiceClient } from "@google-cloud/secret-manager";
+import type { NormalizedMigration, NormalizedRecord, ProviderRef } from "./normalize.js";
+
+export interface GcpMigrateOptions {
+  dryRun?: boolean;
+  deleteLegacy?: boolean;
+  client?: SecretManagerServiceClient;
+}
+
+export type GcpRowStatus =
+  | "migrated"
+  | "already-migrated"
+  | "no-legacy"
+  | "value-mismatch"
+  | "deleted-legacy";
+
+export interface GcpMigrationRow {
+  env: string;
+  keyPath: string;
+  project: string;
+  legacyId: string;
+  newId: string;
+  status: GcpRowStatus;
+  message?: string;
+}
+
+export interface GcpMigrationResult {
+  rows: GcpMigrationRow[];
+  hadError: boolean;
+}
+
+const AUTH_ERROR_PATTERNS = [
+  "invalid_grant",
+  "invalid_rapt",
+  "reauth related error",
+  "token has been expired or revoked",
+  "Could not load the default credentials",
+  "Could not automatically determine credentials"
+];
+
+export class GcpAuthError extends Error {
+  constructor(cause?: Error) {
+    super(
+      "GCP authentication failed. Run `gcloud auth application-default login` to re-authenticate."
+    );
+    this.name = "GcpAuthError";
+    this.cause = cause;
+  }
+}
+
+function isAuthError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  const code = (err as { code?: number }).code;
+  if (code === 16) return true;
+  return AUTH_ERROR_PATTERNS.some((pattern) => err.message.includes(pattern));
+}
+
+function isNotFound(err: unknown): boolean {
+  return err instanceof Error && (err as { code?: number }).code === 5;
+}
+
+export function toSecretId(
+  keyshelfName: string | undefined,
+  envName: string,
+  keyPath: string
+): string {
+  const path = keyPath.replace(/\//g, "__");
+  const segments = ["keyshelf"];
+  if (keyshelfName !== undefined) segments.push(keyshelfName);
+  segments.push(envName, path);
+  return segments.join("__");
+}
+
+interface PlannedMigration {
+  env: string;
+  record: NormalizedRecord;
+  binding: ProviderRef;
+}
+
+function planMigrations(migration: NormalizedMigration): PlannedMigration[] {
+  const planned: PlannedMigration[] = [];
+  for (const record of migration.keys) {
+    if (record.kind !== "secret") continue;
+    for (const env of migration.envs) {
+      const binding =
+        record.values !== undefined && Object.hasOwn(record.values, env)
+          ? record.values[env]
+          : record.default;
+      if (binding === undefined || binding.name !== "gcp") continue;
+      planned.push({ env, record, binding });
+    }
+  }
+  return planned;
+}
+
+export function hasGcpBindings(migration: NormalizedMigration): boolean {
+  return planMigrations(migration).length > 0;
+}
+
+export async function migrateGcpSecrets(
+  migration: NormalizedMigration,
+  options: GcpMigrateOptions = {}
+): Promise<GcpMigrationResult> {
+  const planned = planMigrations(migration);
+  if (planned.length === 0) {
+    return { rows: [], hadError: false };
+  }
+
+  const client = options.client ?? new SecretManagerServiceClient();
+  const rows: GcpMigrationRow[] = [];
+  let hadError = false;
+
+  for (const { env, record, binding } of planned) {
+    const project = binding.options.project;
+    if (typeof project !== "string") {
+      throw new Error(`gcp binding for ${env}:${record.path} is missing a "project" option`);
+    }
+    const legacyId = toSecretId(undefined, env, record.path);
+    const newId = toSecretId(migration.name, env, record.path);
+
+    let stepResult: Pick<GcpMigrationRow, "status" | "message">;
+    try {
+      stepResult = await migrateOne(client, project, legacyId, newId, options);
+    } catch (err) {
+      if (isAuthError(err)) throw new GcpAuthError(err as Error);
+      throw err;
+    }
+
+    rows.push({
+      env,
+      keyPath: record.path,
+      project,
+      legacyId,
+      newId,
+      ...stepResult
+    });
+    if (stepResult.status === "value-mismatch") hadError = true;
+  }
+
+  return { rows, hadError };
+}
+
+async function migrateOne(
+  client: SecretManagerServiceClient,
+  project: string,
+  legacyId: string,
+  newId: string,
+  options: GcpMigrateOptions
+): Promise<Pick<GcpMigrationRow, "status" | "message">> {
+  const legacyValue = await readSecret(client, project, legacyId);
+  if (legacyValue === undefined) {
+    return { status: "no-legacy" };
+  }
+
+  const newValue = await readSecret(client, project, newId);
+  if (newValue !== undefined) {
+    if (newValue === legacyValue) {
+      if (options.deleteLegacy && !options.dryRun) {
+        await client.deleteSecret({ name: `projects/${project}/secrets/${legacyId}` });
+        return { status: "deleted-legacy" };
+      }
+      return { status: "already-migrated" };
+    }
+    return {
+      status: "value-mismatch",
+      message: "new secret already exists with a different value — refusing to overwrite"
+    };
+  }
+
+  if (options.dryRun) {
+    return { status: "migrated", message: "(dry-run)" };
+  }
+
+  await ensureSecret(client, project, newId);
+  await client.addSecretVersion({
+    parent: `projects/${project}/secrets/${newId}`,
+    payload: { data: Buffer.from(legacyValue, "utf-8") }
+  });
+
+  if (options.deleteLegacy) {
+    await client.deleteSecret({ name: `projects/${project}/secrets/${legacyId}` });
+    return { status: "deleted-legacy" };
+  }
+  return { status: "migrated" };
+}
+
+async function readSecret(
+  client: SecretManagerServiceClient,
+  project: string,
+  secretId: string
+): Promise<string | undefined> {
+  try {
+    const [version] = await client.accessSecretVersion({
+      name: `projects/${project}/secrets/${secretId}/versions/latest`
+    });
+    const payload = version.payload?.data;
+    if (!payload) return undefined;
+    return typeof payload === "string" ? payload : Buffer.from(payload).toString("utf-8");
+  } catch (err) {
+    if (isNotFound(err)) return undefined;
+    throw err;
+  }
+}
+
+async function ensureSecret(
+  client: SecretManagerServiceClient,
+  project: string,
+  secretId: string
+): Promise<void> {
+  try {
+    await client.createSecret({
+      parent: `projects/${project}`,
+      secretId,
+      secret: { replication: { automatic: {} } }
+    });
+  } catch (err) {
+    const code = (err as { code?: number }).code;
+    if (code !== 6) throw err;
+  }
+}
+
+export function formatGcpRows(rows: GcpMigrationRow[]): string {
+  if (rows.length === 0) return "";
+  const pathWidth = Math.max(...rows.map((r) => `${r.env}:${r.keyPath}`.length), 4);
+  const statusWidth = Math.max(...rows.map((r) => r.status.length), 6);
+
+  return rows
+    .map((r) => {
+      const label = `${r.env}:${r.keyPath}`.padEnd(pathWidth);
+      return [label, r.status.padEnd(statusWidth), `${r.legacyId} -> ${r.newId}`, r.message ?? ""]
+        .filter(Boolean)
+        .join("   ");
+    })
+    .join("\n");
+}

--- a/packages/migrate/src/migrate-gcp.ts
+++ b/packages/migrate/src/migrate-gcp.ts
@@ -1,5 +1,8 @@
 import { SecretManagerServiceClient } from "@google-cloud/secret-manager";
 import type { NormalizedMigration, NormalizedRecord, ProviderRef } from "./normalize.js";
+import { toSecretId } from "./secret-id.js";
+
+export { toSecretId };
 
 export interface GcpMigrateOptions {
   dryRun?: boolean;
@@ -57,18 +60,6 @@ function isAuthError(err: unknown): boolean {
 
 function isNotFound(err: unknown): boolean {
   return err instanceof Error && (err as { code?: number }).code === 5;
-}
-
-export function toSecretId(
-  keyshelfName: string | undefined,
-  envName: string,
-  keyPath: string
-): string {
-  const path = keyPath.replace(/\//g, "__");
-  const segments = ["keyshelf"];
-  if (keyshelfName !== undefined) segments.push(keyshelfName);
-  segments.push(envName, path);
-  return segments.join("__");
 }
 
 interface PlannedMigration {

--- a/packages/migrate/src/secret-id.ts
+++ b/packages/migrate/src/secret-id.ts
@@ -1,0 +1,11 @@
+export function toSecretId(
+  keyshelfName: string | undefined,
+  envName: string,
+  keyPath: string
+): string {
+  const path = keyPath.replace(/\//g, "__");
+  const segments = ["keyshelf"];
+  if (keyshelfName !== undefined) segments.push(keyshelfName);
+  segments.push(envName, path);
+  return segments.join("__");
+}

--- a/packages/migrate/test/migrate-gcp.test.ts
+++ b/packages/migrate/test/migrate-gcp.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it } from "vitest";
+import { hasGcpBindings, migrateGcpSecrets, toSecretId } from "../src/migrate-gcp.js";
+import type { NormalizedMigration } from "../src/normalize.js";
+
+interface MockSecretStore {
+  [secretId: string]: string;
+}
+
+function createMockClient(initial: MockSecretStore) {
+  const store: MockSecretStore = { ...initial };
+  const calls = {
+    accessSecretVersion: 0,
+    createSecret: 0,
+    addSecretVersion: 0,
+    deleteSecret: 0
+  };
+
+  return {
+    store,
+    calls,
+    accessSecretVersion: async ({ name }: { name: string }) => {
+      calls.accessSecretVersion++;
+      const match = name.match(/^projects\/([^/]+)\/secrets\/([^/]+)\/versions\/latest$/);
+      if (match === null) throw new Error(`bad access name: ${name}`);
+      const [, , secretId] = match;
+      const value = store[secretId];
+      if (value === undefined) {
+        const err = new Error(`secret ${secretId} not found`) as Error & { code: number };
+        err.code = 5;
+        throw err;
+      }
+      return [{ payload: { data: Buffer.from(value, "utf-8") } }];
+    },
+    createSecret: async ({ secretId }: { secretId: string }) => {
+      calls.createSecret++;
+      if (Object.hasOwn(store, secretId)) {
+        const err = new Error(`secret ${secretId} already exists`) as Error & { code: number };
+        err.code = 6;
+        throw err;
+      }
+      store[secretId] = "";
+    },
+    addSecretVersion: async ({
+      parent,
+      payload
+    }: {
+      parent: string;
+      payload: { data: Buffer };
+    }) => {
+      calls.addSecretVersion++;
+      const match = parent.match(/^projects\/[^/]+\/secrets\/([^/]+)$/);
+      if (match === null) throw new Error(`bad parent: ${parent}`);
+      const [, secretId] = match;
+      store[secretId] = payload.data.toString("utf-8");
+    },
+    deleteSecret: async ({ name }: { name: string }) => {
+      calls.deleteSecret++;
+      const match = name.match(/^projects\/[^/]+\/secrets\/([^/]+)$/);
+      if (match === null) throw new Error(`bad delete name: ${name}`);
+      const [, secretId] = match;
+      delete store[secretId];
+    }
+  };
+}
+
+const baseMigration: NormalizedMigration = {
+  name: "demo",
+  envs: ["dev", "production"],
+  groups: [],
+  keys: [
+    {
+      path: "db/password",
+      kind: "secret",
+      optional: false,
+      values: {
+        production: { name: "gcp", options: { project: "prod-project" } }
+      }
+    },
+    {
+      path: "api/token",
+      kind: "secret",
+      optional: false,
+      values: {
+        production: { name: "gcp", options: { project: "prod-project" } },
+        dev: { name: "age", options: {} }
+      }
+    },
+    {
+      path: "log/level",
+      kind: "config",
+      optional: false,
+      default: "info"
+    }
+  ],
+  appMapping: []
+};
+
+describe("toSecretId", () => {
+  it("namespaces by keyshelf name when provided", () => {
+    expect(toSecretId("demo", "production", "db/password")).toBe(
+      "keyshelf__demo__production__db__password"
+    );
+  });
+
+  it("omits the name segment when keyshelfName is undefined (legacy)", () => {
+    expect(toSecretId(undefined, "production", "db/password")).toBe(
+      "keyshelf__production__db__password"
+    );
+  });
+});
+
+describe("hasGcpBindings", () => {
+  it("returns true when at least one secret binds to gcp in any env", () => {
+    expect(hasGcpBindings(baseMigration)).toBe(true);
+  });
+
+  it("returns false when no gcp bindings exist", () => {
+    expect(
+      hasGcpBindings({
+        ...baseMigration,
+        keys: baseMigration.keys.filter((k) => k.path === "log/level")
+      })
+    ).toBe(false);
+  });
+});
+
+describe("migrateGcpSecrets", () => {
+  it("copies legacy ids to namespaced ids per gcp-bound env", async () => {
+    const client = createMockClient({
+      keyshelf__production__db__password: "secret-pw",
+      keyshelf__production__api__token: "secret-token"
+    });
+    const result = await migrateGcpSecrets(baseMigration, { client: client as never });
+
+    expect(result.hadError).toBe(false);
+    expect(result.rows.map((r) => `${r.env}:${r.keyPath}:${r.status}`)).toEqual([
+      "production:db/password:migrated",
+      "production:api/token:migrated"
+    ]);
+    expect(client.store.keyshelf__demo__production__db__password).toBe("secret-pw");
+    expect(client.store.keyshelf__demo__production__api__token).toBe("secret-token");
+    expect(client.store.keyshelf__production__db__password).toBe("secret-pw");
+  });
+
+  it("reports already-migrated when the namespaced id has the same value", async () => {
+    const client = createMockClient({
+      keyshelf__production__db__password: "secret-pw",
+      keyshelf__demo__production__db__password: "secret-pw"
+    });
+    const result = await migrateGcpSecrets(
+      {
+        ...baseMigration,
+        keys: [baseMigration.keys[0]]
+      },
+      { client: client as never }
+    );
+
+    expect(result.rows[0].status).toBe("already-migrated");
+    expect(client.calls.addSecretVersion).toBe(0);
+  });
+
+  it("flags value-mismatch and sets hadError when the namespaced id has a different value", async () => {
+    const client = createMockClient({
+      keyshelf__production__db__password: "old",
+      keyshelf__demo__production__db__password: "new-different"
+    });
+    const result = await migrateGcpSecrets(
+      {
+        ...baseMigration,
+        keys: [baseMigration.keys[0]]
+      },
+      { client: client as never }
+    );
+
+    expect(result.hadError).toBe(true);
+    expect(result.rows[0].status).toBe("value-mismatch");
+  });
+
+  it("emits no-legacy and writes nothing when the legacy id is missing", async () => {
+    const client = createMockClient({});
+    const result = await migrateGcpSecrets(
+      {
+        ...baseMigration,
+        keys: [baseMigration.keys[0]]
+      },
+      { client: client as never }
+    );
+
+    expect(result.rows[0].status).toBe("no-legacy");
+    expect(client.calls.addSecretVersion).toBe(0);
+  });
+
+  it("does not write under --dry-run", async () => {
+    const client = createMockClient({
+      keyshelf__production__db__password: "secret-pw"
+    });
+    const result = await migrateGcpSecrets(
+      {
+        ...baseMigration,
+        keys: [baseMigration.keys[0]]
+      },
+      { client: client as never, dryRun: true }
+    );
+
+    expect(result.rows[0].status).toBe("migrated");
+    expect(result.rows[0].message).toBe("(dry-run)");
+    expect(client.calls.addSecretVersion).toBe(0);
+    expect(client.calls.createSecret).toBe(0);
+  });
+
+  it("deletes legacy secrets when --delete-legacy is set", async () => {
+    const client = createMockClient({
+      keyshelf__production__db__password: "secret-pw"
+    });
+    const result = await migrateGcpSecrets(
+      {
+        ...baseMigration,
+        keys: [baseMigration.keys[0]]
+      },
+      { client: client as never, deleteLegacy: true }
+    );
+
+    expect(result.rows[0].status).toBe("deleted-legacy");
+    expect(client.store.keyshelf__production__db__password).toBeUndefined();
+    expect(client.store.keyshelf__demo__production__db__password).toBe("secret-pw");
+  });
+});


### PR DESCRIPTION
## Summary

- **v5 CLI** detects a v4 `keyshelf.yaml` when no `keyshelf.config.ts` is found and offers to run `@keyshelf/migrate`. Throws a typed `V4ConfigDetectedError` from `findRootDir`; the bin handler prompts on a TTY or prints non-interactive instructions otherwise, then spawns `npx -y @keyshelf/migrate` in the v4 root.
- **`@keyshelf/migrate`** now namespaces existing GCP secret ids *before* emitting the v5 config: `keyshelf__<env>__<path>` → `keyshelf__<name>__<env>__<path>`. If the GCP step fails or hits a value-mismatch, `keyshelf.config.ts` is never written, so the v4 setup stays usable. New flags: `--skip-gcp`, `--delete-legacy-gcp`; `--dry-run` dry-runs both steps.
- Adds `@google-cloud/secret-manager` as a dependency of `@keyshelf/migrate`.

## Why this order

`name` is required in v5, and v5's runtime resolves GCP secrets at the namespaced id only. Doing YAML→TS first and GCP later would leave the app broken between the two steps. Running the GCP copy while the v4 yaml is still authoritative means a failure leaves you on v4 with no half-migration to clean up.

## Test plan

- [x] `npm run typecheck` in `packages/cli` and `packages/migrate`
- [x] `npm run test` in `packages/migrate` — 29 tests, including 8 new `migrate-gcp` cases (status paths, dry-run, delete-legacy, value-mismatch, hasGcpBindings, toSecretId)
- [x] `npx vitest run` in `packages/cli` — 131 tests, including new v4-detection in loader and non-TTY v4 prompt output
- [x] Smoke-tested non-TTY error path with `tsx bin/keyshelf.ts ls </dev/null` against a temp v4 fixture
- [ ] Manual TTY smoke against a real v4 project (out of scope for this PR's CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)