### PR TITLE
docs: guide for migrating v4 projects without a name

### DIFF
--- a/docs/migrating-without-v4-name.md
+++ b/docs/migrating-without-v4-name.md
@@ -1,0 +1,121 @@
+# Migrating from v4 without a `name`
+
+The `name:` field was introduced in v4.6 to namespace GCP secret IDs. v5 requires it. If your `keyshelf.yaml` has no `name:`, the migrator stops with:
+
+```
+keyshelf.yaml must set top-level "name" before it can be migrated
+```
+
+The migrator refuses to invent a name because that name becomes the namespace for your GCP secret IDs and your v5 project identity — guessing wrong would silently fork your secret store. Pick one yourself, add it to `keyshelf.yaml`, then run the migrator.
+
+This guide covers the two cases: projects that don't use GCP, and projects that do.
+
+## 1. Pick a name
+
+Constraints, in the order they're applied:
+
+- v4 load-time check: matches `/^[a-zA-Z0-9_-]+$/` (letters, digits, `-`, `_`).
+- v5 normalization: lowercased and `_` → `-`, then must match `/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/`.
+
+If the v4 name you write contains `_`, you'll need `--accept-renamed-name` later to acknowledge `my_app` → `my-app`. Easiest path: write it in lower-kebab-case to begin with.
+
+Add it at the top of `keyshelf.yaml`:
+
+```yaml
+name: my-app
+keys:
+  # ...your existing keys...
+```
+
+Don't change anything else yet.
+
+## 2a. No GCP bindings — run the migrator
+
+If none of your secrets use `!gcp`, you're done with the prep. Run:
+
+```sh
+npx @keyshelf/migrate --dry-run
+```
+
+Inspect the generated config on stdout. If it looks right:
+
+```sh
+npx @keyshelf/migrate
+```
+
+Then follow the standard post-migration checklist in [`migrating-from-v4.md`](./migrating-from-v4.md).
+
+## 2b. GCP bindings — expect a secret-id rename
+
+Adding a `name` changes how the migrator addresses GCP secrets. Secret IDs in v5 are built as:
+
+```
+keyshelf__<name>__<env>__<key/path with / -> __>
+```
+
+Pre-4.6 secrets in your project were written without the `<name>` segment:
+
+```
+keyshelf__<env>__<key/path with / -> __>
+```
+
+The migrator's GCP step reads each legacy ID, copies the value to the new namespaced ID, and reports each row. It runs **before** `keyshelf.config.ts` is written, so a failure leaves your v4 setup fully usable.
+
+### Dry-run first
+
+```sh
+npx @keyshelf/migrate --dry-run
+```
+
+This dry-runs the GCP copy too. Each row prints one of these statuses:
+
+| Status             | Meaning                                                                      |
+| ------------------ | ---------------------------------------------------------------------------- |
+| `migrated`         | Will copy legacy → new. With `--dry-run`, no write happens.                  |
+| `already-migrated` | New secret already exists and matches the legacy value. No action needed.    |
+| `no-legacy`        | No legacy secret found at that ID. Probably already cleaned up, or unbound.  |
+| `value-mismatch`   | New secret exists with a **different** value. The migrator refuses to write. |
+| `deleted-legacy`   | Only with `--delete-legacy-gcp` (and not `--dry-run`).                       |
+
+`value-mismatch` is the one to investigate. It usually means someone already created the namespaced secret manually with a different value, or you ran a partial migration before. Resolve it (delete one, copy the right value over) before re-running.
+
+### Run for real
+
+Once the dry-run is clean:
+
+```sh
+npx @keyshelf/migrate
+```
+
+This writes new namespaced secrets and emits `keyshelf.config.ts`. Legacy secrets are kept by default.
+
+### Optional: clean up legacy secrets
+
+After verifying v5 reads the new secrets correctly (`keyshelf ls --env <env>` against the new config), you can delete the legacy un-namespaced secrets in one shot:
+
+```sh
+npx @keyshelf/migrate --force --delete-legacy-gcp
+```
+
+Or delete them manually in the GCP console once you're confident nothing else reads them.
+
+## 3. Verify
+
+Independent of which path you took:
+
+```sh
+keyshelf ls --env <env>          # all keys resolve
+keyshelf get --env <env> <path>  # spot-check a secret value
+```
+
+Compare against the same commands on the old v4 install before deleting `keyshelf.yaml` and `.keyshelf/`.
+
+## Authentication note (GCP only)
+
+The GCP step uses application-default credentials. If you see a `GcpAuthError`, run:
+
+```sh
+gcloud auth application-default login
+```
+
+and re-run the migrator. v4 was left untouched, so it's safe to retry.


### PR DESCRIPTION
## Summary
- Adds `docs/migrating-without-v4-name.md`, a focused guide for projects that pre-date the v4.6 `name:` field and therefore can't run `@keyshelf/migrate` without prep.
- Splits the procedure into the no-GCP path (just add the name) and the GCP path (legacy → namespaced secret-id copy), and explains each migrator row status from `migrate-gcp.ts`.
- Links back to `migrating-from-v4.md` for the standard post-migration checklist rather than duplicating it.

## Test plan
- [ ] Render the markdown on GitHub and confirm formatting (table, code fences, internal link)
- [ ] Sanity-check the constraints/regexes in the doc against `packages/migrate/src/load-v4.ts` and `normalize.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)