### PR TITLE
feat(reconcile): plan engine (phase 2 of keyshelf up)

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -111,6 +111,7 @@ config({
   value?: ConfigScalar | TemplateString;             // envless binding
   default?: ConfigScalar | TemplateString;           // alias for `value`
   values?: Partial<Record<EnvName, ConfigScalar | TemplateString>>;
+  movedFrom?: string | string[];                     // rename hints for `keyshelf up`
 })
 ```
 
@@ -153,6 +154,7 @@ secret({
   value?: ProviderRef;                               // envless binding
   default?: ProviderRef;                             // alias for `value`
   values?: Partial<Record<EnvName, ProviderRef>>;
+  movedFrom?: string | string[];                     // rename hints for `keyshelf up`
 })
 ```
 
@@ -262,6 +264,21 @@ Templates are only valid inside `config(...)` bindings, not inside
 
 ---
 
+## `movedFrom`
+
+Both `config(...)` and `secret(...)` accept an optional `movedFrom: string | string[]`.
+It is a hint to `keyshelf up` that this key used to live at a different path. The
+planner uses it to disambiguate renames when multiple orphan storage entries
+plausibly match a new key. The string (or array of strings) is the previous
+key path(s); array form covers a key that has been renamed multiple times
+before the user got around to running `up`.
+
+The validator rejects a `movedFrom` entry that collides with any declared key
+path in the same config — the old path must be retired in the schema for the
+hint to make sense.
+
+---
+
 ## Validation rules (for Phase 2)
 
 The Phase 2 validator must enforce, in addition to the type-level constraints:
@@ -284,6 +301,8 @@ The Phase 2 validator must enforce, in addition to the type-level constraints:
    paths and must not form cycles.
 9. `.env.keyshelf` references must point to declared key paths
    (loader-time validation against the flattened key set).
+10. `movedFrom` entries must NOT collide with a declared key path in the
+    same config (the old path must be retired in the schema).
 
 ---
 

--- a/packages/action/dist/emit-env.mjs
+++ b/packages/action/dist/emit-env.mjs
@@ -72,10 +72,12 @@ var providerRefSchema = z.discriminatedUnion("__kind", [
   gcpProviderSchema,
   sopsProviderSchema
 ]);
+var movedFromSchema = z.union([z.string().min(1), z.array(z.string().min(1)).nonempty()]).optional();
 var baseRecordSchema = {
   group: z.string().optional(),
   optional: z.boolean().optional(),
-  description: z.string().optional()
+  description: z.string().optional(),
+  movedFrom: movedFromSchema
 };
 var configRecordSchema = z.object({
   __kind: z.literal("config"),
@@ -124,6 +126,7 @@ function normalizeConfig(input) {
   const paths = new Set(flattened.map((record) => record.path));
   validatePathConflicts(flattened, errors);
   validateRecords(flattened, parsed.envs, groups2, errors);
+  validateMovedFrom(flattened, paths, errors);
   validateTemplateReferences(flattened, paths, errors);
   if (errors.length > 0) {
     throw new Error(
@@ -206,6 +209,7 @@ function normalizeConfigRecord(path, input, errors) {
     group: input.group,
     optional: input.optional ?? false,
     description: input.description,
+    movedFrom: normalizeMovedFrom(input.movedFrom),
     value: resolveBinding(path, input.value, input.default, errors),
     values: copyDefinedRecord(input.values)
   };
@@ -217,9 +221,14 @@ function normalizeSecretRecord(path, input, errors) {
     group: input.group,
     optional: input.optional ?? false,
     description: input.description,
+    movedFrom: normalizeMovedFrom(input.movedFrom),
     value: resolveBinding(path, input.value, input.default, errors),
     values: copyDefinedRecord(input.values)
   };
+}
+function normalizeMovedFrom(value) {
+  if (value === void 0) return void 0;
+  return Array.isArray(value) ? [...value] : [value];
 }
 function resolveBinding(path, value, fallback, errors) {
   if (value !== void 0 && fallback !== void 0) {
@@ -256,6 +265,20 @@ function validatePathConflicts(records, errors) {
       const prefix = segments.slice(0, index).join("/");
       if (seen.has(prefix)) {
         errors.push(`${record.path}: conflicts with leaf path "${prefix}"`);
+      }
+    }
+  }
+}
+function validateMovedFrom(records, paths, errors) {
+  for (const record of records) {
+    if (record.movedFrom === void 0) continue;
+    for (const from of record.movedFrom) {
+      if (from === record.path) {
+        errors.push(`${record.path}: movedFrom cannot reference itself`);
+        continue;
+      }
+      if (paths.has(from)) {
+        errors.push(`${record.path}: movedFrom "${from}" collides with a declared key path`);
       }
     }
   }

--- a/packages/action/dist/write-identity.mjs
+++ b/packages/action/dist/write-identity.mjs
@@ -71,10 +71,12 @@ var providerRefSchema = z.discriminatedUnion("__kind", [
   gcpProviderSchema,
   sopsProviderSchema
 ]);
+var movedFromSchema = z.union([z.string().min(1), z.array(z.string().min(1)).nonempty()]).optional();
 var baseRecordSchema = {
   group: z.string().optional(),
   optional: z.boolean().optional(),
-  description: z.string().optional()
+  description: z.string().optional(),
+  movedFrom: movedFromSchema
 };
 var configRecordSchema = z.object({
   __kind: z.literal("config"),
@@ -123,6 +125,7 @@ function normalizeConfig(input) {
   const paths = new Set(flattened.map((record) => record.path));
   validatePathConflicts(flattened, errors);
   validateRecords(flattened, parsed.envs, groups, errors);
+  validateMovedFrom(flattened, paths, errors);
   validateTemplateReferences(flattened, paths, errors);
   if (errors.length > 0) {
     throw new Error(
@@ -205,6 +208,7 @@ function normalizeConfigRecord(path, input, errors) {
     group: input.group,
     optional: input.optional ?? false,
     description: input.description,
+    movedFrom: normalizeMovedFrom(input.movedFrom),
     value: resolveBinding(path, input.value, input.default, errors),
     values: copyDefinedRecord(input.values)
   };
@@ -216,9 +220,14 @@ function normalizeSecretRecord(path, input, errors) {
     group: input.group,
     optional: input.optional ?? false,
     description: input.description,
+    movedFrom: normalizeMovedFrom(input.movedFrom),
     value: resolveBinding(path, input.value, input.default, errors),
     values: copyDefinedRecord(input.values)
   };
+}
+function normalizeMovedFrom(value) {
+  if (value === void 0) return void 0;
+  return Array.isArray(value) ? [...value] : [value];
 }
 function resolveBinding(path, value, fallback, errors) {
   if (value !== void 0 && fallback !== void 0) {
@@ -255,6 +264,20 @@ function validatePathConflicts(records, errors) {
       const prefix = segments.slice(0, index).join("/");
       if (seen.has(prefix)) {
         errors.push(`${record.path}: conflicts with leaf path "${prefix}"`);
+      }
+    }
+  }
+}
+function validateMovedFrom(records, paths, errors) {
+  for (const record of records) {
+    if (record.movedFrom === void 0) continue;
+    for (const from of record.movedFrom) {
+      if (from === record.path) {
+        errors.push(`${record.path}: movedFrom cannot reference itself`);
+        continue;
+      }
+      if (paths.has(from)) {
+        errors.push(`${record.path}: movedFrom "${from}" collides with a declared key path`);
       }
     }
   }

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -61,10 +61,15 @@ const providerRefSchema = z.discriminatedUnion("__kind", [
   sopsProviderSchema
 ]);
 
+const movedFromSchema = z
+  .union([z.string().min(1), z.array(z.string().min(1)).nonempty()])
+  .optional();
+
 const baseRecordSchema = {
   group: z.string().optional(),
   optional: z.boolean().optional(),
-  description: z.string().optional()
+  description: z.string().optional(),
+  movedFrom: movedFromSchema
 };
 
 const configRecordSchema = z
@@ -148,6 +153,7 @@ export function normalizeConfig(input: unknown): NormalizedConfig {
 
   validatePathConflicts(flattened, errors);
   validateRecords(flattened, parsed.envs, groups, errors);
+  validateMovedFrom(flattened, paths, errors);
   validateTemplateReferences(flattened, paths, errors);
 
   if (errors.length > 0) {
@@ -278,6 +284,7 @@ function normalizeConfigRecord(
     group: input.group,
     optional: input.optional ?? false,
     description: input.description,
+    movedFrom: normalizeMovedFrom(input.movedFrom),
     value: resolveBinding(path, input.value, input.default, errors),
     values: copyDefinedRecord(input.values)
   };
@@ -294,9 +301,15 @@ function normalizeSecretRecord(
     group: input.group,
     optional: input.optional ?? false,
     description: input.description,
+    movedFrom: normalizeMovedFrom(input.movedFrom),
     value: resolveBinding(path, input.value, input.default, errors),
     values: copyDefinedRecord(input.values)
   };
+}
+
+function normalizeMovedFrom(value: string | string[] | undefined): string[] | undefined {
+  if (value === undefined) return undefined;
+  return Array.isArray(value) ? [...value] : [value];
 }
 
 function resolveBinding<T>(
@@ -344,6 +357,25 @@ function validatePathConflicts(records: NormalizedRecord[], errors: string[]): v
       const prefix = segments.slice(0, index).join("/");
       if (seen.has(prefix)) {
         errors.push(`${record.path}: conflicts with leaf path "${prefix}"`);
+      }
+    }
+  }
+}
+
+function validateMovedFrom(
+  records: NormalizedRecord[],
+  paths: Set<string>,
+  errors: string[]
+): void {
+  for (const record of records) {
+    if (record.movedFrom === undefined) continue;
+    for (const from of record.movedFrom) {
+      if (from === record.path) {
+        errors.push(`${record.path}: movedFrom cannot reference itself`);
+        continue;
+      }
+      if (paths.has(from)) {
+        errors.push(`${record.path}: movedFrom "${from}" collides with a declared key path`);
       }
     }
   }

--- a/packages/cli/src/config/types.ts
+++ b/packages/cli/src/config/types.ts
@@ -30,6 +30,7 @@ export interface BaseRecord<GroupName extends string = string> {
   group?: GroupName;
   optional?: boolean;
   description?: string;
+  movedFrom?: string | string[];
 }
 
 export interface ConfigRecordInput<
@@ -136,6 +137,7 @@ export type NormalizedRecord =
       group?: string;
       optional: boolean;
       description?: string;
+      movedFrom?: string[];
       value?: ConfigBinding;
       values?: Record<string, ConfigBinding>;
     }
@@ -145,6 +147,7 @@ export type NormalizedRecord =
       group?: string;
       optional: boolean;
       description?: string;
+      movedFrom?: string[];
       value?: BuiltinProviderRef;
       values?: Record<string, BuiltinProviderRef>;
     };

--- a/packages/cli/src/reconcile/internal/desired-bindings.ts
+++ b/packages/cli/src/reconcile/internal/desired-bindings.ts
@@ -1,0 +1,76 @@
+import type { BuiltinProviderRef, NormalizedConfig, NormalizedRecord } from "../../config/types.js";
+
+export interface DesiredBinding {
+  keyPath: string;
+  envName: string | undefined;
+  providerName: string;
+  providerParams: unknown;
+}
+
+export function collectDesiredBindings(config: NormalizedConfig): DesiredBinding[] {
+  const bindings: DesiredBinding[] = [];
+  for (const record of config.keys) {
+    if (record.kind !== "secret") continue;
+    appendRecordBindings(record, config.envs, bindings);
+  }
+  return bindings;
+}
+
+export function collectProviderRefs(record: NormalizedRecord): BuiltinProviderRef[] {
+  if (record.kind !== "secret") return [];
+  const refs: BuiltinProviderRef[] = [];
+  if (record.value !== undefined) refs.push(record.value);
+  for (const ref of Object.values(record.values ?? {})) refs.push(ref);
+  return refs;
+}
+
+function appendRecordBindings(
+  record: Extract<NormalizedRecord, { kind: "secret" }>,
+  envs: readonly string[],
+  out: DesiredBinding[]
+): void {
+  const envless = record.value;
+  const perEnv = record.values ?? {};
+
+  if (envless !== undefined) {
+    appendEnvlessBindings(record.path, envless, envs, perEnv, out);
+  }
+
+  for (const [envName, ref] of Object.entries(perEnv)) {
+    out.push({
+      keyPath: record.path,
+      envName,
+      providerName: ref.name,
+      providerParams: ref.options
+    });
+  }
+}
+
+// value/default applies as a fallback for every env not overridden in
+// values. For envless storage providers this collapses to a single entry;
+// the planner handles the collapse via storageScope.
+function appendEnvlessBindings(
+  keyPath: string,
+  envless: BuiltinProviderRef,
+  envs: readonly string[],
+  perEnv: Record<string, BuiltinProviderRef>,
+  out: DesiredBinding[]
+): void {
+  for (const env of envsNotInValues(envs, perEnv)) {
+    out.push({
+      keyPath,
+      envName: env,
+      providerName: envless.name,
+      providerParams: envless.options
+    });
+  }
+}
+
+function envsNotInValues(
+  envs: readonly string[],
+  perEnv: Record<string, BuiltinProviderRef>
+): string[] {
+  const overridden = new Map<string, true>();
+  for (const env of Object.keys(perEnv)) overridden.set(env, true);
+  return envs.filter((env) => !overridden.has(env));
+}

--- a/packages/cli/src/reconcile/internal/desired-bindings.ts
+++ b/packages/cli/src/reconcile/internal/desired-bindings.ts
@@ -8,12 +8,11 @@ export interface DesiredBinding {
 }
 
 export function collectDesiredBindings(config: NormalizedConfig): DesiredBinding[] {
-  const bindings: DesiredBinding[] = [];
+  const collector = new BindingsCollector(config.envs);
   for (const record of config.keys) {
-    if (record.kind !== "secret") continue;
-    appendRecordBindings(record, config.envs, bindings);
+    collector.absorb(record);
   }
-  return bindings;
+  return collector.bindings;
 }
 
 export function collectProviderRefs(record: NormalizedRecord): BuiltinProviderRef[] {
@@ -24,53 +23,51 @@ export function collectProviderRefs(record: NormalizedRecord): BuiltinProviderRe
   return refs;
 }
 
-function appendRecordBindings(
-  record: Extract<NormalizedRecord, { kind: "secret" }>,
-  envs: readonly string[],
-  out: DesiredBinding[]
-): void {
-  const envless = record.value;
-  const perEnv = record.values ?? {};
+class BindingsCollector {
+  readonly bindings: DesiredBinding[] = [];
 
-  if (envless !== undefined) {
-    appendEnvlessBindings(record.path, envless, envs, perEnv, out);
+  constructor(readonly envs: readonly string[]) {}
+
+  absorb(record: NormalizedRecord): void {
+    if (record.kind !== "secret") return;
+    const envless = record.value;
+    const perEnv = record.values ?? {};
+
+    if (envless !== undefined) {
+      this.absorbEnvless(record.path, envless, perEnv);
+    }
+    this.absorbPerEnv(record.path, perEnv);
   }
 
-  for (const [envName, ref] of Object.entries(perEnv)) {
-    out.push({
-      keyPath: record.path,
-      envName,
-      providerName: ref.name,
-      providerParams: ref.options
-    });
+  // value/default applies as a fallback for every env not overridden in
+  // values. For envless storage providers this collapses to a single entry;
+  // the planner handles the collapse via storageScope.
+  private absorbEnvless(
+    keyPath: string,
+    envless: BuiltinProviderRef,
+    perEnv: Record<string, BuiltinProviderRef>
+  ): void {
+    const overridden = new Map<string, true>();
+    for (const env of Object.keys(perEnv)) overridden.set(env, true);
+    for (const env of this.envs) {
+      if (overridden.has(env)) continue;
+      this.bindings.push({
+        keyPath,
+        envName: env,
+        providerName: envless.name,
+        providerParams: envless.options
+      });
+    }
   }
-}
 
-// value/default applies as a fallback for every env not overridden in
-// values. For envless storage providers this collapses to a single entry;
-// the planner handles the collapse via storageScope.
-function appendEnvlessBindings(
-  keyPath: string,
-  envless: BuiltinProviderRef,
-  envs: readonly string[],
-  perEnv: Record<string, BuiltinProviderRef>,
-  out: DesiredBinding[]
-): void {
-  for (const env of envsNotInValues(envs, perEnv)) {
-    out.push({
-      keyPath,
-      envName: env,
-      providerName: envless.name,
-      providerParams: envless.options
-    });
+  private absorbPerEnv(keyPath: string, perEnv: Record<string, BuiltinProviderRef>): void {
+    for (const [envName, ref] of Object.entries(perEnv)) {
+      this.bindings.push({
+        keyPath,
+        envName,
+        providerName: ref.name,
+        providerParams: ref.options
+      });
+    }
   }
-}
-
-function envsNotInValues(
-  envs: readonly string[],
-  perEnv: Record<string, BuiltinProviderRef>
-): string[] {
-  const overridden = new Map<string, true>();
-  for (const env of Object.keys(perEnv)) overridden.set(env, true);
-  return envs.filter((env) => !overridden.has(env));
 }

--- a/packages/cli/src/reconcile/internal/diff.ts
+++ b/packages/cli/src/reconcile/internal/diff.ts
@@ -8,32 +8,44 @@ export interface InstanceDiff {
 }
 
 export function diffInstance(state: InstanceState): InstanceDiff {
-  const diff: InstanceDiff = {
-    matched: new Map(),
-    unmetByPath: new Map(),
-    orphansByPath: new Map()
-  };
-  partitionDesired(state, diff);
-  partitionActual(state, diff);
-  return diff;
+  const partitioner = new DiffPartitioner(state);
+  return partitioner.partition();
 }
 
-function partitionDesired(state: InstanceState, diff: InstanceDiff): void {
-  for (const [path, desiredEnvs] of state.desired) {
-    const actualEnvs = state.actual.get(path) ?? newEnvSet();
-    for (const env of desiredEnvs) {
-      const bucket = actualEnvs.has(env) ? diff.matched : diff.unmetByPath;
-      upsertEnvSet(bucket, path).add(env);
+class DiffPartitioner {
+  readonly matched = new Map<string, EnvSet>();
+  readonly unmetByPath = new Map<string, EnvSet>();
+  readonly orphansByPath = new Map<string, EnvSet>();
+
+  constructor(readonly state: InstanceState) {}
+
+  partition(): InstanceDiff {
+    this.partitionDesired();
+    this.partitionActual();
+    return {
+      matched: this.matched,
+      unmetByPath: this.unmetByPath,
+      orphansByPath: this.orphansByPath
+    };
+  }
+
+  private partitionDesired(): void {
+    for (const [path, desiredEnvs] of this.state.desired) {
+      const actualEnvs = this.state.actual.get(path) ?? newEnvSet();
+      for (const env of desiredEnvs) {
+        const bucket = actualEnvs.has(env) ? this.matched : this.unmetByPath;
+        upsertEnvSet(bucket, path).add(env);
+      }
     }
   }
-}
 
-function partitionActual(state: InstanceState, diff: InstanceDiff): void {
-  for (const [path, actualEnvs] of state.actual) {
-    const desiredEnvs = state.desired.get(path) ?? newEnvSet();
-    for (const env of actualEnvs) {
-      if (!desiredEnvs.has(env)) {
-        upsertEnvSet(diff.orphansByPath, path).add(env);
+  private partitionActual(): void {
+    for (const [path, actualEnvs] of this.state.actual) {
+      const desiredEnvs = this.state.desired.get(path) ?? newEnvSet();
+      for (const env of actualEnvs) {
+        if (!desiredEnvs.has(env)) {
+          upsertEnvSet(this.orphansByPath, path).add(env);
+        }
       }
     }
   }

--- a/packages/cli/src/reconcile/internal/diff.ts
+++ b/packages/cli/src/reconcile/internal/diff.ts
@@ -1,0 +1,40 @@
+import { newEnvSet, type EnvSet } from "./envs.js";
+import { upsertEnvSet, type InstanceState } from "./instance.js";
+
+export interface InstanceDiff {
+  matched: Map<string, EnvSet>;
+  unmetByPath: Map<string, EnvSet>;
+  orphansByPath: Map<string, EnvSet>;
+}
+
+export function diffInstance(state: InstanceState): InstanceDiff {
+  const diff: InstanceDiff = {
+    matched: new Map(),
+    unmetByPath: new Map(),
+    orphansByPath: new Map()
+  };
+  partitionDesired(state, diff);
+  partitionActual(state, diff);
+  return diff;
+}
+
+function partitionDesired(state: InstanceState, diff: InstanceDiff): void {
+  for (const [path, desiredEnvs] of state.desired) {
+    const actualEnvs = state.actual.get(path) ?? newEnvSet();
+    for (const env of desiredEnvs) {
+      const bucket = actualEnvs.has(env) ? diff.matched : diff.unmetByPath;
+      upsertEnvSet(bucket, path).add(env);
+    }
+  }
+}
+
+function partitionActual(state: InstanceState, diff: InstanceDiff): void {
+  for (const [path, actualEnvs] of state.actual) {
+    const desiredEnvs = state.desired.get(path) ?? newEnvSet();
+    for (const env of actualEnvs) {
+      if (!desiredEnvs.has(env)) {
+        upsertEnvSet(diff.orphansByPath, path).add(env);
+      }
+    }
+  }
+}

--- a/packages/cli/src/reconcile/internal/emit.ts
+++ b/packages/cli/src/reconcile/internal/emit.ts
@@ -1,0 +1,41 @@
+import type {
+  Action,
+  AmbiguousAction,
+  CreateAction,
+  DeleteAction,
+  NoOpAction,
+  RenameAction
+} from "../plan.js";
+import { envKeyValue, type EnvSet } from "./envs.js";
+import type { InstanceState } from "./instance.js";
+
+export type LeafKind = "noop" | "create" | "delete";
+
+export function appendLeafActions(
+  actions: Action[],
+  state: InstanceState,
+  kind: LeafKind,
+  byPath: Map<string, EnvSet>
+): void {
+  for (const [path, envs] of byPath) {
+    for (const env of envs) {
+      actions.push(buildLeafAction(state.providerName, kind, path, env));
+    }
+  }
+}
+
+function buildLeafAction(
+  providerName: string,
+  kind: LeafKind,
+  path: string,
+  env: string
+): NoOpAction | CreateAction | DeleteAction {
+  return { kind, keyPath: path, envName: envKeyValue(env), providerName };
+}
+
+export function appendList<T extends RenameAction | AmbiguousAction>(
+  actions: Action[],
+  items: T[]
+): void {
+  for (const item of items) actions.push(item);
+}

--- a/packages/cli/src/reconcile/internal/envs.ts
+++ b/packages/cli/src/reconcile/internal/envs.ts
@@ -1,0 +1,33 @@
+export type EnvKey = string;
+export type EnvSet = Set<EnvKey>;
+
+const ENVLESS: EnvKey = "\0envless";
+
+export function newEnvSet(): EnvSet {
+  return new Set<EnvKey>();
+}
+
+export function envKey(envName: string | undefined): EnvKey {
+  return envName ?? ENVLESS;
+}
+
+export function envKeyValue(key: EnvKey): string | undefined {
+  return key === ENVLESS ? undefined : key;
+}
+
+export function envSetsEqual(a: EnvSet, b: EnvSet): boolean {
+  if (a.size !== b.size) return false;
+  for (const value of a) {
+    if (!b.has(value)) return false;
+  }
+  return true;
+}
+
+export function envSorter(a: string | undefined, b: string | undefined): number {
+  if (a === b) return 0;
+  if (a === undefined) return -1;
+  if (b === undefined) return 1;
+  return a.localeCompare(b);
+}
+
+export { ENVLESS };

--- a/packages/cli/src/reconcile/internal/instance-key.ts
+++ b/packages/cli/src/reconcile/internal/instance-key.ts
@@ -1,0 +1,22 @@
+export function instanceKey(providerName: string, providerParams: unknown): string {
+  return `${providerName}:${stableStringify(providerParams)}`;
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return stableStringifyArray(value);
+  return stableStringifyObject(value as Record<string, unknown>);
+}
+
+function stableStringifyArray(value: unknown[]): string {
+  const parts: string[] = [];
+  for (const item of value) parts.push(stableStringify(item));
+  return `[${parts.join(",")}]`;
+}
+
+function stableStringifyObject(value: Record<string, unknown>): string {
+  const entries = Object.entries(value).sort(([a], [b]) => a.localeCompare(b));
+  const parts: string[] = [];
+  for (const [k, v] of entries) parts.push(`${JSON.stringify(k)}:${stableStringify(v)}`);
+  return `{${parts.join(",")}}`;
+}

--- a/packages/cli/src/reconcile/internal/instance.ts
+++ b/packages/cli/src/reconcile/internal/instance.ts
@@ -1,6 +1,12 @@
-import type { BuiltinProviderRef, NormalizedConfig, NormalizedRecord } from "../../config/types.js";
+import type { NormalizedConfig, NormalizedRecord } from "../../config/types.js";
 import type { ProviderListing, StorageScope } from "../planner.js";
 import { ENVLESS, envKey, newEnvSet, type EnvSet } from "./envs.js";
+import {
+  collectDesiredBindings,
+  collectProviderRefs,
+  type DesiredBinding
+} from "./desired-bindings.js";
+import { instanceKey } from "./instance-key.js";
 
 export interface InstanceState {
   providerName: string;
@@ -11,38 +17,15 @@ export interface InstanceState {
   movedFromByPath: Map<string, string[]>;
 }
 
-export interface DesiredBinding {
-  keyPath: string;
-  envName: string | undefined;
-  providerName: string;
-  providerParams: unknown;
-}
-
 export function buildInstances(
   config: NormalizedConfig,
   listings: ProviderListing[]
 ): Map<string, InstanceState> {
-  const instances = new Map<string, InstanceState>();
-
-  for (const listing of listings) {
-    const key = instanceKey(listing.providerName, listing.providerParams);
-    const state = ensureInstance(instances, key, listing);
-    for (const stored of listing.keys) {
-      const envs = upsertEnvSet(state.actual, stored.keyPath);
-      envs.add(envKey(stored.envName));
-    }
-  }
-
-  for (const binding of collectDesiredBindings(config)) {
-    const key = instanceKey(binding.providerName, binding.providerParams);
-    const state = ensureSyntheticInstance(instances, key, binding);
-    const envSet = upsertEnvSet(state.desired, binding.keyPath);
-    const env = state.storageScope === "envless" ? ENVLESS : envKey(binding.envName);
-    envSet.add(env);
-  }
-
-  attachMovedFrom(config, instances);
-  return instances;
+  const builder = new InstanceBuilder();
+  builder.applyListings(listings);
+  builder.applyDesired(config);
+  builder.applyMovedFrom(config);
+  return builder.instances;
 }
 
 export function upsertEnvSet(map: Map<string, EnvSet>, key: string): EnvSet {
@@ -54,144 +37,82 @@ export function upsertEnvSet(map: Map<string, EnvSet>, key: string): EnvSet {
   return envs;
 }
 
-function ensureInstance(
-  instances: Map<string, InstanceState>,
-  key: string,
-  listing: ProviderListing
-): InstanceState {
-  const existing = instances.get(key);
-  if (existing !== undefined) return existing;
-  const state: InstanceState = {
-    providerName: listing.providerName,
-    providerParams: listing.providerParams,
-    storageScope: listing.storageScope,
-    desired: new Map(),
-    actual: new Map(),
-    movedFromByPath: new Map()
-  };
-  instances.set(key, state);
-  return state;
-}
+class InstanceBuilder {
+  readonly instances = new Map<string, InstanceState>();
 
-function ensureSyntheticInstance(
-  instances: Map<string, InstanceState>,
-  key: string,
-  binding: DesiredBinding
-): InstanceState {
-  const existing = instances.get(key);
-  if (existing !== undefined) return existing;
+  applyListings(listings: ProviderListing[]): void {
+    for (const listing of listings) {
+      const key = instanceKey(listing.providerName, listing.providerParams);
+      const state = this.ensureFromListing(key, listing);
+      for (const stored of listing.keys) {
+        const envs = upsertEnvSet(state.actual, stored.keyPath);
+        envs.add(envKey(stored.envName));
+      }
+    }
+  }
+
+  applyDesired(config: NormalizedConfig): void {
+    for (const binding of collectDesiredBindings(config)) {
+      const key = instanceKey(binding.providerName, binding.providerParams);
+      const state = this.ensureFromBinding(key, binding);
+      const envSet = upsertEnvSet(state.desired, binding.keyPath);
+      const env = state.storageScope === "envless" ? ENVLESS : envKey(binding.envName);
+      envSet.add(env);
+    }
+  }
+
+  applyMovedFrom(config: NormalizedConfig): void {
+    for (const record of config.keys) {
+      if (record.kind !== "secret" || record.movedFrom === undefined) continue;
+      this.attachMovedFromForRecord(record, record.movedFrom);
+    }
+  }
+
+  private ensureFromListing(key: string, listing: ProviderListing): InstanceState {
+    const existing = this.instances.get(key);
+    if (existing !== undefined) return existing;
+    const state: InstanceState = {
+      providerName: listing.providerName,
+      providerParams: listing.providerParams,
+      storageScope: listing.storageScope,
+      desired: new Map(),
+      actual: new Map(),
+      movedFromByPath: new Map()
+    };
+    this.instances.set(key, state);
+    return state;
+  }
+
   // Desired references an instance with no listing supplied. Treat as
   // empty actual storage — every binding becomes a candidate Create.
   // Default to perEnv when we have no listing to tell us otherwise; an
   // envless-storage instance with zero stored keys behaves the same as
   // a perEnv instance with zero stored keys (everything is a Create).
-  const state: InstanceState = {
-    providerName: binding.providerName,
-    providerParams: binding.providerParams,
-    storageScope: "perEnv",
-    desired: new Map(),
-    actual: new Map(),
-    movedFromByPath: new Map()
-  };
-  instances.set(key, state);
-  return state;
-}
-
-function attachMovedFrom(config: NormalizedConfig, instances: Map<string, InstanceState>): void {
-  for (const record of config.keys) {
-    if (record.kind !== "secret" || record.movedFrom === undefined) continue;
-    attachMovedFromForRecord(record, record.movedFrom, instances);
-  }
-}
-
-function attachMovedFromForRecord(
-  record: NormalizedRecord,
-  movedFrom: readonly string[],
-  instances: Map<string, InstanceState>
-): void {
-  const refs = collectProviderRefs(record);
-  const seenInstances = new Map<string, true>();
-  for (const ref of refs) {
-    const key = instanceKey(ref.name, ref.options);
-    if (seenInstances.has(key)) continue;
-    seenInstances.set(key, true);
-    const state = instances.get(key);
-    if (state === undefined) continue;
-    state.movedFromByPath.set(record.path, [...movedFrom]);
-  }
-}
-
-function collectDesiredBindings(config: NormalizedConfig): DesiredBinding[] {
-  const bindings: DesiredBinding[] = [];
-
-  for (const record of config.keys) {
-    if (record.kind !== "secret") continue;
-    appendRecordBindings(record, config.envs, bindings);
+  private ensureFromBinding(key: string, binding: DesiredBinding): InstanceState {
+    const existing = this.instances.get(key);
+    if (existing !== undefined) return existing;
+    const state: InstanceState = {
+      providerName: binding.providerName,
+      providerParams: binding.providerParams,
+      storageScope: "perEnv",
+      desired: new Map(),
+      actual: new Map(),
+      movedFromByPath: new Map()
+    };
+    this.instances.set(key, state);
+    return state;
   }
 
-  return bindings;
-}
-
-function appendRecordBindings(
-  record: Extract<NormalizedRecord, { kind: "secret" }>,
-  envs: readonly string[],
-  out: DesiredBinding[]
-): void {
-  const envless = record.value;
-  const perEnv = record.values ?? {};
-
-  if (envless !== undefined) {
-    // value/default applies as a fallback for every env not overridden in
-    // values. For envless storage providers this collapses to a single
-    // entry; the planner handles the collapse via storageScope.
-    for (const env of envsNotInValues(envs, perEnv)) {
-      out.push({
-        keyPath: record.path,
-        envName: env,
-        providerName: envless.name,
-        providerParams: envless.options
-      });
+  private attachMovedFromForRecord(record: NormalizedRecord, movedFrom: readonly string[]): void {
+    const refs = collectProviderRefs(record);
+    const seenInstances = new Map<string, true>();
+    for (const ref of refs) {
+      const key = instanceKey(ref.name, ref.options);
+      if (seenInstances.has(key)) continue;
+      seenInstances.set(key, true);
+      const state = this.instances.get(key);
+      if (state === undefined) continue;
+      state.movedFromByPath.set(record.path, [...movedFrom]);
     }
   }
-
-  for (const [envName, ref] of Object.entries(perEnv)) {
-    out.push({
-      keyPath: record.path,
-      envName,
-      providerName: ref.name,
-      providerParams: ref.options
-    });
-  }
-}
-
-function envsNotInValues(
-  envs: readonly string[],
-  perEnv: Record<string, BuiltinProviderRef>
-): string[] {
-  const overridden = new Map<string, true>();
-  for (const env of Object.keys(perEnv)) overridden.set(env, true);
-  return envs.filter((env) => !overridden.has(env));
-}
-
-function collectProviderRefs(record: NormalizedRecord): BuiltinProviderRef[] {
-  if (record.kind !== "secret") return [];
-  const refs: BuiltinProviderRef[] = [];
-  if (record.value !== undefined) refs.push(record.value);
-  for (const ref of Object.values(record.values ?? {})) refs.push(ref);
-  return refs;
-}
-
-function instanceKey(providerName: string, providerParams: unknown): string {
-  return `${providerName}:${stableStringify(providerParams)}`;
-}
-
-function stableStringify(value: unknown): string {
-  if (value === null || typeof value !== "object") return JSON.stringify(value);
-  if (Array.isArray(value)) {
-    return `[${value.map(stableStringify).join(",")}]`;
-  }
-  const entries = Object.entries(value as Record<string, unknown>).sort(([a], [b]) =>
-    a.localeCompare(b)
-  );
-  return `{${entries.map(([k, v]) => `${JSON.stringify(k)}:${stableStringify(v)}`).join(",")}}`;
 }

--- a/packages/cli/src/reconcile/internal/instance.ts
+++ b/packages/cli/src/reconcile/internal/instance.ts
@@ -1,0 +1,197 @@
+import type { BuiltinProviderRef, NormalizedConfig, NormalizedRecord } from "../../config/types.js";
+import type { ProviderListing, StorageScope } from "../planner.js";
+import { ENVLESS, envKey, newEnvSet, type EnvSet } from "./envs.js";
+
+export interface InstanceState {
+  providerName: string;
+  providerParams: unknown;
+  storageScope: StorageScope;
+  desired: Map<string, EnvSet>;
+  actual: Map<string, EnvSet>;
+  movedFromByPath: Map<string, string[]>;
+}
+
+export interface DesiredBinding {
+  keyPath: string;
+  envName: string | undefined;
+  providerName: string;
+  providerParams: unknown;
+}
+
+export function buildInstances(
+  config: NormalizedConfig,
+  listings: ProviderListing[]
+): Map<string, InstanceState> {
+  const instances = new Map<string, InstanceState>();
+
+  for (const listing of listings) {
+    const key = instanceKey(listing.providerName, listing.providerParams);
+    const state = ensureInstance(instances, key, listing);
+    for (const stored of listing.keys) {
+      const envs = upsertEnvSet(state.actual, stored.keyPath);
+      envs.add(envKey(stored.envName));
+    }
+  }
+
+  for (const binding of collectDesiredBindings(config)) {
+    const key = instanceKey(binding.providerName, binding.providerParams);
+    const state = ensureSyntheticInstance(instances, key, binding);
+    const envSet = upsertEnvSet(state.desired, binding.keyPath);
+    const env = state.storageScope === "envless" ? ENVLESS : envKey(binding.envName);
+    envSet.add(env);
+  }
+
+  attachMovedFrom(config, instances);
+  return instances;
+}
+
+export function upsertEnvSet(map: Map<string, EnvSet>, key: string): EnvSet {
+  let envs = map.get(key);
+  if (envs === undefined) {
+    envs = newEnvSet();
+    map.set(key, envs);
+  }
+  return envs;
+}
+
+function ensureInstance(
+  instances: Map<string, InstanceState>,
+  key: string,
+  listing: ProviderListing
+): InstanceState {
+  const existing = instances.get(key);
+  if (existing !== undefined) return existing;
+  const state: InstanceState = {
+    providerName: listing.providerName,
+    providerParams: listing.providerParams,
+    storageScope: listing.storageScope,
+    desired: new Map(),
+    actual: new Map(),
+    movedFromByPath: new Map()
+  };
+  instances.set(key, state);
+  return state;
+}
+
+function ensureSyntheticInstance(
+  instances: Map<string, InstanceState>,
+  key: string,
+  binding: DesiredBinding
+): InstanceState {
+  const existing = instances.get(key);
+  if (existing !== undefined) return existing;
+  // Desired references an instance with no listing supplied. Treat as
+  // empty actual storage — every binding becomes a candidate Create.
+  // Default to perEnv when we have no listing to tell us otherwise; an
+  // envless-storage instance with zero stored keys behaves the same as
+  // a perEnv instance with zero stored keys (everything is a Create).
+  const state: InstanceState = {
+    providerName: binding.providerName,
+    providerParams: binding.providerParams,
+    storageScope: "perEnv",
+    desired: new Map(),
+    actual: new Map(),
+    movedFromByPath: new Map()
+  };
+  instances.set(key, state);
+  return state;
+}
+
+function attachMovedFrom(config: NormalizedConfig, instances: Map<string, InstanceState>): void {
+  for (const record of config.keys) {
+    if (record.kind !== "secret" || record.movedFrom === undefined) continue;
+    attachMovedFromForRecord(record, record.movedFrom, instances);
+  }
+}
+
+function attachMovedFromForRecord(
+  record: NormalizedRecord,
+  movedFrom: readonly string[],
+  instances: Map<string, InstanceState>
+): void {
+  const refs = collectProviderRefs(record);
+  const seenInstances = new Map<string, true>();
+  for (const ref of refs) {
+    const key = instanceKey(ref.name, ref.options);
+    if (seenInstances.has(key)) continue;
+    seenInstances.set(key, true);
+    const state = instances.get(key);
+    if (state === undefined) continue;
+    state.movedFromByPath.set(record.path, [...movedFrom]);
+  }
+}
+
+function collectDesiredBindings(config: NormalizedConfig): DesiredBinding[] {
+  const bindings: DesiredBinding[] = [];
+
+  for (const record of config.keys) {
+    if (record.kind !== "secret") continue;
+    appendRecordBindings(record, config.envs, bindings);
+  }
+
+  return bindings;
+}
+
+function appendRecordBindings(
+  record: Extract<NormalizedRecord, { kind: "secret" }>,
+  envs: readonly string[],
+  out: DesiredBinding[]
+): void {
+  const envless = record.value;
+  const perEnv = record.values ?? {};
+
+  if (envless !== undefined) {
+    // value/default applies as a fallback for every env not overridden in
+    // values. For envless storage providers this collapses to a single
+    // entry; the planner handles the collapse via storageScope.
+    for (const env of envsNotInValues(envs, perEnv)) {
+      out.push({
+        keyPath: record.path,
+        envName: env,
+        providerName: envless.name,
+        providerParams: envless.options
+      });
+    }
+  }
+
+  for (const [envName, ref] of Object.entries(perEnv)) {
+    out.push({
+      keyPath: record.path,
+      envName,
+      providerName: ref.name,
+      providerParams: ref.options
+    });
+  }
+}
+
+function envsNotInValues(
+  envs: readonly string[],
+  perEnv: Record<string, BuiltinProviderRef>
+): string[] {
+  const overridden = new Map<string, true>();
+  for (const env of Object.keys(perEnv)) overridden.set(env, true);
+  return envs.filter((env) => !overridden.has(env));
+}
+
+function collectProviderRefs(record: NormalizedRecord): BuiltinProviderRef[] {
+  if (record.kind !== "secret") return [];
+  const refs: BuiltinProviderRef[] = [];
+  if (record.value !== undefined) refs.push(record.value);
+  for (const ref of Object.values(record.values ?? {})) refs.push(ref);
+  return refs;
+}
+
+function instanceKey(providerName: string, providerParams: unknown): string {
+  return `${providerName}:${stableStringify(providerParams)}`;
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(",")}]`;
+  }
+  const entries = Object.entries(value as Record<string, unknown>).sort(([a], [b]) =>
+    a.localeCompare(b)
+  );
+  return `{${entries.map(([k, v]) => `${JSON.stringify(k)}:${stableStringify(v)}`).join(",")}}`;
+}

--- a/packages/cli/src/reconcile/internal/rename.ts
+++ b/packages/cli/src/reconcile/internal/rename.ts
@@ -7,261 +7,169 @@ export interface RenamePlan {
   ambiguous: AmbiguousAction[];
 }
 
-interface MatchPools {
-  pureCreates: Map<string, EnvSet>;
-  pureOrphans: Map<string, EnvSet>;
-  consumedOrphanPaths: Map<string, true>;
-  consumedDesiredPaths: Map<string, true>;
-}
-
 export function resolveRenames(
   state: InstanceState,
   unmetByPath: Map<string, EnvSet>,
   orphansByPath: Map<string, EnvSet>
 ): RenamePlan {
-  const renames: RenameAction[] = [];
-  const ambiguous: AmbiguousAction[] = [];
-  const pools = buildMatchPools(state, unmetByPath, orphansByPath);
-
-  resolveMovedFromMatches(state, pools, renames, unmetByPath, orphansByPath);
-  resolveShapeMatches(state, pools, renames, ambiguous, unmetByPath, orphansByPath);
-
-  return { renames, ambiguous };
+  const resolver = new RenameResolver(state, unmetByPath, orphansByPath);
+  return resolver.resolve();
 }
 
-function buildMatchPools(
-  state: InstanceState,
-  unmetByPath: Map<string, EnvSet>,
-  orphansByPath: Map<string, EnvSet>
-): MatchPools {
-  return {
-    pureCreates: collectPureCreates(state, unmetByPath),
-    pureOrphans: collectPureOrphans(state, orphansByPath),
-    consumedOrphanPaths: new Map(),
-    consumedDesiredPaths: new Map()
-  };
-}
+class RenameResolver {
+  readonly renames: RenameAction[] = [];
+  readonly ambiguous: AmbiguousAction[] = [];
+  readonly pureCreates: Map<string, EnvSet>;
+  readonly pureOrphans: Map<string, EnvSet>;
+  readonly consumedOrphanPaths = new Map<string, true>();
+  readonly consumedDesiredPaths = new Map<string, true>();
 
-// A path is rename-eligible only when *all* of its desired envs are unmet
-// (no overlap with actual storage at this path) and the path itself does
-// not appear in actual storage. Partial-env mismatches stay as Create.
-function collectPureCreates(
-  state: InstanceState,
-  unmetByPath: Map<string, EnvSet>
-): Map<string, EnvSet> {
-  const pureCreates = new Map<string, EnvSet>();
-  for (const [path, envs] of unmetByPath) {
-    const desiredEnvs = state.desired.get(path);
-    if (desiredEnvs === undefined) continue;
-    if (envs.size === desiredEnvs.size && !state.actual.has(path)) {
-      pureCreates.set(path, envs);
+  constructor(
+    readonly state: InstanceState,
+    readonly unmetByPath: Map<string, EnvSet>,
+    readonly orphansByPath: Map<string, EnvSet>
+  ) {
+    this.pureCreates = this.collectPureCreates();
+    this.pureOrphans = this.collectPureOrphans();
+  }
+
+  resolve(): RenamePlan {
+    this.resolveMovedFromMatches();
+    this.resolveShapeMatches();
+    return { renames: this.renames, ambiguous: this.ambiguous };
+  }
+
+  // A path is rename-eligible only when *all* of its desired envs are unmet
+  // (no overlap with actual storage at this path) and the path itself does
+  // not appear in actual storage. Partial-env mismatches stay as Create.
+  private collectPureCreates(): Map<string, EnvSet> {
+    const out = new Map<string, EnvSet>();
+    for (const [path, envs] of this.unmetByPath) {
+      const desiredEnvs = this.state.desired.get(path);
+      if (desiredEnvs === undefined) continue;
+      if (envs.size === desiredEnvs.size && !this.state.actual.has(path)) {
+        out.set(path, envs);
+      }
+    }
+    return out;
+  }
+
+  // An orphan path is rename-eligible only when it doesn't also appear as
+  // desired (e.g. partial overlap stays as Delete).
+  private collectPureOrphans(): Map<string, EnvSet> {
+    const out = new Map<string, EnvSet>();
+    for (const [path, envs] of this.orphansByPath) {
+      if (!this.state.desired.has(path)) {
+        out.set(path, envs);
+      }
+    }
+    return out;
+  }
+
+  // Pass 1: movedFrom forces a match. Consumes the intersection of desired
+  // and orphan envs; leftover envs on either side fall through to
+  // Create/Delete respectively.
+  private resolveMovedFromMatches(): void {
+    for (const [desiredPath, desiredEnvs] of this.pureCreates) {
+      const movedFrom = this.state.movedFromByPath.get(desiredPath);
+      if (movedFrom === undefined) continue;
+      this.tryMovedFromMatch(desiredPath, desiredEnvs, movedFrom);
     }
   }
-  return pureCreates;
-}
 
-// An orphan path is rename-eligible only when it doesn't also appear as
-// desired (e.g. partial overlap stays as Delete).
-function collectPureOrphans(
-  state: InstanceState,
-  orphansByPath: Map<string, EnvSet>
-): Map<string, EnvSet> {
-  const pureOrphans = new Map<string, EnvSet>();
-  for (const [path, envs] of orphansByPath) {
-    if (!state.desired.has(path)) {
-      pureOrphans.set(path, envs);
+  private tryMovedFromMatch(
+    desiredPath: string,
+    desiredEnvs: EnvSet,
+    movedFrom: readonly string[]
+  ): void {
+    for (const candidate of movedFrom) {
+      if (this.consumedOrphanPaths.has(candidate)) continue;
+      const orphanEnvs = this.pureOrphans.get(candidate);
+      if (orphanEnvs === undefined) continue;
+      this.commitRename(candidate, desiredPath, desiredEnvs, orphanEnvs);
+      return;
     }
   }
-  return pureOrphans;
-}
 
-// Pass 1: movedFrom forces a match. Consumes the intersection of desired
-// and orphan envs; leftover envs on either side fall through to
-// Create/Delete respectively.
-function resolveMovedFromMatches(
-  state: InstanceState,
-  pools: MatchPools,
-  renames: RenameAction[],
-  unmetByPath: Map<string, EnvSet>,
-  orphansByPath: Map<string, EnvSet>
-): void {
-  for (const [desiredPath, desiredEnvs] of pools.pureCreates) {
-    const movedFrom = state.movedFromByPath.get(desiredPath);
-    if (movedFrom === undefined) continue;
-    tryMovedFromMatch(
-      state,
-      pools,
-      renames,
-      unmetByPath,
-      orphansByPath,
-      desiredPath,
-      desiredEnvs,
-      movedFrom
-    );
+  // Pass 2: shape match by envCoverage. Within an instance, providerName and
+  // providerParams already match by construction, so envCoverage is the only
+  // remaining shape axis.
+  private resolveShapeMatches(): void {
+    for (const [desiredPath, desiredEnvs] of this.pureCreates) {
+      if (this.consumedDesiredPaths.has(desiredPath)) continue;
+      this.resolveSingleShapeMatch(desiredPath, desiredEnvs);
+    }
   }
-}
 
-function tryMovedFromMatch(
-  state: InstanceState,
-  pools: MatchPools,
-  renames: RenameAction[],
-  unmetByPath: Map<string, EnvSet>,
-  orphansByPath: Map<string, EnvSet>,
-  desiredPath: string,
-  desiredEnvs: EnvSet,
-  movedFrom: readonly string[]
-): void {
-  for (const candidate of movedFrom) {
-    if (pools.consumedOrphanPaths.has(candidate)) continue;
-    const orphanEnvs = pools.pureOrphans.get(candidate);
-    if (orphanEnvs === undefined) continue;
-    commitRename(
-      state,
-      pools,
-      renames,
-      unmetByPath,
-      orphansByPath,
-      candidate,
-      desiredPath,
-      desiredEnvs,
-      orphanEnvs
-    );
-    return;
+  private resolveSingleShapeMatch(desiredPath: string, desiredEnvs: EnvSet): void {
+    const matches = this.findShapeMatches(desiredEnvs);
+    if (matches.length === 0) return;
+    if (matches.length === 1) {
+      this.commitShapeRename(desiredPath, desiredEnvs, matches[0]);
+      return;
+    }
+    this.recordAmbiguous(desiredPath, matches);
   }
-}
 
-// Pass 2: shape match by envCoverage. Within an instance, providerName and
-// providerParams already match by construction, so envCoverage is the only
-// remaining shape axis.
-function resolveShapeMatches(
-  state: InstanceState,
-  pools: MatchPools,
-  renames: RenameAction[],
-  ambiguous: AmbiguousAction[],
-  unmetByPath: Map<string, EnvSet>,
-  orphansByPath: Map<string, EnvSet>
-): void {
-  for (const [desiredPath, desiredEnvs] of pools.pureCreates) {
-    if (pools.consumedDesiredPaths.has(desiredPath)) continue;
-    resolveSingleShapeMatch(
-      state,
-      pools,
-      renames,
-      ambiguous,
-      unmetByPath,
-      orphansByPath,
-      desiredPath,
-      desiredEnvs
-    );
+  private commitShapeRename(desiredPath: string, desiredEnvs: EnvSet, candidate: string): void {
+    const orphanEnvs = this.pureOrphans.get(candidate);
+    // pureOrphans was populated for every entry in `matches` by
+    // findShapeMatches, so the lookup is guaranteed to hit. The guard
+    // exists to satisfy strict-null without a non-null assertion.
+    if (orphanEnvs === undefined) return;
+    this.commitRename(candidate, desiredPath, desiredEnvs, orphanEnvs);
   }
-}
 
-function resolveSingleShapeMatch(
-  state: InstanceState,
-  pools: MatchPools,
-  renames: RenameAction[],
-  ambiguous: AmbiguousAction[],
-  unmetByPath: Map<string, EnvSet>,
-  orphansByPath: Map<string, EnvSet>,
-  desiredPath: string,
-  desiredEnvs: EnvSet
-): void {
-  const matches = findShapeMatches(pools, desiredEnvs);
-  if (matches.length === 0) return;
-  if (matches.length === 1) {
-    commitShapeRename(
-      state,
-      pools,
-      renames,
-      unmetByPath,
-      orphansByPath,
-      desiredPath,
-      desiredEnvs,
-      matches[0]
-    );
-    return;
-  }
-  ambiguous.push(buildAmbiguous(state, desiredPath, matches));
   // Suppress both sides while ambiguity is unresolved — emitting a
   // Delete on a possibly-renamed path would destroy data.
-  unmetByPath.delete(desiredPath);
-  pools.consumedDesiredPaths.set(desiredPath, true);
-  for (const path of matches) {
-    orphansByPath.delete(path);
-    pools.consumedOrphanPaths.set(path, true);
-  }
-}
-
-function commitShapeRename(
-  state: InstanceState,
-  pools: MatchPools,
-  renames: RenameAction[],
-  unmetByPath: Map<string, EnvSet>,
-  orphansByPath: Map<string, EnvSet>,
-  desiredPath: string,
-  desiredEnvs: EnvSet,
-  candidate: string
-): void {
-  const orphanEnvs = pools.pureOrphans.get(candidate);
-  // pureOrphans was populated for every entry in `matches` by
-  // findShapeMatches, so the lookup is guaranteed to hit. The guard
-  // exists to satisfy strict-null without a non-null assertion.
-  if (orphanEnvs === undefined) return;
-  commitRename(
-    state,
-    pools,
-    renames,
-    unmetByPath,
-    orphansByPath,
-    candidate,
-    desiredPath,
-    desiredEnvs,
-    orphanEnvs
-  );
-}
-
-function findShapeMatches(pools: MatchPools, desiredEnvs: EnvSet): string[] {
-  const matches: string[] = [];
-  for (const [orphanPath, orphanEnvs] of pools.pureOrphans) {
-    if (pools.consumedOrphanPaths.has(orphanPath)) continue;
-    if (envSetsEqual(desiredEnvs, orphanEnvs)) {
-      matches.push(orphanPath);
+  private recordAmbiguous(desiredPath: string, matches: string[]): void {
+    this.ambiguous.push(buildAmbiguous(this.state.providerName, desiredPath, matches));
+    this.unmetByPath.delete(desiredPath);
+    this.consumedDesiredPaths.set(desiredPath, true);
+    for (const path of matches) {
+      this.orphansByPath.delete(path);
+      this.consumedOrphanPaths.set(path, true);
     }
   }
-  return matches;
-}
 
-function commitRename(
-  state: InstanceState,
-  pools: MatchPools,
-  renames: RenameAction[],
-  unmetByPath: Map<string, EnvSet>,
-  orphansByPath: Map<string, EnvSet>,
-  fromPath: string,
-  toPath: string,
-  desiredEnvs: EnvSet,
-  orphanEnvs: EnvSet
-): void {
-  const rename = buildRename(state, fromPath, toPath, desiredEnvs, orphanEnvs);
-  renames.push(rename);
-  consumeEnvs(unmetByPath, toPath, rename.envBindings);
-  consumeEnvs(orphansByPath, fromPath, rename.envBindings);
-  pools.consumedOrphanPaths.set(fromPath, true);
-  pools.consumedDesiredPaths.set(toPath, true);
+  private findShapeMatches(desiredEnvs: EnvSet): string[] {
+    const matches: string[] = [];
+    for (const [orphanPath, orphanEnvs] of this.pureOrphans) {
+      if (this.consumedOrphanPaths.has(orphanPath)) continue;
+      if (envSetsEqual(desiredEnvs, orphanEnvs)) {
+        matches.push(orphanPath);
+      }
+    }
+    return matches;
+  }
+
+  private commitRename(
+    fromPath: string,
+    toPath: string,
+    desiredEnvs: EnvSet,
+    orphanEnvs: EnvSet
+  ): void {
+    const rename = buildRename(this.state.providerName, fromPath, toPath, desiredEnvs, orphanEnvs);
+    this.renames.push(rename);
+    consumeEnvs(this.unmetByPath, toPath, rename.envBindings);
+    consumeEnvs(this.orphansByPath, fromPath, rename.envBindings);
+    this.consumedOrphanPaths.set(fromPath, true);
+    this.consumedDesiredPaths.set(toPath, true);
+  }
 }
 
 function buildAmbiguous(
-  state: InstanceState,
+  providerName: string,
   desiredPath: string,
   matches: string[]
 ): AmbiguousAction {
   const candidates = [];
   for (const keyPath of matches) {
-    candidates.push({ keyPath, providerName: state.providerName });
+    candidates.push({ keyPath, providerName });
   }
   return {
     kind: "ambiguous",
-    desired: { keyPath: desiredPath, providerName: state.providerName },
+    desired: { keyPath: desiredPath, providerName },
     candidates,
     hint: `Annotate movedFrom: '<old>' on ${desiredPath} to disambiguate.`
   };
@@ -281,7 +189,7 @@ function consumeEnvs(
 }
 
 function buildRename(
-  state: InstanceState,
+  providerName: string,
   fromPath: string,
   toPath: string,
   desiredEnvs: EnvSet,
@@ -300,7 +208,7 @@ function buildRename(
     kind: "rename",
     from: { keyPath: fromPath },
     to: { keyPath: toPath },
-    providerName: state.providerName,
+    providerName,
     envBindings
   };
 }

--- a/packages/cli/src/reconcile/internal/rename.ts
+++ b/packages/cli/src/reconcile/internal/rename.ts
@@ -1,0 +1,306 @@
+import type { AmbiguousAction, RenameAction } from "../plan.js";
+import { envKey, envKeyValue, envSetsEqual, envSorter, type EnvSet } from "./envs.js";
+import type { InstanceState } from "./instance.js";
+
+export interface RenamePlan {
+  renames: RenameAction[];
+  ambiguous: AmbiguousAction[];
+}
+
+interface MatchPools {
+  pureCreates: Map<string, EnvSet>;
+  pureOrphans: Map<string, EnvSet>;
+  consumedOrphanPaths: Map<string, true>;
+  consumedDesiredPaths: Map<string, true>;
+}
+
+export function resolveRenames(
+  state: InstanceState,
+  unmetByPath: Map<string, EnvSet>,
+  orphansByPath: Map<string, EnvSet>
+): RenamePlan {
+  const renames: RenameAction[] = [];
+  const ambiguous: AmbiguousAction[] = [];
+  const pools = buildMatchPools(state, unmetByPath, orphansByPath);
+
+  resolveMovedFromMatches(state, pools, renames, unmetByPath, orphansByPath);
+  resolveShapeMatches(state, pools, renames, ambiguous, unmetByPath, orphansByPath);
+
+  return { renames, ambiguous };
+}
+
+function buildMatchPools(
+  state: InstanceState,
+  unmetByPath: Map<string, EnvSet>,
+  orphansByPath: Map<string, EnvSet>
+): MatchPools {
+  return {
+    pureCreates: collectPureCreates(state, unmetByPath),
+    pureOrphans: collectPureOrphans(state, orphansByPath),
+    consumedOrphanPaths: new Map(),
+    consumedDesiredPaths: new Map()
+  };
+}
+
+// A path is rename-eligible only when *all* of its desired envs are unmet
+// (no overlap with actual storage at this path) and the path itself does
+// not appear in actual storage. Partial-env mismatches stay as Create.
+function collectPureCreates(
+  state: InstanceState,
+  unmetByPath: Map<string, EnvSet>
+): Map<string, EnvSet> {
+  const pureCreates = new Map<string, EnvSet>();
+  for (const [path, envs] of unmetByPath) {
+    const desiredEnvs = state.desired.get(path);
+    if (desiredEnvs === undefined) continue;
+    if (envs.size === desiredEnvs.size && !state.actual.has(path)) {
+      pureCreates.set(path, envs);
+    }
+  }
+  return pureCreates;
+}
+
+// An orphan path is rename-eligible only when it doesn't also appear as
+// desired (e.g. partial overlap stays as Delete).
+function collectPureOrphans(
+  state: InstanceState,
+  orphansByPath: Map<string, EnvSet>
+): Map<string, EnvSet> {
+  const pureOrphans = new Map<string, EnvSet>();
+  for (const [path, envs] of orphansByPath) {
+    if (!state.desired.has(path)) {
+      pureOrphans.set(path, envs);
+    }
+  }
+  return pureOrphans;
+}
+
+// Pass 1: movedFrom forces a match. Consumes the intersection of desired
+// and orphan envs; leftover envs on either side fall through to
+// Create/Delete respectively.
+function resolveMovedFromMatches(
+  state: InstanceState,
+  pools: MatchPools,
+  renames: RenameAction[],
+  unmetByPath: Map<string, EnvSet>,
+  orphansByPath: Map<string, EnvSet>
+): void {
+  for (const [desiredPath, desiredEnvs] of pools.pureCreates) {
+    const movedFrom = state.movedFromByPath.get(desiredPath);
+    if (movedFrom === undefined) continue;
+    tryMovedFromMatch(
+      state,
+      pools,
+      renames,
+      unmetByPath,
+      orphansByPath,
+      desiredPath,
+      desiredEnvs,
+      movedFrom
+    );
+  }
+}
+
+function tryMovedFromMatch(
+  state: InstanceState,
+  pools: MatchPools,
+  renames: RenameAction[],
+  unmetByPath: Map<string, EnvSet>,
+  orphansByPath: Map<string, EnvSet>,
+  desiredPath: string,
+  desiredEnvs: EnvSet,
+  movedFrom: readonly string[]
+): void {
+  for (const candidate of movedFrom) {
+    if (pools.consumedOrphanPaths.has(candidate)) continue;
+    const orphanEnvs = pools.pureOrphans.get(candidate);
+    if (orphanEnvs === undefined) continue;
+    commitRename(
+      state,
+      pools,
+      renames,
+      unmetByPath,
+      orphansByPath,
+      candidate,
+      desiredPath,
+      desiredEnvs,
+      orphanEnvs
+    );
+    return;
+  }
+}
+
+// Pass 2: shape match by envCoverage. Within an instance, providerName and
+// providerParams already match by construction, so envCoverage is the only
+// remaining shape axis.
+function resolveShapeMatches(
+  state: InstanceState,
+  pools: MatchPools,
+  renames: RenameAction[],
+  ambiguous: AmbiguousAction[],
+  unmetByPath: Map<string, EnvSet>,
+  orphansByPath: Map<string, EnvSet>
+): void {
+  for (const [desiredPath, desiredEnvs] of pools.pureCreates) {
+    if (pools.consumedDesiredPaths.has(desiredPath)) continue;
+    resolveSingleShapeMatch(
+      state,
+      pools,
+      renames,
+      ambiguous,
+      unmetByPath,
+      orphansByPath,
+      desiredPath,
+      desiredEnvs
+    );
+  }
+}
+
+function resolveSingleShapeMatch(
+  state: InstanceState,
+  pools: MatchPools,
+  renames: RenameAction[],
+  ambiguous: AmbiguousAction[],
+  unmetByPath: Map<string, EnvSet>,
+  orphansByPath: Map<string, EnvSet>,
+  desiredPath: string,
+  desiredEnvs: EnvSet
+): void {
+  const matches = findShapeMatches(pools, desiredEnvs);
+  if (matches.length === 0) return;
+  if (matches.length === 1) {
+    commitShapeRename(
+      state,
+      pools,
+      renames,
+      unmetByPath,
+      orphansByPath,
+      desiredPath,
+      desiredEnvs,
+      matches[0]
+    );
+    return;
+  }
+  ambiguous.push(buildAmbiguous(state, desiredPath, matches));
+  // Suppress both sides while ambiguity is unresolved — emitting a
+  // Delete on a possibly-renamed path would destroy data.
+  unmetByPath.delete(desiredPath);
+  pools.consumedDesiredPaths.set(desiredPath, true);
+  for (const path of matches) {
+    orphansByPath.delete(path);
+    pools.consumedOrphanPaths.set(path, true);
+  }
+}
+
+function commitShapeRename(
+  state: InstanceState,
+  pools: MatchPools,
+  renames: RenameAction[],
+  unmetByPath: Map<string, EnvSet>,
+  orphansByPath: Map<string, EnvSet>,
+  desiredPath: string,
+  desiredEnvs: EnvSet,
+  candidate: string
+): void {
+  const orphanEnvs = pools.pureOrphans.get(candidate);
+  // pureOrphans was populated for every entry in `matches` by
+  // findShapeMatches, so the lookup is guaranteed to hit. The guard
+  // exists to satisfy strict-null without a non-null assertion.
+  if (orphanEnvs === undefined) return;
+  commitRename(
+    state,
+    pools,
+    renames,
+    unmetByPath,
+    orphansByPath,
+    candidate,
+    desiredPath,
+    desiredEnvs,
+    orphanEnvs
+  );
+}
+
+function findShapeMatches(pools: MatchPools, desiredEnvs: EnvSet): string[] {
+  const matches: string[] = [];
+  for (const [orphanPath, orphanEnvs] of pools.pureOrphans) {
+    if (pools.consumedOrphanPaths.has(orphanPath)) continue;
+    if (envSetsEqual(desiredEnvs, orphanEnvs)) {
+      matches.push(orphanPath);
+    }
+  }
+  return matches;
+}
+
+function commitRename(
+  state: InstanceState,
+  pools: MatchPools,
+  renames: RenameAction[],
+  unmetByPath: Map<string, EnvSet>,
+  orphansByPath: Map<string, EnvSet>,
+  fromPath: string,
+  toPath: string,
+  desiredEnvs: EnvSet,
+  orphanEnvs: EnvSet
+): void {
+  const rename = buildRename(state, fromPath, toPath, desiredEnvs, orphanEnvs);
+  renames.push(rename);
+  consumeEnvs(unmetByPath, toPath, rename.envBindings);
+  consumeEnvs(orphansByPath, fromPath, rename.envBindings);
+  pools.consumedOrphanPaths.set(fromPath, true);
+  pools.consumedDesiredPaths.set(toPath, true);
+}
+
+function buildAmbiguous(
+  state: InstanceState,
+  desiredPath: string,
+  matches: string[]
+): AmbiguousAction {
+  const candidates = [];
+  for (const keyPath of matches) {
+    candidates.push({ keyPath, providerName: state.providerName });
+  }
+  return {
+    kind: "ambiguous",
+    desired: { keyPath: desiredPath, providerName: state.providerName },
+    candidates,
+    hint: `Annotate movedFrom: '<old>' on ${desiredPath} to disambiguate.`
+  };
+}
+
+function consumeEnvs(
+  byPath: Map<string, EnvSet>,
+  path: string,
+  envs: Array<string | undefined>
+): void {
+  const set = byPath.get(path);
+  if (set === undefined) return;
+  for (const env of envs) {
+    set.delete(envKey(env));
+  }
+  if (set.size === 0) byPath.delete(path);
+}
+
+function buildRename(
+  state: InstanceState,
+  fromPath: string,
+  toPath: string,
+  desiredEnvs: EnvSet,
+  orphanEnvs: EnvSet
+): RenameAction {
+  // envBindings is the set of envs the apply step must move bytes for —
+  // i.e. the intersection of "envs the desired side wants" and "envs the
+  // orphan side actually has". Anything else falls out as Create or Delete
+  // on a re-plan after apply.
+  const envBindings: Array<string | undefined> = [];
+  for (const env of desiredEnvs) {
+    if (orphanEnvs.has(env)) envBindings.push(envKeyValue(env));
+  }
+  envBindings.sort(envSorter);
+  return {
+    kind: "rename",
+    from: { keyPath: fromPath },
+    to: { keyPath: toPath },
+    providerName: state.providerName,
+    envBindings
+  };
+}

--- a/packages/cli/src/reconcile/plan.ts
+++ b/packages/cli/src/reconcile/plan.ts
@@ -1,0 +1,45 @@
+export interface KeyLocation {
+  keyPath: string;
+  envName: string | undefined;
+  providerName: string;
+}
+
+export interface CreateAction {
+  kind: "create";
+  keyPath: string;
+  envName: string | undefined;
+  providerName: string;
+}
+
+export interface RenameAction {
+  kind: "rename";
+  from: { keyPath: string };
+  to: { keyPath: string };
+  providerName: string;
+  envBindings: Array<string | undefined>;
+}
+
+export interface DeleteAction {
+  kind: "delete";
+  keyPath: string;
+  envName: string | undefined;
+  providerName: string;
+}
+
+export interface NoOpAction {
+  kind: "noop";
+  keyPath: string;
+  envName: string | undefined;
+  providerName: string;
+}
+
+export interface AmbiguousAction {
+  kind: "ambiguous";
+  desired: { keyPath: string; providerName: string };
+  candidates: Array<{ keyPath: string; providerName: string }>;
+  hint: string;
+}
+
+export type Action = CreateAction | RenameAction | DeleteAction | NoOpAction | AmbiguousAction;
+
+export type Plan = Action[];

--- a/packages/cli/src/reconcile/planner.ts
+++ b/packages/cli/src/reconcile/planner.ts
@@ -1,14 +1,6 @@
 import type { BuiltinProviderRef, NormalizedConfig, NormalizedRecord } from "../config/types.js";
 import type { StoredKey } from "../providers/types.js";
-import type {
-  Action,
-  AmbiguousAction,
-  CreateAction,
-  DeleteAction,
-  NoOpAction,
-  Plan,
-  RenameAction
-} from "./plan.js";
+import type { Action, AmbiguousAction, Plan, RenameAction } from "./plan.js";
 
 export type StorageScope = "envless" | "perEnv";
 

--- a/packages/cli/src/reconcile/planner.ts
+++ b/packages/cli/src/reconcile/planner.ts
@@ -115,8 +115,26 @@ function attachMovedFrom(config: NormalizedConfig, instances: Map<string, Instan
   }
 }
 
+interface InstanceDiff {
+  matched: Map<string, Set<EnvKey>>;
+  unmetByPath: Map<string, Set<EnvKey>>;
+  orphansByPath: Map<string, Set<EnvKey>>;
+}
+
 function planInstance(state: InstanceState): Action[] {
-  const actions: Action[] = [];
+  const diff = diffInstance(state);
+  const renamePlan = resolveRenames(state, diff.unmetByPath, diff.orphansByPath);
+
+  return [
+    ...emitLeafActions(state, "noop", diff.matched),
+    ...renamePlan.renames,
+    ...renamePlan.ambiguous,
+    ...emitLeafActions(state, "create", diff.unmetByPath),
+    ...emitLeafActions(state, "delete", diff.orphansByPath)
+  ];
+}
+
+function diffInstance(state: InstanceState): InstanceDiff {
   const matched = new Map<string, Set<EnvKey>>();
   const unmetByPath = new Map<string, Set<EnvKey>>();
   const orphansByPath = new Map<string, Set<EnvKey>>();
@@ -124,11 +142,8 @@ function planInstance(state: InstanceState): Action[] {
   for (const [path, desiredEnvs] of state.desired) {
     const actualEnvs = state.actual.get(path) ?? new Set<EnvKey>();
     for (const env of desiredEnvs) {
-      if (actualEnvs.has(env)) {
-        upsertSet(matched, path).add(env);
-      } else {
-        upsertSet(unmetByPath, path).add(env);
-      }
+      const bucket = actualEnvs.has(env) ? matched : unmetByPath;
+      upsertSet(bucket, path).add(env);
     }
   }
 
@@ -141,46 +156,27 @@ function planInstance(state: InstanceState): Action[] {
     }
   }
 
-  for (const [path, envs] of matched) {
+  return { matched, unmetByPath, orphansByPath };
+}
+
+type LeafKind = "noop" | "create" | "delete";
+
+function emitLeafActions(
+  state: InstanceState,
+  kind: LeafKind,
+  byPath: Map<string, Set<EnvKey>>
+): Array<NoOpAction | CreateAction | DeleteAction> {
+  const actions: Array<NoOpAction | CreateAction | DeleteAction> = [];
+  for (const [path, envs] of byPath) {
     for (const env of envs) {
-      const action: NoOpAction = {
-        kind: "noop",
+      actions.push({
+        kind,
         keyPath: path,
         envName: envKeyValue(env),
         providerName: state.providerName
-      };
-      actions.push(action);
+      });
     }
   }
-
-  const renamePlan = resolveRenames(state, unmetByPath, orphansByPath);
-  for (const rename of renamePlan.renames) actions.push(rename);
-  for (const ambiguous of renamePlan.ambiguous) actions.push(ambiguous);
-
-  for (const [path, envs] of unmetByPath) {
-    for (const env of envs) {
-      const action: CreateAction = {
-        kind: "create",
-        keyPath: path,
-        envName: envKeyValue(env),
-        providerName: state.providerName
-      };
-      actions.push(action);
-    }
-  }
-
-  for (const [path, envs] of orphansByPath) {
-    for (const env of envs) {
-      const action: DeleteAction = {
-        kind: "delete",
-        keyPath: path,
-        envName: envKeyValue(env),
-        providerName: state.providerName
-      };
-      actions.push(action);
-    }
-  }
-
   return actions;
 }
 

--- a/packages/cli/src/reconcile/planner.ts
+++ b/packages/cli/src/reconcile/planner.ts
@@ -189,6 +189,13 @@ interface RenamePlan {
   ambiguous: AmbiguousAction[];
 }
 
+interface MatchPools {
+  pureCreates: Map<string, Set<EnvKey>>;
+  pureOrphans: Map<string, Set<EnvKey>>;
+  consumedOrphanPaths: Set<string>;
+  consumedDesiredPaths: Set<string>;
+}
+
 function resolveRenames(
   state: InstanceState,
   unmetByPath: Map<string, Set<EnvKey>>,
@@ -196,7 +203,19 @@ function resolveRenames(
 ): RenamePlan {
   const renames: RenameAction[] = [];
   const ambiguous: AmbiguousAction[] = [];
+  const pools = buildMatchPools(state, unmetByPath, orphansByPath);
 
+  resolveMovedFromMatches(state, pools, renames, unmetByPath, orphansByPath);
+  resolveShapeMatches(state, pools, renames, ambiguous, unmetByPath, orphansByPath);
+
+  return { renames, ambiguous };
+}
+
+function buildMatchPools(
+  state: InstanceState,
+  unmetByPath: Map<string, Set<EnvKey>>,
+  orphansByPath: Map<string, Set<EnvKey>>
+): MatchPools {
   // A path is rename-eligible only when *all* of its desired envs are unmet
   // (no overlap with actual storage at this path) and the path itself does
   // not appear in actual storage. Partial-env mismatches stay as Create.
@@ -217,74 +236,134 @@ function resolveRenames(
     }
   }
 
-  const consumedOrphanPaths = new Set<string>();
-  const consumedDesiredPaths = new Set<string>();
+  return {
+    pureCreates,
+    pureOrphans,
+    consumedOrphanPaths: new Set(),
+    consumedDesiredPaths: new Set()
+  };
+}
 
-  // Pass 1: movedFrom forces a match. Consumes the intersection of desired
-  // and orphan envs; leftover envs on either side fall through to
-  // Create/Delete respectively.
-  for (const [desiredPath, desiredEnvs] of pureCreates) {
+// Pass 1: movedFrom forces a match. Consumes the intersection of desired
+// and orphan envs; leftover envs on either side fall through to
+// Create/Delete respectively.
+function resolveMovedFromMatches(
+  state: InstanceState,
+  pools: MatchPools,
+  renames: RenameAction[],
+  unmetByPath: Map<string, Set<EnvKey>>,
+  orphansByPath: Map<string, Set<EnvKey>>
+): void {
+  for (const [desiredPath, desiredEnvs] of pools.pureCreates) {
     const movedFrom = state.movedFromByPath.get(desiredPath);
     if (movedFrom === undefined) continue;
     for (const candidate of movedFrom) {
-      if (consumedOrphanPaths.has(candidate)) continue;
-      const orphanEnvs = pureOrphans.get(candidate);
+      if (pools.consumedOrphanPaths.has(candidate)) continue;
+      const orphanEnvs = pools.pureOrphans.get(candidate);
       if (orphanEnvs === undefined) continue;
-      const rename = buildRename(state, candidate, desiredPath, desiredEnvs, orphanEnvs);
-      renames.push(rename);
-      consumeEnvs(unmetByPath, desiredPath, rename.envBindings);
-      consumeEnvs(orphansByPath, candidate, rename.envBindings);
-      consumedOrphanPaths.add(candidate);
-      consumedDesiredPaths.add(desiredPath);
+      commitRename(
+        state,
+        pools,
+        renames,
+        unmetByPath,
+        orphansByPath,
+        candidate,
+        desiredPath,
+        desiredEnvs,
+        orphanEnvs
+      );
       break;
     }
   }
+}
 
-  // Pass 2: shape match by envCoverage. Within an instance, providerName and
-  // providerParams already match by construction, so envCoverage is the only
-  // remaining shape axis.
-  for (const [desiredPath, desiredEnvs] of pureCreates) {
-    if (consumedDesiredPaths.has(desiredPath)) continue;
+// Pass 2: shape match by envCoverage. Within an instance, providerName and
+// providerParams already match by construction, so envCoverage is the only
+// remaining shape axis.
+function resolveShapeMatches(
+  state: InstanceState,
+  pools: MatchPools,
+  renames: RenameAction[],
+  ambiguous: AmbiguousAction[],
+  unmetByPath: Map<string, Set<EnvKey>>,
+  orphansByPath: Map<string, Set<EnvKey>>
+): void {
+  for (const [desiredPath, desiredEnvs] of pools.pureCreates) {
+    if (pools.consumedDesiredPaths.has(desiredPath)) continue;
 
-    const matches: string[] = [];
-    for (const [orphanPath, orphanEnvs] of pureOrphans) {
-      if (consumedOrphanPaths.has(orphanPath)) continue;
-      if (envSetsEqual(desiredEnvs, orphanEnvs)) {
-        matches.push(orphanPath);
-      }
-    }
-
+    const matches = findShapeMatches(pools, desiredEnvs);
     if (matches.length === 1) {
       const candidate = matches[0];
-      const orphanEnvs = pureOrphans.get(candidate)!;
-      const rename = buildRename(state, candidate, desiredPath, desiredEnvs, orphanEnvs);
-      renames.push(rename);
-      consumeEnvs(unmetByPath, desiredPath, rename.envBindings);
-      consumeEnvs(orphansByPath, candidate, rename.envBindings);
-      consumedOrphanPaths.add(candidate);
-      consumedDesiredPaths.add(desiredPath);
+      const orphanEnvs = pools.pureOrphans.get(candidate)!;
+      commitRename(
+        state,
+        pools,
+        renames,
+        unmetByPath,
+        orphansByPath,
+        candidate,
+        desiredPath,
+        desiredEnvs,
+        orphanEnvs
+      );
     } else if (matches.length > 1) {
-      ambiguous.push({
-        kind: "ambiguous",
-        desired: { keyPath: desiredPath, providerName: state.providerName },
-        candidates: matches.map((path) => ({
-          keyPath: path,
-          providerName: state.providerName
-        })),
-        hint: `Annotate movedFrom: '<old>' on ${desiredPath} to disambiguate.`
-      });
+      ambiguous.push(buildAmbiguous(state, desiredPath, matches));
       // Suppress both sides while ambiguity is unresolved — emitting a
       // Delete on a possibly-renamed path would destroy data.
       unmetByPath.delete(desiredPath);
-      consumedDesiredPaths.add(desiredPath);
+      pools.consumedDesiredPaths.add(desiredPath);
       for (const path of matches) {
         orphansByPath.delete(path);
-        consumedOrphanPaths.add(path);
+        pools.consumedOrphanPaths.add(path);
       }
     }
   }
+}
 
-  return { renames, ambiguous };
+function findShapeMatches(pools: MatchPools, desiredEnvs: Set<EnvKey>): string[] {
+  const matches: string[] = [];
+  for (const [orphanPath, orphanEnvs] of pools.pureOrphans) {
+    if (pools.consumedOrphanPaths.has(orphanPath)) continue;
+    if (envSetsEqual(desiredEnvs, orphanEnvs)) {
+      matches.push(orphanPath);
+    }
+  }
+  return matches;
+}
+
+function commitRename(
+  state: InstanceState,
+  pools: MatchPools,
+  renames: RenameAction[],
+  unmetByPath: Map<string, Set<EnvKey>>,
+  orphansByPath: Map<string, Set<EnvKey>>,
+  fromPath: string,
+  toPath: string,
+  desiredEnvs: Set<EnvKey>,
+  orphanEnvs: Set<EnvKey>
+): void {
+  const rename = buildRename(state, fromPath, toPath, desiredEnvs, orphanEnvs);
+  renames.push(rename);
+  consumeEnvs(unmetByPath, toPath, rename.envBindings);
+  consumeEnvs(orphansByPath, fromPath, rename.envBindings);
+  pools.consumedOrphanPaths.add(fromPath);
+  pools.consumedDesiredPaths.add(toPath);
+}
+
+function buildAmbiguous(
+  state: InstanceState,
+  desiredPath: string,
+  matches: string[]
+): AmbiguousAction {
+  return {
+    kind: "ambiguous",
+    desired: { keyPath: desiredPath, providerName: state.providerName },
+    candidates: matches.map((path) => ({
+      keyPath: path,
+      providerName: state.providerName
+    })),
+    hint: `Annotate movedFrom: '<old>' on ${desiredPath} to disambiguate.`
+  };
 }
 
 function consumeEnvs(

--- a/packages/cli/src/reconcile/planner.ts
+++ b/packages/cli/src/reconcile/planner.ts
@@ -1,16 +1,9 @@
 import type { NormalizedConfig } from "../config/types.js";
 import type { StoredKey } from "../providers/types.js";
-import type {
-  Action,
-  AmbiguousAction,
-  CreateAction,
-  DeleteAction,
-  NoOpAction,
-  Plan,
-  RenameAction
-} from "./plan.js";
-import { envKeyValue, newEnvSet, type EnvSet } from "./internal/envs.js";
-import { buildInstances, upsertEnvSet, type InstanceState } from "./internal/instance.js";
+import type { Action, Plan } from "./plan.js";
+import { diffInstance } from "./internal/diff.js";
+import { appendLeafActions, appendList } from "./internal/emit.js";
+import { buildInstances, type InstanceState } from "./internal/instance.js";
 import { resolveRenames } from "./internal/rename.js";
 
 export type StorageScope = "envless" | "perEnv";
@@ -39,68 +32,4 @@ function appendInstanceActions(actions: Action[], state: InstanceState): void {
   appendList(actions, renamePlan.ambiguous);
   appendLeafActions(actions, state, "create", diff.unmetByPath);
   appendLeafActions(actions, state, "delete", diff.orphansByPath);
-}
-
-interface InstanceDiff {
-  matched: Map<string, EnvSet>;
-  unmetByPath: Map<string, EnvSet>;
-  orphansByPath: Map<string, EnvSet>;
-}
-
-function diffInstance(state: InstanceState): InstanceDiff {
-  const matched = new Map<string, EnvSet>();
-  const unmetByPath = new Map<string, EnvSet>();
-  const orphansByPath = new Map<string, EnvSet>();
-
-  for (const [path, desiredEnvs] of state.desired) {
-    const actualEnvs = state.actual.get(path) ?? newEnvSet();
-    for (const env of desiredEnvs) {
-      const bucket = actualEnvs.has(env) ? matched : unmetByPath;
-      upsertEnvSet(bucket, path).add(env);
-    }
-  }
-
-  for (const [path, actualEnvs] of state.actual) {
-    const desiredEnvs = state.desired.get(path) ?? newEnvSet();
-    for (const env of actualEnvs) {
-      if (!desiredEnvs.has(env)) {
-        upsertEnvSet(orphansByPath, path).add(env);
-      }
-    }
-  }
-
-  return { matched, unmetByPath, orphansByPath };
-}
-
-type LeafKind = "noop" | "create" | "delete";
-
-function appendLeafActions(
-  actions: Action[],
-  state: InstanceState,
-  kind: LeafKind,
-  byPath: Map<string, EnvSet>
-): void {
-  for (const [path, envs] of byPath) {
-    for (const env of envs) {
-      actions.push(buildLeafAction(state, kind, path, env));
-    }
-  }
-}
-
-function buildLeafAction(
-  state: InstanceState,
-  kind: LeafKind,
-  path: string,
-  env: string
-): NoOpAction | CreateAction | DeleteAction {
-  return {
-    kind,
-    keyPath: path,
-    envName: envKeyValue(env),
-    providerName: state.providerName
-  };
-}
-
-function appendList<T extends RenameAction | AmbiguousAction>(actions: Action[], items: T[]): void {
-  for (const item of items) actions.push(item);
 }

--- a/packages/cli/src/reconcile/planner.ts
+++ b/packages/cli/src/reconcile/planner.ts
@@ -22,13 +22,18 @@ interface InstanceState {
   providerName: string;
   providerParams: unknown;
   storageScope: StorageScope;
-  desired: Map<string, Set<EnvKey>>;
-  actual: Map<string, Set<EnvKey>>;
+  desired: Map<string, EnvSet>;
+  actual: Map<string, EnvSet>;
   movedFromByPath: Map<string, string[]>;
 }
 
 type EnvKey = string;
+type EnvSet = Set<EnvKey>;
 const ENVLESS: EnvKey = "\0envless";
+
+function newEnvSet(): EnvSet {
+  return new Set<EnvKey>();
+}
 
 function envKey(envName: string | undefined): EnvKey {
   return envName ?? ENVLESS;
@@ -108,9 +113,9 @@ function attachMovedFrom(config: NormalizedConfig, instances: Map<string, Instan
 }
 
 interface InstanceDiff {
-  matched: Map<string, Set<EnvKey>>;
-  unmetByPath: Map<string, Set<EnvKey>>;
-  orphansByPath: Map<string, Set<EnvKey>>;
+  matched: Map<string, EnvSet>;
+  unmetByPath: Map<string, EnvSet>;
+  orphansByPath: Map<string, EnvSet>;
 }
 
 function planInstance(state: InstanceState): Action[] {
@@ -130,12 +135,12 @@ function appendList<T extends Action>(actions: Action[], items: T[]): void {
 }
 
 function diffInstance(state: InstanceState): InstanceDiff {
-  const matched = new Map<string, Set<EnvKey>>();
-  const unmetByPath = new Map<string, Set<EnvKey>>();
-  const orphansByPath = new Map<string, Set<EnvKey>>();
+  const matched = new Map<string, EnvSet>();
+  const unmetByPath = new Map<string, EnvSet>();
+  const orphansByPath = new Map<string, EnvSet>();
 
   for (const [path, desiredEnvs] of state.desired) {
-    const actualEnvs = state.actual.get(path) ?? new Set<EnvKey>();
+    const actualEnvs = state.actual.get(path) ?? newEnvSet();
     for (const env of desiredEnvs) {
       const bucket = actualEnvs.has(env) ? matched : unmetByPath;
       upsertSet(bucket, path).add(env);
@@ -143,7 +148,7 @@ function diffInstance(state: InstanceState): InstanceDiff {
   }
 
   for (const [path, actualEnvs] of state.actual) {
-    const desiredEnvs = state.desired.get(path) ?? new Set<EnvKey>();
+    const desiredEnvs = state.desired.get(path) ?? newEnvSet();
     for (const env of actualEnvs) {
       if (!desiredEnvs.has(env)) {
         upsertSet(orphansByPath, path).add(env);
@@ -160,7 +165,7 @@ function appendLeafActions(
   actions: Action[],
   state: InstanceState,
   kind: LeafKind,
-  byPath: Map<string, Set<EnvKey>>
+  byPath: Map<string, EnvSet>
 ): void {
   for (const [path, envs] of byPath) {
     for (const env of envs) {
@@ -180,16 +185,16 @@ interface RenamePlan {
 }
 
 interface MatchPools {
-  pureCreates: Map<string, Set<EnvKey>>;
-  pureOrphans: Map<string, Set<EnvKey>>;
+  pureCreates: Map<string, EnvSet>;
+  pureOrphans: Map<string, EnvSet>;
   consumedOrphanPaths: Set<string>;
   consumedDesiredPaths: Set<string>;
 }
 
 function resolveRenames(
   state: InstanceState,
-  unmetByPath: Map<string, Set<EnvKey>>,
-  orphansByPath: Map<string, Set<EnvKey>>
+  unmetByPath: Map<string, EnvSet>,
+  orphansByPath: Map<string, EnvSet>
 ): RenamePlan {
   const renames: RenameAction[] = [];
   const ambiguous: AmbiguousAction[] = [];
@@ -203,15 +208,15 @@ function resolveRenames(
 
 function buildMatchPools(
   state: InstanceState,
-  unmetByPath: Map<string, Set<EnvKey>>,
-  orphansByPath: Map<string, Set<EnvKey>>
+  unmetByPath: Map<string, EnvSet>,
+  orphansByPath: Map<string, EnvSet>
 ): MatchPools {
   // A path is rename-eligible only when *all* of its desired envs are unmet
   // (no overlap with actual storage at this path) and the path itself does
   // not appear in actual storage. Partial-env mismatches stay as Create.
-  const pureCreates = new Map<string, Set<EnvKey>>();
+  const pureCreates = new Map<string, EnvSet>();
   for (const [path, envs] of unmetByPath) {
-    const desiredEnvs = state.desired.get(path) ?? new Set<EnvKey>();
+    const desiredEnvs = state.desired.get(path) ?? newEnvSet();
     if (envs.size === desiredEnvs.size && !state.actual.has(path)) {
       pureCreates.set(path, envs);
     }
@@ -219,7 +224,7 @@ function buildMatchPools(
 
   // An orphan path is rename-eligible only when it doesn't also appear as
   // desired (e.g. partial overlap stays as Delete).
-  const pureOrphans = new Map<string, Set<EnvKey>>();
+  const pureOrphans = new Map<string, EnvSet>();
   for (const [path, envs] of orphansByPath) {
     if (!state.desired.has(path)) {
       pureOrphans.set(path, envs);
@@ -241,8 +246,8 @@ function resolveMovedFromMatches(
   state: InstanceState,
   pools: MatchPools,
   renames: RenameAction[],
-  unmetByPath: Map<string, Set<EnvKey>>,
-  orphansByPath: Map<string, Set<EnvKey>>
+  unmetByPath: Map<string, EnvSet>,
+  orphansByPath: Map<string, EnvSet>
 ): void {
   for (const [desiredPath, desiredEnvs] of pools.pureCreates) {
     const movedFrom = state.movedFromByPath.get(desiredPath);
@@ -275,8 +280,8 @@ function resolveShapeMatches(
   pools: MatchPools,
   renames: RenameAction[],
   ambiguous: AmbiguousAction[],
-  unmetByPath: Map<string, Set<EnvKey>>,
-  orphansByPath: Map<string, Set<EnvKey>>
+  unmetByPath: Map<string, EnvSet>,
+  orphansByPath: Map<string, EnvSet>
 ): void {
   for (const [desiredPath, desiredEnvs] of pools.pureCreates) {
     if (pools.consumedDesiredPaths.has(desiredPath)) continue;
@@ -314,7 +319,7 @@ function resolveShapeMatches(
   }
 }
 
-function findShapeMatches(pools: MatchPools, desiredEnvs: Set<EnvKey>): string[] {
+function findShapeMatches(pools: MatchPools, desiredEnvs: EnvSet): string[] {
   const matches: string[] = [];
   for (const [orphanPath, orphanEnvs] of pools.pureOrphans) {
     if (pools.consumedOrphanPaths.has(orphanPath)) continue;
@@ -329,12 +334,12 @@ function commitRename(
   state: InstanceState,
   pools: MatchPools,
   renames: RenameAction[],
-  unmetByPath: Map<string, Set<EnvKey>>,
-  orphansByPath: Map<string, Set<EnvKey>>,
+  unmetByPath: Map<string, EnvSet>,
+  orphansByPath: Map<string, EnvSet>,
   fromPath: string,
   toPath: string,
-  desiredEnvs: Set<EnvKey>,
-  orphanEnvs: Set<EnvKey>
+  desiredEnvs: EnvSet,
+  orphanEnvs: EnvSet
 ): void {
   const rename = buildRename(state, fromPath, toPath, desiredEnvs, orphanEnvs);
   renames.push(rename);
@@ -362,7 +367,7 @@ function buildAmbiguous(
 }
 
 function consumeEnvs(
-  byPath: Map<string, Set<EnvKey>>,
+  byPath: Map<string, EnvSet>,
   path: string,
   envs: Array<string | undefined>
 ): void {
@@ -378,8 +383,8 @@ function buildRename(
   state: InstanceState,
   fromPath: string,
   toPath: string,
-  desiredEnvs: Set<EnvKey>,
-  orphanEnvs: Set<EnvKey>
+  desiredEnvs: EnvSet,
+  orphanEnvs: EnvSet
 ): RenameAction {
   // envBindings is the set of envs the apply step must move bytes for —
   // i.e. the intersection of "envs the desired side wants" and "envs the
@@ -406,7 +411,7 @@ function envSorter(a: string | undefined, b: string | undefined): number {
   return a.localeCompare(b);
 }
 
-function envSetsEqual(a: Set<EnvKey>, b: Set<EnvKey>): boolean {
+function envSetsEqual(a: EnvSet, b: EnvSet): boolean {
   if (a.size !== b.size) return false;
   for (const value of a) {
     if (!b.has(value)) return false;

--- a/packages/cli/src/reconcile/planner.ts
+++ b/packages/cli/src/reconcile/planner.ts
@@ -1,6 +1,17 @@
-import type { BuiltinProviderRef, NormalizedConfig, NormalizedRecord } from "../config/types.js";
+import type { NormalizedConfig } from "../config/types.js";
 import type { StoredKey } from "../providers/types.js";
-import type { Action, AmbiguousAction, Plan, RenameAction } from "./plan.js";
+import type {
+  Action,
+  AmbiguousAction,
+  CreateAction,
+  DeleteAction,
+  NoOpAction,
+  Plan,
+  RenameAction
+} from "./plan.js";
+import { envKeyValue, newEnvSet, type EnvSet } from "./internal/envs.js";
+import { buildInstances, upsertEnvSet, type InstanceState } from "./internal/instance.js";
+import { resolveRenames } from "./internal/rename.js";
 
 export type StorageScope = "envless" | "perEnv";
 
@@ -11,127 +22,29 @@ export interface ProviderListing {
   keys: StoredKey[];
 }
 
-interface DesiredBinding {
-  keyPath: string;
-  envName: string | undefined;
-  providerName: string;
-  providerParams: unknown;
-}
-
-interface InstanceState {
-  providerName: string;
-  providerParams: unknown;
-  storageScope: StorageScope;
-  desired: Map<string, EnvSet>;
-  actual: Map<string, EnvSet>;
-  movedFromByPath: Map<string, string[]>;
-}
-
-type EnvKey = string;
-type EnvSet = Set<EnvKey>;
-const ENVLESS: EnvKey = "\0envless";
-
-function newEnvSet(): EnvSet {
-  return new Set<EnvKey>();
-}
-
-function envKey(envName: string | undefined): EnvKey {
-  return envName ?? ENVLESS;
-}
-
-function envKeyValue(key: EnvKey): string | undefined {
-  return key === ENVLESS ? undefined : key;
-}
-
 export function planReconciliation(config: NormalizedConfig, listings: ProviderListing[]): Plan {
   const instances = buildInstances(config, listings);
   const actions: Action[] = [];
-
   for (const instance of instances.values()) {
-    actions.push(...planInstance(instance));
+    appendInstanceActions(actions, instance);
   }
-
   return actions;
 }
 
-function buildInstances(
-  config: NormalizedConfig,
-  listings: ProviderListing[]
-): Map<string, InstanceState> {
-  const instances = new Map<string, InstanceState>();
-
-  for (const listing of listings) {
-    const key = instanceKey(listing.providerName, listing.providerParams);
-    const state = ensureInstance(instances, key, listing);
-    for (const stored of listing.keys) {
-      const envs = upsertSet(state.actual, stored.keyPath);
-      envs.add(envKey(stored.envName));
-    }
-  }
-
-  for (const binding of collectDesiredBindings(config)) {
-    const key = instanceKey(binding.providerName, binding.providerParams);
-    let state = instances.get(key);
-    if (state === undefined) {
-      // Desired references an instance with no listing supplied. Treat as
-      // empty actual storage — every binding becomes a candidate Create.
-      state = {
-        providerName: binding.providerName,
-        providerParams: binding.providerParams,
-        // Default to perEnv when we have no listing to tell us otherwise; an
-        // envless-storage instance with zero stored keys behaves the same as
-        // a perEnv instance with zero stored keys (everything is a Create).
-        storageScope: "perEnv",
-        desired: new Map(),
-        actual: new Map(),
-        movedFromByPath: new Map()
-      };
-      instances.set(key, state);
-    }
-    const envSet = upsertSet(state.desired, binding.keyPath);
-    envSet.add(state.storageScope === "envless" ? ENVLESS : envKey(binding.envName));
-  }
-
-  attachMovedFrom(config, instances);
-  return instances;
-}
-
-function attachMovedFrom(config: NormalizedConfig, instances: Map<string, InstanceState>): void {
-  for (const record of config.keys) {
-    if (record.kind !== "secret" || record.movedFrom === undefined) continue;
-    const refs = collectProviderRefs(record);
-    const seenInstances = new Set<string>();
-    for (const ref of refs) {
-      const key = instanceKey(ref.name, ref.options);
-      if (seenInstances.has(key)) continue;
-      seenInstances.add(key);
-      const state = instances.get(key);
-      if (state === undefined) continue;
-      state.movedFromByPath.set(record.path, [...record.movedFrom]);
-    }
-  }
+function appendInstanceActions(actions: Action[], state: InstanceState): void {
+  const diff = diffInstance(state);
+  const renamePlan = resolveRenames(state, diff.unmetByPath, diff.orphansByPath);
+  appendLeafActions(actions, state, "noop", diff.matched);
+  appendList(actions, renamePlan.renames);
+  appendList(actions, renamePlan.ambiguous);
+  appendLeafActions(actions, state, "create", diff.unmetByPath);
+  appendLeafActions(actions, state, "delete", diff.orphansByPath);
 }
 
 interface InstanceDiff {
   matched: Map<string, EnvSet>;
   unmetByPath: Map<string, EnvSet>;
   orphansByPath: Map<string, EnvSet>;
-}
-
-function planInstance(state: InstanceState): Action[] {
-  const diff = diffInstance(state);
-  const renamePlan = resolveRenames(state, diff.unmetByPath, diff.orphansByPath);
-  const actions: Action[] = [];
-  appendLeafActions(actions, state, "noop", diff.matched);
-  appendList(actions, renamePlan.renames);
-  appendList(actions, renamePlan.ambiguous);
-  appendLeafActions(actions, state, "create", diff.unmetByPath);
-  appendLeafActions(actions, state, "delete", diff.orphansByPath);
-  return actions;
-}
-
-function appendList<T extends Action>(actions: Action[], items: T[]): void {
-  for (const item of items) actions.push(item);
 }
 
 function diffInstance(state: InstanceState): InstanceDiff {
@@ -143,7 +56,7 @@ function diffInstance(state: InstanceState): InstanceDiff {
     const actualEnvs = state.actual.get(path) ?? newEnvSet();
     for (const env of desiredEnvs) {
       const bucket = actualEnvs.has(env) ? matched : unmetByPath;
-      upsertSet(bucket, path).add(env);
+      upsertEnvSet(bucket, path).add(env);
     }
   }
 
@@ -151,7 +64,7 @@ function diffInstance(state: InstanceState): InstanceDiff {
     const desiredEnvs = state.desired.get(path) ?? newEnvSet();
     for (const env of actualEnvs) {
       if (!desiredEnvs.has(env)) {
-        upsertSet(orphansByPath, path).add(env);
+        upsertEnvSet(orphansByPath, path).add(env);
       }
     }
   }
@@ -169,351 +82,25 @@ function appendLeafActions(
 ): void {
   for (const [path, envs] of byPath) {
     for (const env of envs) {
-      actions.push({
-        kind,
-        keyPath: path,
-        envName: envKeyValue(env),
-        providerName: state.providerName
-      });
+      actions.push(buildLeafAction(state, kind, path, env));
     }
   }
 }
 
-interface RenamePlan {
-  renames: RenameAction[];
-  ambiguous: AmbiguousAction[];
-}
-
-interface MatchPools {
-  pureCreates: Map<string, EnvSet>;
-  pureOrphans: Map<string, EnvSet>;
-  consumedOrphanPaths: Set<string>;
-  consumedDesiredPaths: Set<string>;
-}
-
-function resolveRenames(
+function buildLeafAction(
   state: InstanceState,
-  unmetByPath: Map<string, EnvSet>,
-  orphansByPath: Map<string, EnvSet>
-): RenamePlan {
-  const renames: RenameAction[] = [];
-  const ambiguous: AmbiguousAction[] = [];
-  const pools = buildMatchPools(state, unmetByPath, orphansByPath);
-
-  resolveMovedFromMatches(state, pools, renames, unmetByPath, orphansByPath);
-  resolveShapeMatches(state, pools, renames, ambiguous, unmetByPath, orphansByPath);
-
-  return { renames, ambiguous };
-}
-
-function buildMatchPools(
-  state: InstanceState,
-  unmetByPath: Map<string, EnvSet>,
-  orphansByPath: Map<string, EnvSet>
-): MatchPools {
-  // A path is rename-eligible only when *all* of its desired envs are unmet
-  // (no overlap with actual storage at this path) and the path itself does
-  // not appear in actual storage. Partial-env mismatches stay as Create.
-  const pureCreates = new Map<string, EnvSet>();
-  for (const [path, envs] of unmetByPath) {
-    const desiredEnvs = state.desired.get(path) ?? newEnvSet();
-    if (envs.size === desiredEnvs.size && !state.actual.has(path)) {
-      pureCreates.set(path, envs);
-    }
-  }
-
-  // An orphan path is rename-eligible only when it doesn't also appear as
-  // desired (e.g. partial overlap stays as Delete).
-  const pureOrphans = new Map<string, EnvSet>();
-  for (const [path, envs] of orphansByPath) {
-    if (!state.desired.has(path)) {
-      pureOrphans.set(path, envs);
-    }
-  }
-
-  return {
-    pureCreates,
-    pureOrphans,
-    consumedOrphanPaths: new Set(),
-    consumedDesiredPaths: new Set()
-  };
-}
-
-// Pass 1: movedFrom forces a match. Consumes the intersection of desired
-// and orphan envs; leftover envs on either side fall through to
-// Create/Delete respectively.
-function resolveMovedFromMatches(
-  state: InstanceState,
-  pools: MatchPools,
-  renames: RenameAction[],
-  unmetByPath: Map<string, EnvSet>,
-  orphansByPath: Map<string, EnvSet>
-): void {
-  for (const [desiredPath, desiredEnvs] of pools.pureCreates) {
-    const movedFrom = state.movedFromByPath.get(desiredPath);
-    if (movedFrom === undefined) continue;
-    for (const candidate of movedFrom) {
-      if (pools.consumedOrphanPaths.has(candidate)) continue;
-      const orphanEnvs = pools.pureOrphans.get(candidate);
-      if (orphanEnvs === undefined) continue;
-      commitRename(
-        state,
-        pools,
-        renames,
-        unmetByPath,
-        orphansByPath,
-        candidate,
-        desiredPath,
-        desiredEnvs,
-        orphanEnvs
-      );
-      break;
-    }
-  }
-}
-
-// Pass 2: shape match by envCoverage. Within an instance, providerName and
-// providerParams already match by construction, so envCoverage is the only
-// remaining shape axis.
-function resolveShapeMatches(
-  state: InstanceState,
-  pools: MatchPools,
-  renames: RenameAction[],
-  ambiguous: AmbiguousAction[],
-  unmetByPath: Map<string, EnvSet>,
-  orphansByPath: Map<string, EnvSet>
-): void {
-  for (const [desiredPath, desiredEnvs] of pools.pureCreates) {
-    if (pools.consumedDesiredPaths.has(desiredPath)) continue;
-
-    const matches = findShapeMatches(pools, desiredEnvs);
-    if (matches.length === 1) {
-      const candidate = matches[0];
-      const orphanEnvs = pools.pureOrphans.get(candidate);
-      // pureOrphans was populated for every entry in `matches` by
-      // findShapeMatches, so the lookup is guaranteed to hit. The guard
-      // exists to satisfy strict-null without a non-null assertion.
-      if (orphanEnvs === undefined) continue;
-      commitRename(
-        state,
-        pools,
-        renames,
-        unmetByPath,
-        orphansByPath,
-        candidate,
-        desiredPath,
-        desiredEnvs,
-        orphanEnvs
-      );
-    } else if (matches.length > 1) {
-      ambiguous.push(buildAmbiguous(state, desiredPath, matches));
-      // Suppress both sides while ambiguity is unresolved — emitting a
-      // Delete on a possibly-renamed path would destroy data.
-      unmetByPath.delete(desiredPath);
-      pools.consumedDesiredPaths.add(desiredPath);
-      for (const path of matches) {
-        orphansByPath.delete(path);
-        pools.consumedOrphanPaths.add(path);
-      }
-    }
-  }
-}
-
-function findShapeMatches(pools: MatchPools, desiredEnvs: EnvSet): string[] {
-  const matches: string[] = [];
-  for (const [orphanPath, orphanEnvs] of pools.pureOrphans) {
-    if (pools.consumedOrphanPaths.has(orphanPath)) continue;
-    if (envSetsEqual(desiredEnvs, orphanEnvs)) {
-      matches.push(orphanPath);
-    }
-  }
-  return matches;
-}
-
-function commitRename(
-  state: InstanceState,
-  pools: MatchPools,
-  renames: RenameAction[],
-  unmetByPath: Map<string, EnvSet>,
-  orphansByPath: Map<string, EnvSet>,
-  fromPath: string,
-  toPath: string,
-  desiredEnvs: EnvSet,
-  orphanEnvs: EnvSet
-): void {
-  const rename = buildRename(state, fromPath, toPath, desiredEnvs, orphanEnvs);
-  renames.push(rename);
-  consumeEnvs(unmetByPath, toPath, rename.envBindings);
-  consumeEnvs(orphansByPath, fromPath, rename.envBindings);
-  pools.consumedOrphanPaths.add(fromPath);
-  pools.consumedDesiredPaths.add(toPath);
-}
-
-function buildAmbiguous(
-  state: InstanceState,
-  desiredPath: string,
-  matches: string[]
-): AmbiguousAction {
-  const candidates = [];
-  for (const keyPath of matches) {
-    candidates.push({ keyPath, providerName: state.providerName });
-  }
-  return {
-    kind: "ambiguous",
-    desired: { keyPath: desiredPath, providerName: state.providerName },
-    candidates,
-    hint: `Annotate movedFrom: '<old>' on ${desiredPath} to disambiguate.`
-  };
-}
-
-function consumeEnvs(
-  byPath: Map<string, EnvSet>,
+  kind: LeafKind,
   path: string,
-  envs: Array<string | undefined>
-): void {
-  const set = byPath.get(path);
-  if (set === undefined) return;
-  for (const env of envs) {
-    set.delete(envKey(env));
-  }
-  if (set.size === 0) byPath.delete(path);
-}
-
-function buildRename(
-  state: InstanceState,
-  fromPath: string,
-  toPath: string,
-  desiredEnvs: EnvSet,
-  orphanEnvs: EnvSet
-): RenameAction {
-  // envBindings is the set of envs the apply step must move bytes for —
-  // i.e. the intersection of "envs the desired side wants" and "envs the
-  // orphan side actually has". Anything else falls out as Create or Delete
-  // on a re-plan after apply.
-  const envBindings: Array<string | undefined> = [];
-  for (const env of desiredEnvs) {
-    if (orphanEnvs.has(env)) envBindings.push(envKeyValue(env));
-  }
-  envBindings.sort(envSorter);
+  env: string
+): NoOpAction | CreateAction | DeleteAction {
   return {
-    kind: "rename",
-    from: { keyPath: fromPath },
-    to: { keyPath: toPath },
-    providerName: state.providerName,
-    envBindings
+    kind,
+    keyPath: path,
+    envName: envKeyValue(env),
+    providerName: state.providerName
   };
 }
 
-function envSorter(a: string | undefined, b: string | undefined): number {
-  if (a === b) return 0;
-  if (a === undefined) return -1;
-  if (b === undefined) return 1;
-  return a.localeCompare(b);
-}
-
-function envSetsEqual(a: EnvSet, b: EnvSet): boolean {
-  if (a.size !== b.size) return false;
-  for (const value of a) {
-    if (!b.has(value)) return false;
-  }
-  return true;
-}
-
-function collectDesiredBindings(config: NormalizedConfig): DesiredBinding[] {
-  const bindings: DesiredBinding[] = [];
-
-  for (const record of config.keys) {
-    if (record.kind !== "secret") continue;
-
-    const envless = record.value;
-    const perEnv = record.values ?? {};
-
-    if (envless !== undefined) {
-      const envsCovered = envsNotInValues(config.envs, perEnv);
-      // value/default applies as a fallback for every env not overridden in
-      // values. For envless storage providers this collapses to a single
-      // entry; the planner handles the collapse via storageScope.
-      for (const env of envsCovered) {
-        bindings.push({
-          keyPath: record.path,
-          envName: env,
-          providerName: envless.name,
-          providerParams: envless.options
-        });
-      }
-      // If perEnv is empty and config.envs is empty (impossible per schema)
-      // we'd miss the binding entirely — schema guarantees envs.length >= 1.
-    }
-
-    for (const [envName, ref] of Object.entries(perEnv)) {
-      bindings.push({
-        keyPath: record.path,
-        envName,
-        providerName: ref.name,
-        providerParams: ref.options
-      });
-    }
-  }
-
-  return bindings;
-}
-
-function envsNotInValues(
-  envs: readonly string[],
-  perEnv: Record<string, BuiltinProviderRef>
-): string[] {
-  const overridden = new Set(Object.keys(perEnv));
-  return envs.filter((env) => !overridden.has(env));
-}
-
-function collectProviderRefs(record: NormalizedRecord): BuiltinProviderRef[] {
-  if (record.kind !== "secret") return [];
-  const refs: BuiltinProviderRef[] = [];
-  if (record.value !== undefined) refs.push(record.value);
-  for (const ref of Object.values(record.values ?? {})) refs.push(ref);
-  return refs;
-}
-
-function instanceKey(providerName: string, providerParams: unknown): string {
-  return `${providerName}:${stableStringify(providerParams)}`;
-}
-
-function stableStringify(value: unknown): string {
-  if (value === null || typeof value !== "object") return JSON.stringify(value);
-  if (Array.isArray(value)) {
-    return `[${value.map(stableStringify).join(",")}]`;
-  }
-  const entries = Object.entries(value as Record<string, unknown>).sort(([a], [b]) =>
-    a.localeCompare(b)
-  );
-  return `{${entries.map(([k, v]) => `${JSON.stringify(k)}:${stableStringify(v)}`).join(",")}}`;
-}
-
-function ensureInstance(
-  instances: Map<string, InstanceState>,
-  key: string,
-  listing: ProviderListing
-): InstanceState {
-  let state = instances.get(key);
-  if (state === undefined) {
-    state = {
-      providerName: listing.providerName,
-      providerParams: listing.providerParams,
-      storageScope: listing.storageScope,
-      desired: new Map(),
-      actual: new Map(),
-      movedFromByPath: new Map()
-    };
-    instances.set(key, state);
-  }
-  return state;
-}
-
-function upsertSet<K, V>(map: Map<K, Set<V>>, key: K): Set<V> {
-  let set = map.get(key);
-  if (set === undefined) {
-    set = new Set<V>();
-    map.set(key, set);
-  }
-  return set;
+function appendList<T extends RenameAction | AmbiguousAction>(actions: Action[], items: T[]): void {
+  for (const item of items) actions.push(item);
 }

--- a/packages/cli/src/reconcile/planner.ts
+++ b/packages/cli/src/reconcile/planner.ts
@@ -124,14 +124,17 @@ interface InstanceDiff {
 function planInstance(state: InstanceState): Action[] {
   const diff = diffInstance(state);
   const renamePlan = resolveRenames(state, diff.unmetByPath, diff.orphansByPath);
+  const actions: Action[] = [];
+  appendLeafActions(actions, state, "noop", diff.matched);
+  appendList(actions, renamePlan.renames);
+  appendList(actions, renamePlan.ambiguous);
+  appendLeafActions(actions, state, "create", diff.unmetByPath);
+  appendLeafActions(actions, state, "delete", diff.orphansByPath);
+  return actions;
+}
 
-  return [
-    ...emitLeafActions(state, "noop", diff.matched),
-    ...renamePlan.renames,
-    ...renamePlan.ambiguous,
-    ...emitLeafActions(state, "create", diff.unmetByPath),
-    ...emitLeafActions(state, "delete", diff.orphansByPath)
-  ];
+function appendList<T extends Action>(actions: Action[], items: T[]): void {
+  for (const item of items) actions.push(item);
 }
 
 function diffInstance(state: InstanceState): InstanceDiff {
@@ -161,12 +164,12 @@ function diffInstance(state: InstanceState): InstanceDiff {
 
 type LeafKind = "noop" | "create" | "delete";
 
-function emitLeafActions(
+function appendLeafActions(
+  actions: Action[],
   state: InstanceState,
   kind: LeafKind,
   byPath: Map<string, Set<EnvKey>>
-): Array<NoOpAction | CreateAction | DeleteAction> {
-  const actions: Array<NoOpAction | CreateAction | DeleteAction> = [];
+): void {
   for (const [path, envs] of byPath) {
     for (const env of envs) {
       actions.push({
@@ -177,7 +180,6 @@ function emitLeafActions(
       });
     }
   }
-  return actions;
 }
 
 interface RenamePlan {
@@ -355,13 +357,14 @@ function buildAmbiguous(
   desiredPath: string,
   matches: string[]
 ): AmbiguousAction {
+  const candidates = [];
+  for (const keyPath of matches) {
+    candidates.push({ keyPath, providerName: state.providerName });
+  }
   return {
     kind: "ambiguous",
     desired: { keyPath: desiredPath, providerName: state.providerName },
-    candidates: matches.map((path) => ({
-      keyPath: path,
-      providerName: state.providerName
-    })),
+    candidates,
     hint: `Annotate movedFrom: '<old>' on ${desiredPath} to disambiguate.`
   };
 }

--- a/packages/cli/src/reconcile/planner.ts
+++ b/packages/cli/src/reconcile/planner.ts
@@ -290,7 +290,11 @@ function resolveShapeMatches(
     const matches = findShapeMatches(pools, desiredEnvs);
     if (matches.length === 1) {
       const candidate = matches[0];
-      const orphanEnvs = pools.pureOrphans.get(candidate)!;
+      const orphanEnvs = pools.pureOrphans.get(candidate);
+      // pureOrphans was populated for every entry in `matches` by
+      // findShapeMatches, so the lookup is guaranteed to hit. The guard
+      // exists to satisfy strict-null without a non-null assertion.
+      if (orphanEnvs === undefined) continue;
       commitRename(
         state,
         pools,

--- a/packages/cli/src/reconcile/planner.ts
+++ b/packages/cli/src/reconcile/planner.ts
@@ -1,0 +1,440 @@
+import type { BuiltinProviderRef, NormalizedConfig, NormalizedRecord } from "../config/types.js";
+import type { StoredKey } from "../providers/types.js";
+import type {
+  Action,
+  AmbiguousAction,
+  CreateAction,
+  DeleteAction,
+  NoOpAction,
+  Plan,
+  RenameAction
+} from "./plan.js";
+
+export type StorageScope = "envless" | "perEnv";
+
+export interface ProviderListing {
+  providerName: string;
+  providerParams: unknown;
+  storageScope: StorageScope;
+  keys: StoredKey[];
+}
+
+interface DesiredBinding {
+  keyPath: string;
+  envName: string | undefined;
+  providerName: string;
+  providerParams: unknown;
+}
+
+interface InstanceState {
+  providerName: string;
+  providerParams: unknown;
+  storageScope: StorageScope;
+  desired: Map<string, Set<EnvKey>>;
+  actual: Map<string, Set<EnvKey>>;
+  movedFromByPath: Map<string, string[]>;
+}
+
+type EnvKey = string;
+const ENVLESS: EnvKey = "\0envless";
+
+function envKey(envName: string | undefined): EnvKey {
+  return envName ?? ENVLESS;
+}
+
+function envKeyValue(key: EnvKey): string | undefined {
+  return key === ENVLESS ? undefined : key;
+}
+
+export function planReconciliation(config: NormalizedConfig, listings: ProviderListing[]): Plan {
+  const instances = buildInstances(config, listings);
+  const actions: Action[] = [];
+
+  for (const instance of instances.values()) {
+    actions.push(...planInstance(instance));
+  }
+
+  return actions;
+}
+
+function buildInstances(
+  config: NormalizedConfig,
+  listings: ProviderListing[]
+): Map<string, InstanceState> {
+  const instances = new Map<string, InstanceState>();
+
+  for (const listing of listings) {
+    const key = instanceKey(listing.providerName, listing.providerParams);
+    const state = ensureInstance(instances, key, listing);
+    for (const stored of listing.keys) {
+      const envs = upsertSet(state.actual, stored.keyPath);
+      envs.add(envKey(stored.envName));
+    }
+  }
+
+  for (const binding of collectDesiredBindings(config)) {
+    const key = instanceKey(binding.providerName, binding.providerParams);
+    let state = instances.get(key);
+    if (state === undefined) {
+      // Desired references an instance with no listing supplied. Treat as
+      // empty actual storage — every binding becomes a candidate Create.
+      state = {
+        providerName: binding.providerName,
+        providerParams: binding.providerParams,
+        // Default to perEnv when we have no listing to tell us otherwise; an
+        // envless-storage instance with zero stored keys behaves the same as
+        // a perEnv instance with zero stored keys (everything is a Create).
+        storageScope: "perEnv",
+        desired: new Map(),
+        actual: new Map(),
+        movedFromByPath: new Map()
+      };
+      instances.set(key, state);
+    }
+    const envSet = upsertSet(state.desired, binding.keyPath);
+    envSet.add(state.storageScope === "envless" ? ENVLESS : envKey(binding.envName));
+  }
+
+  attachMovedFrom(config, instances);
+  return instances;
+}
+
+function attachMovedFrom(config: NormalizedConfig, instances: Map<string, InstanceState>): void {
+  for (const record of config.keys) {
+    if (record.kind !== "secret" || record.movedFrom === undefined) continue;
+    const refs = collectProviderRefs(record);
+    const seenInstances = new Set<string>();
+    for (const ref of refs) {
+      const key = instanceKey(ref.name, ref.options);
+      if (seenInstances.has(key)) continue;
+      seenInstances.add(key);
+      const state = instances.get(key);
+      if (state === undefined) continue;
+      state.movedFromByPath.set(record.path, [...record.movedFrom]);
+    }
+  }
+}
+
+function planInstance(state: InstanceState): Action[] {
+  const actions: Action[] = [];
+  const matched = new Map<string, Set<EnvKey>>();
+  const unmetByPath = new Map<string, Set<EnvKey>>();
+  const orphansByPath = new Map<string, Set<EnvKey>>();
+
+  for (const [path, desiredEnvs] of state.desired) {
+    const actualEnvs = state.actual.get(path) ?? new Set<EnvKey>();
+    for (const env of desiredEnvs) {
+      if (actualEnvs.has(env)) {
+        upsertSet(matched, path).add(env);
+      } else {
+        upsertSet(unmetByPath, path).add(env);
+      }
+    }
+  }
+
+  for (const [path, actualEnvs] of state.actual) {
+    const desiredEnvs = state.desired.get(path) ?? new Set<EnvKey>();
+    for (const env of actualEnvs) {
+      if (!desiredEnvs.has(env)) {
+        upsertSet(orphansByPath, path).add(env);
+      }
+    }
+  }
+
+  for (const [path, envs] of matched) {
+    for (const env of envs) {
+      const action: NoOpAction = {
+        kind: "noop",
+        keyPath: path,
+        envName: envKeyValue(env),
+        providerName: state.providerName
+      };
+      actions.push(action);
+    }
+  }
+
+  const renamePlan = resolveRenames(state, unmetByPath, orphansByPath);
+  for (const rename of renamePlan.renames) actions.push(rename);
+  for (const ambiguous of renamePlan.ambiguous) actions.push(ambiguous);
+
+  for (const [path, envs] of unmetByPath) {
+    for (const env of envs) {
+      const action: CreateAction = {
+        kind: "create",
+        keyPath: path,
+        envName: envKeyValue(env),
+        providerName: state.providerName
+      };
+      actions.push(action);
+    }
+  }
+
+  for (const [path, envs] of orphansByPath) {
+    for (const env of envs) {
+      const action: DeleteAction = {
+        kind: "delete",
+        keyPath: path,
+        envName: envKeyValue(env),
+        providerName: state.providerName
+      };
+      actions.push(action);
+    }
+  }
+
+  return actions;
+}
+
+interface RenamePlan {
+  renames: RenameAction[];
+  ambiguous: AmbiguousAction[];
+}
+
+function resolveRenames(
+  state: InstanceState,
+  unmetByPath: Map<string, Set<EnvKey>>,
+  orphansByPath: Map<string, Set<EnvKey>>
+): RenamePlan {
+  const renames: RenameAction[] = [];
+  const ambiguous: AmbiguousAction[] = [];
+
+  // A path is rename-eligible only when *all* of its desired envs are unmet
+  // (no overlap with actual storage at this path) and the path itself does
+  // not appear in actual storage. Partial-env mismatches stay as Create.
+  const pureCreates = new Map<string, Set<EnvKey>>();
+  for (const [path, envs] of unmetByPath) {
+    const desiredEnvs = state.desired.get(path) ?? new Set<EnvKey>();
+    if (envs.size === desiredEnvs.size && !state.actual.has(path)) {
+      pureCreates.set(path, envs);
+    }
+  }
+
+  // An orphan path is rename-eligible only when it doesn't also appear as
+  // desired (e.g. partial overlap stays as Delete).
+  const pureOrphans = new Map<string, Set<EnvKey>>();
+  for (const [path, envs] of orphansByPath) {
+    if (!state.desired.has(path)) {
+      pureOrphans.set(path, envs);
+    }
+  }
+
+  const consumedOrphanPaths = new Set<string>();
+  const consumedDesiredPaths = new Set<string>();
+
+  // Pass 1: movedFrom forces a match. Consumes the intersection of desired
+  // and orphan envs; leftover envs on either side fall through to
+  // Create/Delete respectively.
+  for (const [desiredPath, desiredEnvs] of pureCreates) {
+    const movedFrom = state.movedFromByPath.get(desiredPath);
+    if (movedFrom === undefined) continue;
+    for (const candidate of movedFrom) {
+      if (consumedOrphanPaths.has(candidate)) continue;
+      const orphanEnvs = pureOrphans.get(candidate);
+      if (orphanEnvs === undefined) continue;
+      const rename = buildRename(state, candidate, desiredPath, desiredEnvs, orphanEnvs);
+      renames.push(rename);
+      consumeEnvs(unmetByPath, desiredPath, rename.envBindings);
+      consumeEnvs(orphansByPath, candidate, rename.envBindings);
+      consumedOrphanPaths.add(candidate);
+      consumedDesiredPaths.add(desiredPath);
+      break;
+    }
+  }
+
+  // Pass 2: shape match by envCoverage. Within an instance, providerName and
+  // providerParams already match by construction, so envCoverage is the only
+  // remaining shape axis.
+  for (const [desiredPath, desiredEnvs] of pureCreates) {
+    if (consumedDesiredPaths.has(desiredPath)) continue;
+
+    const matches: string[] = [];
+    for (const [orphanPath, orphanEnvs] of pureOrphans) {
+      if (consumedOrphanPaths.has(orphanPath)) continue;
+      if (envSetsEqual(desiredEnvs, orphanEnvs)) {
+        matches.push(orphanPath);
+      }
+    }
+
+    if (matches.length === 1) {
+      const candidate = matches[0];
+      const orphanEnvs = pureOrphans.get(candidate)!;
+      const rename = buildRename(state, candidate, desiredPath, desiredEnvs, orphanEnvs);
+      renames.push(rename);
+      consumeEnvs(unmetByPath, desiredPath, rename.envBindings);
+      consumeEnvs(orphansByPath, candidate, rename.envBindings);
+      consumedOrphanPaths.add(candidate);
+      consumedDesiredPaths.add(desiredPath);
+    } else if (matches.length > 1) {
+      ambiguous.push({
+        kind: "ambiguous",
+        desired: { keyPath: desiredPath, providerName: state.providerName },
+        candidates: matches.map((path) => ({
+          keyPath: path,
+          providerName: state.providerName
+        })),
+        hint: `Annotate movedFrom: '<old>' on ${desiredPath} to disambiguate.`
+      });
+      // Suppress both sides while ambiguity is unresolved — emitting a
+      // Delete on a possibly-renamed path would destroy data.
+      unmetByPath.delete(desiredPath);
+      consumedDesiredPaths.add(desiredPath);
+      for (const path of matches) {
+        orphansByPath.delete(path);
+        consumedOrphanPaths.add(path);
+      }
+    }
+  }
+
+  return { renames, ambiguous };
+}
+
+function consumeEnvs(
+  byPath: Map<string, Set<EnvKey>>,
+  path: string,
+  envs: Array<string | undefined>
+): void {
+  const set = byPath.get(path);
+  if (set === undefined) return;
+  for (const env of envs) {
+    set.delete(envKey(env));
+  }
+  if (set.size === 0) byPath.delete(path);
+}
+
+function buildRename(
+  state: InstanceState,
+  fromPath: string,
+  toPath: string,
+  desiredEnvs: Set<EnvKey>,
+  orphanEnvs: Set<EnvKey>
+): RenameAction {
+  // envBindings is the set of envs the apply step must move bytes for —
+  // i.e. the intersection of "envs the desired side wants" and "envs the
+  // orphan side actually has". Anything else falls out as Create or Delete
+  // on a re-plan after apply.
+  const envBindings: Array<string | undefined> = [];
+  for (const env of desiredEnvs) {
+    if (orphanEnvs.has(env)) envBindings.push(envKeyValue(env));
+  }
+  envBindings.sort(envSorter);
+  return {
+    kind: "rename",
+    from: { keyPath: fromPath },
+    to: { keyPath: toPath },
+    providerName: state.providerName,
+    envBindings
+  };
+}
+
+function envSorter(a: string | undefined, b: string | undefined): number {
+  if (a === b) return 0;
+  if (a === undefined) return -1;
+  if (b === undefined) return 1;
+  return a.localeCompare(b);
+}
+
+function envSetsEqual(a: Set<EnvKey>, b: Set<EnvKey>): boolean {
+  if (a.size !== b.size) return false;
+  for (const value of a) {
+    if (!b.has(value)) return false;
+  }
+  return true;
+}
+
+function collectDesiredBindings(config: NormalizedConfig): DesiredBinding[] {
+  const bindings: DesiredBinding[] = [];
+
+  for (const record of config.keys) {
+    if (record.kind !== "secret") continue;
+
+    const envless = record.value;
+    const perEnv = record.values ?? {};
+
+    if (envless !== undefined) {
+      const envsCovered = envsNotInValues(config.envs, perEnv);
+      // value/default applies as a fallback for every env not overridden in
+      // values. For envless storage providers this collapses to a single
+      // entry; the planner handles the collapse via storageScope.
+      for (const env of envsCovered) {
+        bindings.push({
+          keyPath: record.path,
+          envName: env,
+          providerName: envless.name,
+          providerParams: envless.options
+        });
+      }
+      // If perEnv is empty and config.envs is empty (impossible per schema)
+      // we'd miss the binding entirely — schema guarantees envs.length >= 1.
+    }
+
+    for (const [envName, ref] of Object.entries(perEnv)) {
+      bindings.push({
+        keyPath: record.path,
+        envName,
+        providerName: ref.name,
+        providerParams: ref.options
+      });
+    }
+  }
+
+  return bindings;
+}
+
+function envsNotInValues(
+  envs: readonly string[],
+  perEnv: Record<string, BuiltinProviderRef>
+): string[] {
+  const overridden = new Set(Object.keys(perEnv));
+  return envs.filter((env) => !overridden.has(env));
+}
+
+function collectProviderRefs(record: NormalizedRecord): BuiltinProviderRef[] {
+  if (record.kind !== "secret") return [];
+  const refs: BuiltinProviderRef[] = [];
+  if (record.value !== undefined) refs.push(record.value);
+  for (const ref of Object.values(record.values ?? {})) refs.push(ref);
+  return refs;
+}
+
+function instanceKey(providerName: string, providerParams: unknown): string {
+  return `${providerName}:${stableStringify(providerParams)}`;
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(",")}]`;
+  }
+  const entries = Object.entries(value as Record<string, unknown>).sort(([a], [b]) =>
+    a.localeCompare(b)
+  );
+  return `{${entries.map(([k, v]) => `${JSON.stringify(k)}:${stableStringify(v)}`).join(",")}}`;
+}
+
+function ensureInstance(
+  instances: Map<string, InstanceState>,
+  key: string,
+  listing: ProviderListing
+): InstanceState {
+  let state = instances.get(key);
+  if (state === undefined) {
+    state = {
+      providerName: listing.providerName,
+      providerParams: listing.providerParams,
+      storageScope: listing.storageScope,
+      desired: new Map(),
+      actual: new Map(),
+      movedFromByPath: new Map()
+    };
+    instances.set(key, state);
+  }
+  return state;
+}
+
+function upsertSet<K, V>(map: Map<K, Set<V>>, key: K): Set<V> {
+  let set = map.get(key);
+  if (set === undefined) {
+    set = new Set<V>();
+    map.set(key, set);
+  }
+  return set;
+}

--- a/packages/cli/test/unit/config.test.ts
+++ b/packages/cli/test/unit/config.test.ts
@@ -259,6 +259,56 @@ describe("config factories and validation", () => {
     expect(normalized.keys.map((key) => key.path)).toEqual(["token", "url"]);
   });
 
+  it("normalizes movedFrom into a string array on config and secret records", () => {
+    const normalized = normalizeConfig(
+      defineConfig({
+        name: "test",
+        envs: ["dev"],
+        keys: {
+          host: config({ value: "localhost", movedFrom: "old/host" }),
+          token: secret({
+            value: gcp({ project: "my-project" }),
+            movedFrom: ["very-old/token", "old/token"]
+          })
+        }
+      })
+    );
+
+    const host = normalized.keys.find((k) => k.path === "host");
+    const token = normalized.keys.find((k) => k.path === "token");
+    expect(host?.movedFrom).toEqual(["old/host"]);
+    expect(token?.movedFrom).toEqual(["very-old/token", "old/token"]);
+  });
+
+  it("rejects movedFrom that collides with a declared key path", () => {
+    expect(() =>
+      normalizeConfig(
+        defineConfig({
+          name: "test",
+          envs: ["dev"],
+          keys: {
+            "old/host": "localhost",
+            host: config({ value: "localhost", movedFrom: "old/host" })
+          }
+        })
+      )
+    ).toThrow('movedFrom "old/host" collides with a declared key path');
+  });
+
+  it("rejects movedFrom that references the record's own path", () => {
+    expect(() =>
+      normalizeConfig(
+        defineConfig({
+          name: "test",
+          envs: ["dev"],
+          keys: {
+            host: config({ value: "localhost", movedFrom: "host" })
+          }
+        })
+      )
+    ).toThrow("movedFrom cannot reference itself");
+  });
+
   it("validates app mapping references against flattened keys", () => {
     const normalized = normalizeConfig(
       defineConfig({

--- a/packages/cli/test/unit/reconcile/planner.test.ts
+++ b/packages/cli/test/unit/reconcile/planner.test.ts
@@ -37,7 +37,8 @@ function gcpListing(
 function actionsByKind(actions: Action[]): Record<string, Action[]> {
   const out: Record<string, Action[]> = {};
   for (const a of actions) {
-    (out[a.kind] ??= []).push(a);
+    if (out[a.kind] === undefined) out[a.kind] = [];
+    out[a.kind].push(a);
   }
   return out;
 }

--- a/packages/cli/test/unit/reconcile/planner.test.ts
+++ b/packages/cli/test/unit/reconcile/planner.test.ts
@@ -1,0 +1,346 @@
+import { describe, expect, it } from "vitest";
+import {
+  age,
+  config,
+  defineConfig,
+  gcp,
+  normalizeConfig,
+  secret
+} from "../../../src/config/index.js";
+import { planReconciliation } from "../../../src/reconcile/planner.js";
+import type { ProviderListing } from "../../../src/reconcile/planner.js";
+import type { Action } from "../../../src/reconcile/plan.js";
+
+const ageOpts = { identityFile: "./id.txt", secretsDir: "./secrets" };
+const gcpOpts = { project: "proj-a" };
+
+function ageListing(keys: Array<{ keyPath: string }>): ProviderListing {
+  return {
+    providerName: "age",
+    providerParams: ageOpts,
+    storageScope: "envless",
+    keys: keys.map((k) => ({ keyPath: k.keyPath, envName: undefined }))
+  };
+}
+
+function gcpListing(
+  keys: Array<{ keyPath: string; envName: string | undefined }>
+): ProviderListing {
+  return {
+    providerName: "gcp",
+    providerParams: gcpOpts,
+    storageScope: "perEnv",
+    keys
+  };
+}
+
+function actionsByKind(actions: Action[]): Record<string, Action[]> {
+  const out: Record<string, Action[]> = {};
+  for (const a of actions) {
+    (out[a.kind] ??= []).push(a);
+  }
+  return out;
+}
+
+describe("planReconciliation", () => {
+  it("(a) clean state — every desired binding has matching storage → all NoOps", () => {
+    const cfg = normalizeConfig(
+      defineConfig({
+        name: "test",
+        envs: ["dev"],
+        keys: {
+          token: secret({ value: age(ageOpts) })
+        }
+      })
+    );
+
+    const plan = planReconciliation(cfg, [ageListing([{ keyPath: "token" }])]);
+
+    expect(plan).toEqual([
+      {
+        kind: "noop",
+        keyPath: "token",
+        envName: undefined,
+        providerName: "age"
+      }
+    ]);
+  });
+
+  it("(b) one new key — desired but no storage → Create", () => {
+    const cfg = normalizeConfig(
+      defineConfig({
+        name: "test",
+        envs: ["dev"],
+        keys: {
+          token: secret({ value: age(ageOpts) })
+        }
+      })
+    );
+
+    const plan = planReconciliation(cfg, [ageListing([])]);
+
+    expect(plan).toEqual([
+      {
+        kind: "create",
+        keyPath: "token",
+        envName: undefined,
+        providerName: "age"
+      }
+    ]);
+  });
+
+  it("(c) one orphan — storage exists for an undeclared key → Delete", () => {
+    const cfg = normalizeConfig(
+      defineConfig({
+        name: "test",
+        envs: ["dev"],
+        keys: {
+          // keep the instance alive in the listings map; otherwise an
+          // unrelated declared key wouldn't be required.
+          token: secret({ value: age(ageOpts) })
+        }
+      })
+    );
+
+    const plan = planReconciliation(cfg, [
+      ageListing([{ keyPath: "token" }, { keyPath: "legacy/old-thing" }])
+    ]);
+
+    const byKind = actionsByKind(plan);
+    expect(byKind.noop).toHaveLength(1);
+    expect(byKind.delete).toEqual([
+      {
+        kind: "delete",
+        keyPath: "legacy/old-thing",
+        envName: undefined,
+        providerName: "age"
+      }
+    ]);
+  });
+
+  it("(d) shape-unique rename — one orphan, one new key, same envCoverage → Rename", () => {
+    const cfg = normalizeConfig(
+      defineConfig({
+        name: "test",
+        envs: ["dev"],
+        keys: {
+          databases: {
+            auth: { dbPassword: secret({ value: age(ageOpts) }) }
+          }
+        }
+      })
+    );
+
+    const plan = planReconciliation(cfg, [ageListing([{ keyPath: "supabase/db-password" }])]);
+
+    expect(plan).toEqual([
+      {
+        kind: "rename",
+        from: { keyPath: "supabase/db-password" },
+        to: { keyPath: "databases/auth/dbPassword" },
+        providerName: "age",
+        envBindings: [undefined]
+      }
+    ]);
+  });
+
+  it("(e) ambiguous — two orphans match one new key by shape → Ambiguous", () => {
+    const cfg = normalizeConfig(
+      defineConfig({
+        name: "test",
+        envs: ["dev"],
+        keys: {
+          newKey: secret({ value: age(ageOpts) })
+        }
+      })
+    );
+
+    const plan = planReconciliation(cfg, [
+      ageListing([{ keyPath: "old-a" }, { keyPath: "old-b" }])
+    ]);
+
+    const byKind = actionsByKind(plan);
+    expect(byKind.ambiguous).toHaveLength(1);
+    const ambiguous = byKind.ambiguous[0];
+    if (ambiguous.kind !== "ambiguous") throw new Error("expected ambiguous");
+    expect(ambiguous.desired.keyPath).toBe("newKey");
+    expect(ambiguous.candidates.map((c) => c.keyPath).sort()).toEqual(["old-a", "old-b"]);
+    // While ambiguous is unresolved, neither side is emitted as Create/Delete.
+    expect(byKind.create).toBeUndefined();
+    expect(byKind.delete).toBeUndefined();
+  });
+
+  it("(f) movedFrom resolves ambiguity — picks the named candidate", () => {
+    const cfg = normalizeConfig(
+      defineConfig({
+        name: "test",
+        envs: ["dev"],
+        keys: {
+          newKey: secret({ value: age(ageOpts), movedFrom: "old-a" })
+        }
+      })
+    );
+
+    const plan = planReconciliation(cfg, [
+      ageListing([{ keyPath: "old-a" }, { keyPath: "old-b" }])
+    ]);
+
+    const byKind = actionsByKind(plan);
+    expect(byKind.rename).toEqual([
+      {
+        kind: "rename",
+        from: { keyPath: "old-a" },
+        to: { keyPath: "newKey" },
+        providerName: "age",
+        envBindings: [undefined]
+      }
+    ]);
+    // old-b is left over → Delete (the movedFrom hint resolved old-a, but
+    // old-b is still an orphan with no other claim on it).
+    expect(byKind.delete).toEqual([
+      {
+        kind: "delete",
+        keyPath: "old-b",
+        envName: undefined,
+        providerName: "age"
+      }
+    ]);
+  });
+
+  it("(g) per-env partial moves — gcp orphan covers dev but not prod", () => {
+    const cfg = normalizeConfig(
+      defineConfig({
+        name: "test",
+        envs: ["dev", "prod"],
+        keys: {
+          newKey: secret({
+            values: { dev: gcp(gcpOpts), prod: gcp(gcpOpts) }
+          })
+        }
+      })
+    );
+
+    const plan = planReconciliation(cfg, [gcpListing([{ keyPath: "old-key", envName: "dev" }])]);
+
+    const byKind = actionsByKind(plan);
+    // The orphan only covers dev, the desired wants dev+prod. envCoverage
+    // doesn't match, so no shape rename is proposed. Both sides fall out
+    // separately.
+    expect(byKind.rename).toBeUndefined();
+    expect(byKind.create?.map((a) => a.kind === "create" && a.envName).sort()).toEqual([
+      "dev",
+      "prod"
+    ]);
+    expect(byKind.delete).toEqual([
+      {
+        kind: "delete",
+        keyPath: "old-key",
+        envName: "dev",
+        providerName: "gcp"
+      }
+    ]);
+  });
+
+  it("(g2) per-env rename via movedFrom — orphan dev moves to new path, prod is Create", () => {
+    const cfg = normalizeConfig(
+      defineConfig({
+        name: "test",
+        envs: ["dev", "prod"],
+        keys: {
+          newKey: secret({
+            values: { dev: gcp(gcpOpts), prod: gcp(gcpOpts) },
+            movedFrom: "old-key"
+          })
+        }
+      })
+    );
+
+    const plan = planReconciliation(cfg, [gcpListing([{ keyPath: "old-key", envName: "dev" }])]);
+
+    const byKind = actionsByKind(plan);
+    // movedFrom forces the match even though envCoverage differs.
+    // envBindings = intersection (just "dev"); prod stays as Create.
+    expect(byKind.rename).toEqual([
+      {
+        kind: "rename",
+        from: { keyPath: "old-key" },
+        to: { keyPath: "newKey" },
+        providerName: "gcp",
+        envBindings: ["dev"]
+      }
+    ]);
+    expect(byKind.create).toEqual([
+      {
+        kind: "create",
+        keyPath: "newKey",
+        envName: "prod",
+        providerName: "gcp"
+      }
+    ]);
+    expect(byKind.delete).toBeUndefined();
+  });
+
+  it("(h) provider-param drift — same path, different gcp project → not a rename", () => {
+    const cfg = normalizeConfig(
+      defineConfig({
+        name: "test",
+        envs: ["dev"],
+        keys: {
+          token: secret({ value: gcp({ project: "proj-b" }) })
+        }
+      })
+    );
+
+    // Listing for proj-a (the old project) holds the entry; listing for
+    // proj-b is empty. The two are different instances.
+    const plan = planReconciliation(cfg, [
+      {
+        providerName: "gcp",
+        providerParams: { project: "proj-a" },
+        storageScope: "perEnv",
+        keys: [{ keyPath: "token", envName: "dev" }]
+      },
+      {
+        providerName: "gcp",
+        providerParams: { project: "proj-b" },
+        storageScope: "perEnv",
+        keys: []
+      }
+    ]);
+
+    const byKind = actionsByKind(plan);
+    // No rename — instances don't cross.
+    expect(byKind.rename).toBeUndefined();
+    expect(byKind.create).toEqual([
+      {
+        kind: "create",
+        keyPath: "token",
+        envName: "dev",
+        providerName: "gcp"
+      }
+    ]);
+    expect(byKind.delete).toEqual([
+      {
+        kind: "delete",
+        keyPath: "token",
+        envName: "dev",
+        providerName: "gcp"
+      }
+    ]);
+  });
+
+  it("ignores config records — they don't touch storage", () => {
+    const cfg = normalizeConfig(
+      defineConfig({
+        name: "test",
+        envs: ["dev"],
+        keys: {
+          host: "localhost",
+          port: config({ value: 5432 })
+        }
+      })
+    );
+
+    expect(planReconciliation(cfg, [])).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2 of [`.claude/plans/keyshelf-up.md`](./.claude/plans/keyshelf-up.md): the internal plan engine. No user-visible change — the planner is consumed by `keyshelf up --plan` in Phase 3.

- **`reconcile/plan.ts`** — tagged `Action` union: `Create`, `Rename`, `Delete`, `NoOp`, `Ambiguous`.
- **`reconcile/planner.ts`** — pure function. Groups desired bindings and provider listings into `(providerName, providerParams)` instances and reconciles within each. Per-listing `storageScope: 'envless' | 'perEnv'` lets the planner collapse per-env desired bindings against an envless storage layout (age, sops) without leaking that knowledge into the `Provider` interface. Renames come from envCoverage shape match (unique) or `movedFrom`; multi-match surfaces as `Ambiguous` and suppresses Create/Delete on the suspect paths to avoid destructive moves while the user disambiguates.
- **`config/factories.ts` + schema** — accepts `movedFrom?: string | string[]` on `config(...)` and `secret(...)`. Normalized to a string array; validator rejects entries that collide with a declared path or reference the record's own path.

## Test plan

- [x] Unit tests for the planner cover the matrix in the plan: clean state, new key, orphan, shape-unique rename, ambiguous, `movedFrom` resolves ambiguity, per-env partial moves (including `movedFrom` with partial overlap), and provider-param drift across two gcp project instances.
- [x] Unit tests for `movedFrom` validation: collision with a declared path, self-reference, normalization of string vs array.
- [x] Full cli suite passes (158 tests).
- [x] `tsc --noEmit` clean.

## Out of scope

- Phase 3 (`keyshelf up --plan` CLI): wires the planner into a command and renders the plan.
- Phase 4 (apply): `copy` / `delete` provider methods + apply pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)