### PR TITLE
feat(cli): keyshelf up --plan (phase 3 of keyshelf up)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1737,6 +1737,7 @@
       "version": "4.0.9",
       "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
       "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
@@ -5313,7 +5314,6 @@
       "license": "MIT",
       "dependencies": {
         "@google-cloud/secret-manager": "^6.1.1",
-        "@types/js-yaml": "^4.0.9",
         "age-encryption": "^0.3.0",
         "commander": "^14.0.3",
         "cross-spawn": "^7.0.6",
@@ -5326,6 +5326,7 @@
       },
       "devDependencies": {
         "@types/cross-spawn": "^6.0.6",
+        "@types/js-yaml": "^4.0.9",
         "@types/node": "^25.5.0",
         "tsup": "^8.5.1",
         "tsx": "^4.21.0",

--- a/packages/action/dist/emit-env.mjs
+++ b/packages/action/dist/emit-env.mjs
@@ -3007,6 +3007,9 @@ var ProviderRegistry = class {
 // ../cli/dist/src/providers/plaintext.js
 var PlaintextProvider = class {
   name = "plaintext";
+  // Plaintext values live inline in the config tree, not in storage. No
+  // listing exists; scope is moot but envless matches the empty-list shape.
+  storageScope = "envless";
   async resolve(ctx) {
     const value = ctx.config.value;
     if (typeof value !== "string") {
@@ -11641,6 +11644,7 @@ function secretFilePath(secretsDir, keyPath) {
 }
 var AgeProvider = class {
   name = "age";
+  storageScope = "envless";
   resolveOptions(ctx) {
     return {
       identityFile: resolvePath(requireStringConfig("age", ctx, "identityFile"), ctx.rootDir),
@@ -11750,6 +11754,7 @@ async function writeSecretsFile(path, file) {
 }
 var SopsProvider = class {
   name = "sops";
+  storageScope = "envless";
   resolveOptions(ctx) {
     return {
       identityFile: resolvePath(requireStringConfig("sops", ctx, "identityFile"), ctx.rootDir),

--- a/packages/cli/src/cli/index.ts
+++ b/packages/cli/src/cli/index.ts
@@ -3,6 +3,7 @@ import { runCommand } from "./run.js";
 import { lsCommand } from "./ls.js";
 import { setCommand } from "./set.js";
 import { importCommand } from "./import.js";
+import { upCommand } from "./up.js";
 
 const CLI_VERSION = "5.0.0";
 
@@ -15,6 +16,7 @@ export function createProgram(): Command {
   program.addCommand(lsCommand);
   program.addCommand(setCommand);
   program.addCommand(importCommand);
+  program.addCommand(upCommand);
 
   return program;
 }

--- a/packages/cli/src/cli/up.ts
+++ b/packages/cli/src/cli/up.ts
@@ -1,0 +1,55 @@
+import { Command } from "commander";
+import { loadConfig } from "../config/index.js";
+import { createDefaultRegistry } from "../providers/setup.js";
+import { gatherListings, type ListingFailure } from "../reconcile/listings.js";
+import { planReconciliation } from "../reconcile/planner.js";
+import { countMutatingActions, renderPlan } from "../reconcile/format.js";
+
+interface UpOptions {
+  plan?: boolean;
+}
+
+export const upCommand = new Command("up")
+  .description("Reconcile config against provider storage (Phase 3: read-only --plan)")
+  .option("--plan", "Show the reconciliation plan without mutating storage")
+  .action(async (opts: UpOptions) => {
+    // Phase 3 only ships read-only behavior. Whether or not --plan is passed,
+    // `up` does not mutate storage. Phase 4 will add the apply path.
+    void opts;
+    await runPlan();
+  });
+
+async function runPlan(): Promise<void> {
+  try {
+    const exitCode = await computePlanExitCode();
+    process.exit(exitCode);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`error: ${msg}`);
+    process.exit(1);
+  }
+}
+
+async function computePlanExitCode(): Promise<number> {
+  const loaded = await loadConfig(process.cwd());
+  const registry = createDefaultRegistry();
+
+  const { listings, failures } = await gatherListings({
+    config: loaded.config,
+    registry,
+    rootDir: loaded.rootDir
+  });
+
+  reportFailures(failures);
+
+  const plan = planReconciliation(loaded.config, listings);
+  process.stdout.write(renderPlan(plan));
+
+  return countMutatingActions(plan) === 0 ? 0 : 2;
+}
+
+function reportFailures(failures: ListingFailure[]): void {
+  for (const f of failures) {
+    console.error(`warning: skipped listing for provider "${f.providerName}" (${f.error.message})`);
+  }
+}

--- a/packages/cli/src/providers/age.ts
+++ b/packages/cli/src/providers/age.ts
@@ -2,7 +2,13 @@ import { readFile, writeFile, mkdir, readdir } from "node:fs/promises";
 import type { Dirent } from "node:fs";
 import { dirname, join } from "node:path";
 import { Encrypter, Decrypter, generateIdentity, identityToRecipient } from "age-encryption";
-import type { Provider, ProviderContext, ProviderListContext, StoredKey } from "./types.js";
+import type {
+  Provider,
+  ProviderContext,
+  ProviderListContext,
+  StorageScope,
+  StoredKey
+} from "./types.js";
 import {
   readIdentity,
   readIdentityWithRecipient,
@@ -25,6 +31,7 @@ function secretFilePath(secretsDir: string, keyPath: string): string {
 
 export class AgeProvider implements Provider {
   name = "age";
+  storageScope: StorageScope = "envless";
 
   private resolveOptions(ctx: ProviderContext): AgeProviderOptions {
     return {

--- a/packages/cli/src/providers/gcp-sm.ts
+++ b/packages/cli/src/providers/gcp-sm.ts
@@ -1,5 +1,11 @@
 import { SecretManagerServiceClient } from "@google-cloud/secret-manager";
-import type { Provider, ProviderContext, ProviderListContext, StoredKey } from "./types.js";
+import type {
+  Provider,
+  ProviderContext,
+  ProviderListContext,
+  StorageScope,
+  StoredKey
+} from "./types.js";
 
 export interface GcpSmProviderOptions {
   project: string;
@@ -48,6 +54,7 @@ export function toSecretId(
 
 export class GcpSmProvider implements Provider {
   name = "gcp";
+  storageScope: StorageScope = "perEnv";
 
   private client: SecretManagerServiceClient;
 

--- a/packages/cli/src/providers/plaintext.ts
+++ b/packages/cli/src/providers/plaintext.ts
@@ -1,7 +1,10 @@
-import type { Provider, ProviderContext, StoredKey } from "./types.js";
+import type { Provider, ProviderContext, StorageScope, StoredKey } from "./types.js";
 
 export class PlaintextProvider implements Provider {
   name = "plaintext";
+  // Plaintext values live inline in the config tree, not in storage. No
+  // listing exists; scope is moot but envless matches the empty-list shape.
+  storageScope: StorageScope = "envless";
 
   async resolve(ctx: ProviderContext): Promise<string> {
     const value = ctx.config.value;

--- a/packages/cli/src/providers/sops.ts
+++ b/packages/cli/src/providers/sops.ts
@@ -2,7 +2,13 @@ import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { randomBytes, createCipheriv, createDecipheriv, createHmac } from "node:crypto";
 import { dirname } from "node:path";
 import { Encrypter, Decrypter } from "age-encryption";
-import type { Provider, ProviderContext, ProviderListContext, StoredKey } from "./types.js";
+import type {
+  Provider,
+  ProviderContext,
+  ProviderListContext,
+  StorageScope,
+  StoredKey
+} from "./types.js";
 import {
   readIdentity,
   readIdentityWithRecipient,
@@ -98,6 +104,7 @@ async function writeSecretsFile(path: string, file: SecretsFile): Promise<void> 
 
 export class SopsProvider implements Provider {
   name = "sops";
+  storageScope: StorageScope = "envless";
 
   private resolveOptions(ctx: ProviderContext): SopsProviderOptions {
     return {

--- a/packages/cli/src/providers/types.ts
+++ b/packages/cli/src/providers/types.ts
@@ -21,8 +21,17 @@ export interface StoredKey {
   envName: string | undefined;
 }
 
+// Whether this provider's storage layout encodes env in the storage id.
+// gcp uses `envless__<env>__<path>`, so different envs map to different
+// stored entries (perEnv). age and sops store one entry per key path
+// regardless of env (envless). The planner uses this to decide whether
+// a value/default binding fans out into per-env entries when matching
+// desired vs actual.
+export type StorageScope = "envless" | "perEnv";
+
 export interface Provider {
   name: string;
+  storageScope: StorageScope;
   resolve(ctx: ProviderContext): Promise<string>;
   validate(ctx: ProviderContext): Promise<boolean>;
   set(ctx: ProviderContext, value: string): Promise<void>;

--- a/packages/cli/src/reconcile/format.ts
+++ b/packages/cli/src/reconcile/format.ts
@@ -1,0 +1,150 @@
+import type {
+  Action,
+  AmbiguousAction,
+  CreateAction,
+  DeleteAction,
+  NoOpAction,
+  Plan,
+  RenameAction
+} from "./plan.js";
+
+// Terraform-style render for `keyshelf up --plan`. Pure: takes a plan and
+// returns the text. Caller decides where to write it.
+export function renderPlan(plan: Plan): string {
+  const grouped = groupByKind(plan);
+  if (countMutatingActions(plan) === 0) {
+    const noopSuffix = grouped.noop.length > 0 ? ` (${grouped.noop.length} unchanged)` : "";
+    return `No changes. Storage is in sync with the config.${noopSuffix}\n`;
+  }
+
+  const sections: string[] = [];
+
+  if (grouped.rename.length > 0) sections.push(renderRenames(grouped.rename));
+  if (grouped.create.length > 0) sections.push(renderCreates(grouped.create));
+  if (grouped.delete.length > 0) sections.push(renderDeletes(grouped.delete));
+  if (grouped.ambiguous.length > 0) sections.push(renderAmbiguous(grouped.ambiguous));
+
+  const summary = renderSummary(grouped);
+  return ["Plan:", "", ...sections, summary].join("\n");
+}
+
+interface GroupedActions {
+  noop: NoOpAction[];
+  create: CreateAction[];
+  delete: DeleteAction[];
+  rename: RenameAction[];
+  ambiguous: AmbiguousAction[];
+}
+
+function groupByKind(plan: Plan): GroupedActions {
+  const out: GroupedActions = {
+    noop: [],
+    create: [],
+    delete: [],
+    rename: [],
+    ambiguous: []
+  };
+  for (const action of plan) {
+    appendByKind(out, action);
+  }
+  return out;
+}
+
+function appendByKind(out: GroupedActions, action: Action): void {
+  switch (action.kind) {
+    case "noop":
+      out.noop.push(action);
+      return;
+    case "create":
+      out.create.push(action);
+      return;
+    case "delete":
+      out.delete.push(action);
+      return;
+    case "rename":
+      out.rename.push(action);
+      return;
+    case "ambiguous":
+      out.ambiguous.push(action);
+      return;
+  }
+}
+
+function renderRenames(items: RenameAction[]): string {
+  const lines: string[] = [];
+  for (const r of items) {
+    lines.push(`  ~ ${r.to.keyPath}   (renamed from ${r.from.keyPath})`);
+    lines.push(`      provider: ${r.providerName}`);
+    lines.push(`      envs: ${formatEnvBindings(r.envBindings)}`);
+  }
+  return lines.join("\n") + "\n";
+}
+
+function renderCreates(items: CreateAction[]): string {
+  const lines: string[] = [];
+  for (const c of items) {
+    lines.push(
+      `  + ${c.keyPath}${formatEnvSuffix(c.envName)}   (new — run \`keyshelf set\` to populate)`
+    );
+    lines.push(`      provider: ${c.providerName}`);
+  }
+  return lines.join("\n") + "\n";
+}
+
+function renderDeletes(items: DeleteAction[]): string {
+  const lines: string[] = [];
+  for (const d of items) {
+    lines.push(
+      `  - ${d.keyPath}${formatEnvSuffix(d.envName)}   (orphan; will be deleted on apply)`
+    );
+    lines.push(`      provider: ${d.providerName}`);
+  }
+  return lines.join("\n") + "\n";
+}
+
+function renderAmbiguous(items: AmbiguousAction[]): string {
+  const lines: string[] = [];
+  for (const a of items) {
+    lines.push(`  ? ${a.desired.keyPath}   (ambiguous rename)`);
+    lines.push(`      provider: ${a.desired.providerName}`);
+    lines.push(`      candidate orphans:`);
+    for (const cand of a.candidates) {
+      lines.push(`        - ${cand.keyPath}`);
+    }
+    lines.push(`      ${a.hint}`);
+    lines.push(`      add one of:`);
+    for (const cand of a.candidates) {
+      lines.push(`        secret({ movedFrom: ${JSON.stringify(cand.keyPath)}, ... })`);
+    }
+  }
+  return lines.join("\n") + "\n";
+}
+
+function renderSummary(grouped: GroupedActions): string {
+  const parts: string[] = [];
+  if (grouped.create.length > 0) parts.push(`${grouped.create.length} to create`);
+  if (grouped.rename.length > 0) parts.push(`${grouped.rename.length} to rename`);
+  if (grouped.delete.length > 0) parts.push(`${grouped.delete.length} to delete`);
+  if (grouped.ambiguous.length > 0) parts.push(`${grouped.ambiguous.length} ambiguous`);
+  if (grouped.noop.length > 0) parts.push(`${grouped.noop.length} unchanged`);
+  return `Summary: ${parts.join(", ")}\n`;
+}
+
+function formatEnvSuffix(envName: string | undefined): string {
+  return envName === undefined ? "" : ` [${envName}]`;
+}
+
+function formatEnvBindings(envs: Array<string | undefined>): string {
+  if (envs.length === 0) return "(envless)";
+  return envs.map((e) => e ?? "(envless)").join(", ");
+}
+
+// Counts a plan's mutating actions (excludes noop). Used by the CLI to
+// pick its exit code: 0 if zero mutating actions, 2 otherwise.
+export function countMutatingActions(plan: Plan): number {
+  let count = 0;
+  for (const action of plan) {
+    if (action.kind !== "noop") count += 1;
+  }
+  return count;
+}

--- a/packages/cli/src/reconcile/format.ts
+++ b/packages/cli/src/reconcile/format.ts
@@ -77,7 +77,7 @@ function renderRenames(items: RenameAction[]): string {
     lines.push(`      provider: ${r.providerName}`);
     lines.push(`      envs: ${formatEnvBindings(r.envBindings)}`);
   }
-  return lines.join("\n") + "\n";
+  return `${lines.join("\n")}\n`;
 }
 
 function renderCreates(items: CreateAction[]): string {
@@ -88,7 +88,7 @@ function renderCreates(items: CreateAction[]): string {
     );
     lines.push(`      provider: ${c.providerName}`);
   }
-  return lines.join("\n") + "\n";
+  return `${lines.join("\n")}\n`;
 }
 
 function renderDeletes(items: DeleteAction[]): string {
@@ -99,7 +99,7 @@ function renderDeletes(items: DeleteAction[]): string {
     );
     lines.push(`      provider: ${d.providerName}`);
   }
-  return lines.join("\n") + "\n";
+  return `${lines.join("\n")}\n`;
 }
 
 function renderAmbiguous(items: AmbiguousAction[]): string {
@@ -117,7 +117,7 @@ function renderAmbiguous(items: AmbiguousAction[]): string {
       lines.push(`        secret({ movedFrom: ${JSON.stringify(cand.keyPath)}, ... })`);
     }
   }
-  return lines.join("\n") + "\n";
+  return `${lines.join("\n")}\n`;
 }
 
 function renderSummary(grouped: GroupedActions): string {

--- a/packages/cli/src/reconcile/listings.ts
+++ b/packages/cli/src/reconcile/listings.ts
@@ -1,0 +1,102 @@
+import type { BuiltinProviderRef, NormalizedConfig, NormalizedRecord } from "../config/types.js";
+import type { ProviderRegistry } from "../providers/registry.js";
+import { instanceKey } from "./internal/instance-key.js";
+import type { ProviderListing } from "./planner.js";
+
+export interface GatherListingsContext {
+  config: NormalizedConfig;
+  registry: ProviderRegistry;
+  rootDir: string;
+}
+
+export interface ListingFailure {
+  providerName: string;
+  providerParams: unknown;
+  error: Error;
+}
+
+export interface GatherListingsResult {
+  listings: ProviderListing[];
+  failures: ListingFailure[];
+}
+
+// Walk the config to find every distinct (provider, params) instance, then
+// call list() once per instance. Failures are collected rather than thrown
+// so a single broken provider doesn't block the rest of the plan.
+export async function gatherListings(ctx: GatherListingsContext): Promise<GatherListingsResult> {
+  const refs = collectProviderInstances(ctx.config);
+  const listings: ProviderListing[] = [];
+  const failures: ListingFailure[] = [];
+
+  for (const ref of refs.values()) {
+    const result = await listOne(ctx, ref);
+    if (result.kind === "ok") {
+      listings.push(result.listing);
+    } else {
+      failures.push(result.failure);
+    }
+  }
+
+  return { listings, failures };
+}
+
+interface ListOk {
+  kind: "ok";
+  listing: ProviderListing;
+}
+
+interface ListErr {
+  kind: "err";
+  failure: ListingFailure;
+}
+
+async function listOne(
+  ctx: GatherListingsContext,
+  ref: BuiltinProviderRef
+): Promise<ListOk | ListErr> {
+  try {
+    const provider = ctx.registry.get(ref.name);
+    const stored = await provider.list({
+      rootDir: ctx.rootDir,
+      config: (ref.options ?? {}) as unknown as Record<string, unknown>,
+      keyshelfName: ctx.config.name,
+      envs: ctx.config.envs
+    });
+    return {
+      kind: "ok",
+      listing: {
+        providerName: ref.name,
+        providerParams: ref.options,
+        storageScope: provider.storageScope,
+        keys: stored
+      }
+    };
+  } catch (err) {
+    return {
+      kind: "err",
+      failure: {
+        providerName: ref.name,
+        providerParams: ref.options,
+        error: err instanceof Error ? err : new Error(String(err))
+      }
+    };
+  }
+}
+
+function collectProviderInstances(config: NormalizedConfig): Map<string, BuiltinProviderRef> {
+  const out = new Map<string, BuiltinProviderRef>();
+  for (const record of config.keys) {
+    for (const ref of providerRefsOf(record)) {
+      out.set(instanceKey(ref.name, ref.options), ref);
+    }
+  }
+  return out;
+}
+
+function providerRefsOf(record: NormalizedRecord): BuiltinProviderRef[] {
+  if (record.kind !== "secret") return [];
+  const refs: BuiltinProviderRef[] = [];
+  if (record.value !== undefined) refs.push(record.value);
+  for (const ref of Object.values(record.values ?? {})) refs.push(ref);
+  return refs;
+}

--- a/packages/cli/src/reconcile/listings.ts
+++ b/packages/cli/src/reconcile/listings.ts
@@ -1,5 +1,6 @@
-import type { BuiltinProviderRef, NormalizedConfig, NormalizedRecord } from "../config/types.js";
+import type { BuiltinProviderRef, NormalizedConfig } from "../config/types.js";
 import type { ProviderRegistry } from "../providers/registry.js";
+import { collectProviderRefs } from "./internal/desired-bindings.js";
 import { instanceKey } from "./internal/instance-key.js";
 import type { ProviderListing } from "./planner.js";
 
@@ -86,17 +87,9 @@ async function listOne(
 function collectProviderInstances(config: NormalizedConfig): Map<string, BuiltinProviderRef> {
   const out = new Map<string, BuiltinProviderRef>();
   for (const record of config.keys) {
-    for (const ref of providerRefsOf(record)) {
+    for (const ref of collectProviderRefs(record)) {
       out.set(instanceKey(ref.name, ref.options), ref);
     }
   }
   return out;
-}
-
-function providerRefsOf(record: NormalizedRecord): BuiltinProviderRef[] {
-  if (record.kind !== "secret") return [];
-  const refs: BuiltinProviderRef[] = [];
-  if (record.value !== undefined) refs.push(record.value);
-  for (const ref of Object.values(record.values ?? {})) refs.push(ref);
-  return refs;
 }

--- a/packages/cli/src/reconcile/planner.ts
+++ b/packages/cli/src/reconcile/planner.ts
@@ -1,12 +1,12 @@
 import type { NormalizedConfig } from "../config/types.js";
-import type { StoredKey } from "../providers/types.js";
+import type { StorageScope, StoredKey } from "../providers/types.js";
 import type { Action, Plan } from "./plan.js";
 import { diffInstance } from "./internal/diff.js";
 import { appendLeafActions, appendList } from "./internal/emit.js";
 import { buildInstances, type InstanceState } from "./internal/instance.js";
 import { resolveRenames } from "./internal/rename.js";
 
-export type StorageScope = "envless" | "perEnv";
+export type { StorageScope } from "../providers/types.js";
 
 export interface ProviderListing {
   providerName: string;

--- a/packages/cli/test/e2e/up.test.ts
+++ b/packages/cli/test/e2e/up.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+import { CLI, TSX } from "./helpers/cli.js";
+import { setupAgeFixtureDir, writeKeyshelfConfig } from "./helpers/fixture.js";
+import { AgeProvider } from "../../src/providers/age.js";
+
+interface CliResult {
+  stdout: string;
+  stderr: string;
+  status: number;
+}
+
+function runUp(cwd: string, args: string[] = []): CliResult {
+  try {
+    const stdout = execFileSync(TSX, [CLI, "up", ...args], {
+      cwd,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"]
+    });
+    return { stdout, stderr: "", status: 0 };
+  } catch (err) {
+    const e = err as { stdout?: string; stderr?: string; status?: number };
+    return { stdout: e.stdout ?? "", stderr: e.stderr ?? "", status: e.status ?? -1 };
+  }
+}
+
+describe("keyshelf up --plan", () => {
+  let root: string;
+  let identityFile: string;
+  let secretsDir: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "keyshelf-up-"));
+    ({ identityFile, secretsDir } = await setupAgeFixtureDir(root));
+  });
+
+  it("reports an in-sync state when storage matches the config (exit 0)", async () => {
+    await writeKeyshelfConfig(root, [
+      `name: "demo",`,
+      `envs: ["dev"],`,
+      `keys: {`,
+      `  token: secret({ value: age({ identityFile: ${JSON.stringify(identityFile)}, secretsDir: ${JSON.stringify(secretsDir)} }) }),`,
+      `},`
+    ]);
+    const provider = new AgeProvider();
+    await provider.set(
+      { keyPath: "token", envName: undefined, rootDir: root, config: { identityFile, secretsDir } },
+      "secret-value"
+    );
+
+    const result = runUp(root, ["--plan"]);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("No changes. Storage is in sync with the config.");
+  });
+
+  it("plans a Create when storage is missing for a desired key (exit 2)", async () => {
+    await writeKeyshelfConfig(root, [
+      `name: "demo",`,
+      `envs: ["dev"],`,
+      `keys: {`,
+      `  token: secret({ value: age({ identityFile: ${JSON.stringify(identityFile)}, secretsDir: ${JSON.stringify(secretsDir)} }) }),`,
+      `},`
+    ]);
+
+    const result = runUp(root, ["--plan"]);
+    expect(result.status).toBe(2);
+    expect(result.stdout).toContain("+ token");
+    expect(result.stdout).toContain("provider: age");
+    expect(result.stdout).toContain("1 to create");
+  });
+
+  it("plans a Delete for orphan storage entries (exit 2)", async () => {
+    await writeKeyshelfConfig(root, [
+      `name: "demo",`,
+      `envs: ["dev"],`,
+      `keys: {`,
+      `  token: secret({ value: age({ identityFile: ${JSON.stringify(identityFile)}, secretsDir: ${JSON.stringify(secretsDir)} }) }),`,
+      `},`
+    ]);
+    const provider = new AgeProvider();
+    await provider.set(
+      { keyPath: "token", envName: undefined, rootDir: root, config: { identityFile, secretsDir } },
+      "current"
+    );
+    await provider.set(
+      {
+        keyPath: "legacy",
+        envName: undefined,
+        rootDir: root,
+        config: { identityFile, secretsDir }
+      },
+      "old"
+    );
+
+    const result = runUp(root, ["--plan"]);
+    expect(result.status).toBe(2);
+    expect(result.stdout).toContain("- legacy");
+    expect(result.stdout).toContain("1 to delete");
+    expect(result.stdout).toContain("1 unchanged");
+  });
+
+  it("infers a Rename via movedFrom and renders it as a single action", async () => {
+    await writeKeyshelfConfig(root, [
+      `name: "demo",`,
+      `envs: ["dev"],`,
+      `keys: {`,
+      `  databases: {`,
+      `    auth: {`,
+      `      dbPassword: secret({`,
+      `        value: age({ identityFile: ${JSON.stringify(identityFile)}, secretsDir: ${JSON.stringify(secretsDir)} }),`,
+      `        movedFrom: "supabase/db-password",`,
+      `      }),`,
+      `    },`,
+      `  },`,
+      `},`
+    ]);
+
+    const provider = new AgeProvider();
+    await provider.set(
+      {
+        keyPath: "supabase/db-password",
+        envName: undefined,
+        rootDir: root,
+        config: { identityFile, secretsDir }
+      },
+      "the-password"
+    );
+
+    const result = runUp(root, ["--plan"]);
+    expect(result.status).toBe(2);
+    expect(result.stdout).toContain(
+      "~ databases/auth/dbPassword   (renamed from supabase/db-password)"
+    );
+    expect(result.stdout).toContain("1 to rename");
+  });
+
+  it("renders ambiguity with a movedFrom snippet for each candidate", async () => {
+    // Two orphans + one new key with the same shape (envless, age, same params)
+    // produce an Ambiguous action when no movedFrom is supplied.
+    await writeKeyshelfConfig(root, [
+      `name: "demo",`,
+      `envs: ["dev"],`,
+      `keys: {`,
+      `  newKey: secret({ value: age({ identityFile: ${JSON.stringify(identityFile)}, secretsDir: ${JSON.stringify(secretsDir)} }) }),`,
+      `},`
+    ]);
+    const provider = new AgeProvider();
+    await provider.set(
+      { keyPath: "oldA", envName: undefined, rootDir: root, config: { identityFile, secretsDir } },
+      "a"
+    );
+    await provider.set(
+      { keyPath: "oldB", envName: undefined, rootDir: root, config: { identityFile, secretsDir } },
+      "b"
+    );
+
+    const result = runUp(root, ["--plan"]);
+    expect(result.status).toBe(2);
+    expect(result.stdout).toContain("? newKey   (ambiguous rename)");
+    expect(result.stdout).toContain('secret({ movedFrom: "oldA", ... })');
+    expect(result.stdout).toContain('secret({ movedFrom: "oldB", ... })');
+    expect(result.stdout).toContain("1 ambiguous");
+  });
+
+  it("exits 1 when no keyshelf config is found", () => {
+    const result = runUp(root, ["--plan"]);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("error:");
+  });
+});

--- a/packages/cli/test/unit/cli.test.ts
+++ b/packages/cli/test/unit/cli.test.ts
@@ -2,14 +2,15 @@ import { describe, expect, it } from "vitest";
 import { createProgram } from "../../src/index.js";
 
 describe("createProgram", () => {
-  it("registers run, ls, set, and import commands", () => {
+  it("registers run, ls, set, import, and up commands", () => {
     const program = createProgram();
     expect(program.name()).toBe("keyshelf");
     expect(program.commands.map((command) => command.name()).sort()).toEqual([
       "import",
       "ls",
       "run",
-      "set"
+      "set",
+      "up"
     ]);
   });
 });

--- a/packages/cli/test/unit/reconcile/format.test.ts
+++ b/packages/cli/test/unit/reconcile/format.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { countMutatingActions, renderPlan } from "../../../src/reconcile/format.js";
+import type { Plan } from "../../../src/reconcile/plan.js";
+
+describe("renderPlan", () => {
+  it("returns the in-sync banner for an empty plan", () => {
+    expect(renderPlan([])).toBe("No changes. Storage is in sync with the config.\n");
+  });
+
+  it("treats noop-only plans as in-sync (no mutating actions)", () => {
+    const plan: Plan = [
+      { kind: "noop", keyPath: "token", envName: undefined, providerName: "age" }
+    ];
+    const out = renderPlan(plan);
+    expect(out).toContain("No changes. Storage is in sync with the config.");
+    expect(out).toContain("(1 unchanged)");
+    expect(countMutatingActions(plan)).toBe(0);
+  });
+
+  it("renders create with provider and (where present) env suffix", () => {
+    const plan: Plan = [
+      { kind: "create", keyPath: "token", envName: undefined, providerName: "age" },
+      { kind: "create", keyPath: "db/password", envName: "production", providerName: "gcp" }
+    ];
+    const out = renderPlan(plan);
+    expect(out).toContain("+ token   (new — run `keyshelf set` to populate)");
+    expect(out).toContain("provider: age");
+    expect(out).toContain("+ db/password [production]");
+    expect(out).toContain("provider: gcp");
+    expect(out).toContain("2 to create");
+  });
+
+  it("renders delete actions with orphan annotation", () => {
+    const plan: Plan = [
+      { kind: "delete", keyPath: "legacy", envName: undefined, providerName: "age" }
+    ];
+    const out = renderPlan(plan);
+    expect(out).toContain("- legacy   (orphan; will be deleted on apply)");
+    expect(out).toContain("1 to delete");
+  });
+
+  it("renders rename actions with from/to and env bindings", () => {
+    const plan: Plan = [
+      {
+        kind: "rename",
+        from: { keyPath: "supabase/db-password" },
+        to: { keyPath: "databases/auth/dbPassword" },
+        providerName: "age",
+        envBindings: [undefined]
+      }
+    ];
+    const out = renderPlan(plan);
+    expect(out).toContain("~ databases/auth/dbPassword   (renamed from supabase/db-password)");
+    expect(out).toContain("envs: (envless)");
+    expect(out).toContain("1 to rename");
+  });
+
+  it("renders ambiguous actions with candidate set and movedFrom snippet", () => {
+    const plan: Plan = [
+      {
+        kind: "ambiguous",
+        desired: { keyPath: "newKey", providerName: "age" },
+        candidates: [
+          { keyPath: "oldA", providerName: "age" },
+          { keyPath: "oldB", providerName: "age" }
+        ],
+        hint: "annotate movedFrom on the new key to disambiguate."
+      }
+    ];
+    const out = renderPlan(plan);
+    expect(out).toContain("? newKey   (ambiguous rename)");
+    expect(out).toContain("- oldA");
+    expect(out).toContain("- oldB");
+    expect(out).toContain('secret({ movedFrom: "oldA", ... })');
+    expect(out).toContain('secret({ movedFrom: "oldB", ... })');
+    expect(out).toContain("1 ambiguous");
+  });
+
+  it("counts mutating actions across kinds, ignoring noop", () => {
+    const plan: Plan = [
+      { kind: "noop", keyPath: "a", envName: undefined, providerName: "age" },
+      { kind: "create", keyPath: "b", envName: undefined, providerName: "age" },
+      { kind: "delete", keyPath: "c", envName: undefined, providerName: "age" },
+      {
+        kind: "rename",
+        from: { keyPath: "d-old" },
+        to: { keyPath: "d" },
+        providerName: "age",
+        envBindings: [undefined]
+      },
+      {
+        kind: "ambiguous",
+        desired: { keyPath: "e", providerName: "age" },
+        candidates: [{ keyPath: "e-old", providerName: "age" }],
+        hint: "..."
+      }
+    ];
+    expect(countMutatingActions(plan)).toBe(4);
+  });
+});

--- a/packages/cli/test/unit/reconcile/listings.test.ts
+++ b/packages/cli/test/unit/reconcile/listings.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  age,
+  config,
+  defineConfig,
+  gcp,
+  normalizeConfig,
+  secret
+} from "../../../src/config/index.js";
+import { ProviderRegistry } from "../../../src/providers/registry.js";
+import type {
+  Provider,
+  ProviderListContext,
+  StorageScope,
+  StoredKey
+} from "../../../src/providers/types.js";
+import { gatherListings } from "../../../src/reconcile/listings.js";
+
+class StubProvider implements Provider {
+  storageScope: StorageScope;
+  list: (ctx: ProviderListContext) => Promise<StoredKey[]>;
+
+  constructor(
+    public name: string,
+    storageScope: StorageScope,
+    list: (ctx: ProviderListContext) => Promise<StoredKey[]>
+  ) {
+    this.storageScope = storageScope;
+    this.list = list;
+  }
+
+  resolve(): Promise<string> {
+    return Promise.reject(new Error("not used"));
+  }
+  validate(): Promise<boolean> {
+    return Promise.resolve(false);
+  }
+  set(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+function buildRegistry(providers: Provider[]): ProviderRegistry {
+  const registry = new ProviderRegistry();
+  for (const p of providers) registry.register(p);
+  return registry;
+}
+
+const ageOpts = { identityFile: "./id.txt", secretsDir: "./secrets" };
+const gcpOpts = { project: "proj-a" };
+
+describe("gatherListings", () => {
+  it("calls list once per distinct (provider, params) instance referenced by config", async () => {
+    const ageList = vi
+      .fn<(ctx: ProviderListContext) => Promise<StoredKey[]>>()
+      .mockResolvedValue([{ keyPath: "token", envName: undefined }]);
+    const gcpList = vi
+      .fn<(ctx: ProviderListContext) => Promise<StoredKey[]>>()
+      .mockResolvedValue([{ keyPath: "db/password", envName: "production" }]);
+
+    const registry = buildRegistry([
+      new StubProvider("age", "envless", ageList),
+      new StubProvider("gcp", "perEnv", gcpList)
+    ]);
+
+    const cfg = normalizeConfig(
+      defineConfig({
+        name: "test",
+        envs: ["dev", "production"],
+        keys: {
+          // Same age instance referenced twice — should be listed once.
+          tokenA: secret({ value: age(ageOpts) }),
+          tokenB: secret({ value: age(ageOpts) }),
+          db: {
+            password: secret({ values: { production: gcp(gcpOpts) } })
+          }
+        }
+      })
+    );
+
+    const result = await gatherListings({ config: cfg, registry, rootDir: "/tmp/root" });
+
+    expect(ageList).toHaveBeenCalledTimes(1);
+    expect(gcpList).toHaveBeenCalledTimes(1);
+
+    // Listings include storageScope from the provider instance.
+    const ageListing = result.listings.find((l) => l.providerName === "age");
+    const gcpListing = result.listings.find((l) => l.providerName === "gcp");
+    expect(ageListing?.storageScope).toBe("envless");
+    expect(gcpListing?.storageScope).toBe("perEnv");
+    expect(ageListing?.providerParams).toEqual(ageOpts);
+    expect(gcpListing?.providerParams).toEqual(gcpOpts);
+    expect(result.failures).toEqual([]);
+  });
+
+  it("propagates keyshelfName and envs into the list context", async () => {
+    const ageList = vi
+      .fn<(ctx: ProviderListContext) => Promise<StoredKey[]>>()
+      .mockResolvedValue([]);
+    const registry = buildRegistry([new StubProvider("age", "envless", ageList)]);
+
+    const cfg = normalizeConfig(
+      defineConfig({
+        name: "myapp",
+        envs: ["dev", "prod"],
+        keys: { token: secret({ value: age(ageOpts) }) }
+      })
+    );
+
+    await gatherListings({ config: cfg, registry, rootDir: "/tmp/root" });
+
+    const ctxArg = ageList.mock.calls[0][0];
+    expect(ctxArg.keyshelfName).toBe("myapp");
+    expect(ctxArg.envs).toEqual(["dev", "prod"]);
+    expect(ctxArg.rootDir).toBe("/tmp/root");
+    expect(ctxArg.config).toEqual(ageOpts);
+  });
+
+  it("collects failures rather than throwing when a provider list call rejects", async () => {
+    const failing = vi
+      .fn<(ctx: ProviderListContext) => Promise<StoredKey[]>>()
+      .mockRejectedValue(new Error("auth missing"));
+    const registry = buildRegistry([new StubProvider("age", "envless", failing)]);
+
+    const cfg = normalizeConfig(
+      defineConfig({
+        name: "test",
+        envs: ["dev"],
+        keys: { token: secret({ value: age(ageOpts) }) }
+      })
+    );
+
+    const result = await gatherListings({ config: cfg, registry, rootDir: "/tmp/root" });
+    expect(result.listings).toEqual([]);
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0].providerName).toBe("age");
+    expect(result.failures[0].error.message).toBe("auth missing");
+  });
+
+  it("ignores config-kind records (no provider listing required)", async () => {
+    const ageList = vi
+      .fn<(ctx: ProviderListContext) => Promise<StoredKey[]>>()
+      .mockResolvedValue([]);
+    const registry = buildRegistry([new StubProvider("age", "envless", ageList)]);
+
+    const cfg = normalizeConfig(
+      defineConfig({
+        name: "test",
+        envs: ["dev"],
+        keys: { host: config({ default: "localhost" }) }
+      })
+    );
+
+    const result = await gatherListings({ config: cfg, registry, rootDir: "/tmp/root" });
+    expect(result.listings).toEqual([]);
+    expect(ageList).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `keyshelf up --plan` — a read-only reconcile command that loads the config, calls every referenced provider's `list()`, runs the planner, and prints a Terraform-style diff.
- Renders Create / Delete / Rename / Ambiguous actions; the in-sync case prints a single banner. Exit codes: `0` clean, `2` actions pending, `1` error — so CI can use it as a drift check.
- Ambiguous renders the candidate orphans plus a copy-paste `secret({ movedFrom: '<old>', ... })` snippet for each one, so the user can disambiguate without leaving the terminal.
- Adds a `storageScope` field to the `Provider` interface (`age`/`sops` envless, `gcp` perEnv, `plaintext` envless and unused). The listings collector attaches scope per instance without hardcoding the mapping in the CLI.
- Apply, prompt, and `--yes` are deferred to phase 4. This phase is purely informational.

## Test plan

- [x] `npm run typecheck` (workspace)
- [x] `npm run lint` (workspace)
- [x] `npm test -w keyshelf` — 181 passed (includes 6 new e2e cases for the `up` subcommand and unit tests for `format` + `listings`)
- [x] `npm run build -w keyshelf` and `npm run build -w @keyshelf/action` — action bundle regenerated
- [ ] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)