### PR TITLE
refactor(migrate): split into yaml-to-typescript and project-name subcommands

### DIFF
--- a/packages/action/dist/emit-env.mjs
+++ b/packages/action/dist/emit-env.mjs
@@ -42,7 +42,7 @@ function parseAppMapping(content) {
 }
 var PATH_SEGMENT_RE = /^[A-Za-z_][A-Za-z0-9_-]*$/;
 var TEMPLATE_RE2 = /(?<!\$)\$\{([^}]+)\}/g;
-var CONFIG_NAME_RE = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
+var CONFIG_NAME_RE = /^[A-Za-z0-9_-]+$/;
 var configScalarSchema = z.union([z.string(), z.number(), z.boolean()]);
 var ageProviderSchema = z.object({
   __kind: z.literal("provider:age"),
@@ -108,7 +108,7 @@ var keyNodeSchema = z.lazy(
 var keyshelfConfigSchema = z.object({
   __kind: z.literal("keyshelf:config"),
   name: z.string().min(1).refine((value) => CONFIG_NAME_RE.test(value), {
-    message: "name must match /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/ (lowercase, digits, dashes; no leading or trailing dash)"
+    message: "name must contain only letters, digits, hyphens, and underscores"
   }),
   envs: z.array(z.string().min(1)).nonempty(),
   groups: z.array(z.string().min(1)).optional(),

--- a/packages/action/dist/write-identity.mjs
+++ b/packages/action/dist/write-identity.mjs
@@ -41,7 +41,7 @@ function parseAppMapping(content) {
 }
 var PATH_SEGMENT_RE = /^[A-Za-z_][A-Za-z0-9_-]*$/;
 var TEMPLATE_RE2 = /(?<!\$)\$\{([^}]+)\}/g;
-var CONFIG_NAME_RE = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
+var CONFIG_NAME_RE = /^[A-Za-z0-9_-]+$/;
 var configScalarSchema = z.union([z.string(), z.number(), z.boolean()]);
 var ageProviderSchema = z.object({
   __kind: z.literal("provider:age"),
@@ -107,7 +107,7 @@ var keyNodeSchema = z.lazy(
 var keyshelfConfigSchema = z.object({
   __kind: z.literal("keyshelf:config"),
   name: z.string().min(1).refine((value) => CONFIG_NAME_RE.test(value), {
-    message: "name must match /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/ (lowercase, digits, dashes; no leading or trailing dash)"
+    message: "name must contain only letters, digits, hyphens, and underscores"
   }),
   envs: z.array(z.string().min(1)).nonempty(),
   groups: z.array(z.string().min(1)).optional(),

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -13,7 +13,7 @@ import type {
 
 const PATH_SEGMENT_RE = /^[A-Za-z_][A-Za-z0-9_-]*$/;
 const TEMPLATE_RE = /(?<!\$)\$\{([^}]+)\}/g;
-const CONFIG_NAME_RE = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
+const CONFIG_NAME_RE = /^[A-Za-z0-9_-]+$/;
 
 const configScalarSchema = z.union([z.string(), z.number(), z.boolean()]);
 
@@ -127,8 +127,7 @@ const keyshelfConfigSchema = z
       .string()
       .min(1)
       .refine((value) => CONFIG_NAME_RE.test(value), {
-        message:
-          "name must match /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/ (lowercase, digits, dashes; no leading or trailing dash)"
+        message: "name must contain only letters, digits, hyphens, and underscores"
       }),
     envs: z.array(z.string().min(1)).nonempty(),
     groups: z.array(z.string().min(1)).optional(),

--- a/packages/migrate/README.md
+++ b/packages/migrate/README.md
@@ -1,24 +1,33 @@
 # @keyshelf/migrate
 
-One-shot migrator from keyshelf v4 YAML files to the v5 `keyshelf.config.ts` format.
+Helpers for moving keyshelf v4 projects to v5. v4 YAML configs are now valid v5 configs at runtime, so most projects do not need to migrate at all — these subcommands cover the two cases that are not automatic.
 
-## Run
+## Subcommands
 
-From the repository root that contains `keyshelf.yaml`:
+### `yaml-to-typescript`
 
-```bash
-npx @keyshelf/migrate
-```
-
-By default the migrator writes `keyshelf.config.ts` and refuses to overwrite an existing file.
+Converts `keyshelf.yaml` + `.keyshelf/*.yaml` into a single `keyshelf.config.ts`. Useful if you prefer the TypeScript authoring surface or want IDE autocomplete on key paths.
 
 ```bash
-npx @keyshelf/migrate --dry-run
-npx @keyshelf/migrate --out ./keyshelf.config.ts --force
-npx @keyshelf/migrate --accept-renamed-name
+npx @keyshelf/migrate yaml-to-typescript
+npx @keyshelf/migrate yaml-to-typescript --dry-run
+npx @keyshelf/migrate yaml-to-typescript --out ./keyshelf.config.ts --force
 ```
 
-Use `--accept-renamed-name` when a v4 `name` contains underscores. v5 names are lowercase kebab-case, so `my_app` becomes `my-app`.
+### `project-name`
+
+Re-namespaces remote secret stores under the v5 project name. The migration is dispatched per provider:
+
+- `age`, `sops` — no-op (secrets are co-located with the project; there is no remote namespace to migrate).
+- `gcp` — copies legacy un-namespaced GCP secret ids (e.g. `keyshelf__production__db__password`) to project-namespaced ids (`keyshelf__<name>__production__db__password`).
+
+```bash
+npx @keyshelf/migrate project-name --dry-run
+npx @keyshelf/migrate project-name
+npx @keyshelf/migrate project-name --delete-legacy
+```
+
+`--delete-legacy` deletes the un-namespaced secrets after copying — only run it once you have confirmed the new ids resolve correctly.
 
 ## What It Reads
 
@@ -26,12 +35,11 @@ Use `--accept-renamed-name` when a v4 `name` contains underscores. v5 names are 
 - `.keyshelf/*.yaml`
 - `.env.keyshelf`, when present at the repository root
 
-The generated config keeps `.env.keyshelf` as a separate file. v5 still reads app mappings from `.env.keyshelf`.
+`.env.keyshelf` is preserved as a separate file by both subcommands.
 
-## Review After Migration
+## Review After `yaml-to-typescript`
 
 - Confirm the generated `name` is the intended v5 project name.
 - Fill in `groups: []` if you want to use v5 group filters.
-- Rebind or copy secret values as needed. The report prints `keyshelf set` commands for each migrated secret binding.
 - Review provider paths such as `identityFile`, `secretsDir`, and `secretsFile`.
 - Run the v5 CLI against the generated config before deleting v4 YAML files.

--- a/packages/migrate/src/cli.ts
+++ b/packages/migrate/src/cli.ts
@@ -4,39 +4,50 @@ import { resolve } from "node:path";
 import { Command } from "commander";
 import { emitConfig } from "./emit.js";
 import { loadV4Project } from "./load-v4.js";
-import { normalizeProject, type NormalizedMigration } from "./normalize.js";
+import { normalizeProject, type NormalizedMigration, type ProviderRef } from "./normalize.js";
 import { buildReport } from "./report.js";
 import { formatGcpRows, hasGcpBindings, migrateGcpSecrets } from "./migrate-gcp.js";
 
-interface CliOptions {
+interface YamlToTsOptions {
   out: string;
   dryRun?: boolean;
   force?: boolean;
-  acceptRenamedName?: boolean;
-  skipGcp?: boolean;
-  deleteLegacyGcp?: boolean;
+}
+
+interface ProjectNameOptions {
+  dryRun?: boolean;
+  deleteLegacy?: boolean;
 }
 
 const program = new Command();
 
+program.name("keyshelf-migrate").description("Migrate keyshelf v4 projects to v5");
+
 program
-  .name("keyshelf-migrate")
-  .description("Migrate keyshelf v4 YAML files to keyshelf.config.ts")
+  .command("yaml-to-typescript")
+  .description("Convert keyshelf.yaml + .keyshelf/*.yaml into a single keyshelf.config.ts")
   .option("--out <path>", "Output path", "keyshelf.config.ts")
-  .option("--dry-run", "Write generated config to stdout (also dry-runs GCP secret-id migration)")
+  .option("--dry-run", "Write generated config to stdout instead of disk")
   .option("--force", "Overwrite the output file if it already exists")
-  .option("--accept-renamed-name", "Accept converting v4 names with underscores to v5 kebab-case")
-  .option(
-    "--skip-gcp",
-    "Skip the GCP secret-id namespacing step (use only if you have already migrated or are not using gcp)"
-  )
-  .option(
-    "--delete-legacy-gcp",
-    "Delete legacy un-namespaced GCP secrets after copying (use with care)"
-  )
-  .action(async (options: CliOptions) => {
+  .action(async (options: YamlToTsOptions) => {
     try {
-      await run(options);
+      await runYamlToTypescript(options);
+    } catch (err) {
+      console.error(`error: ${err instanceof Error ? err.message : String(err)}`);
+      process.exitCode = 1;
+    }
+  });
+
+program
+  .command("project-name")
+  .description(
+    "Re-namespace remote secret stores under the project name (no-op for age/sops; rewrites GCP secret ids)"
+  )
+  .option("--dry-run", "Report planned changes without writing to remote stores")
+  .option("--delete-legacy", "Delete legacy un-namespaced secrets after copying (use with care)")
+  .action(async (options: ProjectNameOptions) => {
+    try {
+      await runProjectName(options);
     } catch (err) {
       console.error(`error: ${err instanceof Error ? err.message : String(err)}`);
       process.exitCode = 1;
@@ -45,38 +56,17 @@ program
 
 await program.parseAsync(process.argv);
 
-async function run(options: CliOptions): Promise<void> {
-  const project = await loadV4Project(process.cwd());
-  const migration = normalizeProject(project, {
-    acceptRenamedName: options.acceptRenamedName
-  });
-
+async function runYamlToTypescript(options: YamlToTsOptions): Promise<void> {
+  const migration = await loadMigration();
   const outPath = resolve(process.cwd(), options.out);
-  if (!options.dryRun) {
-    assertOutputWritable(outPath, options.force);
+  if (!options.dryRun && existsSync(outPath) && !options.force) {
+    throw new Error(`${outPath} already exists. Re-run with --force to overwrite it.`);
   }
-
-  await runGcpStep(migration, options);
 
   const source = emitConfig(migration);
   const report = buildReport(migration);
 
-  await writeOutput(source, report, outPath, options.dryRun);
-}
-
-function assertOutputWritable(outPath: string, force: boolean | undefined): void {
-  if (existsSync(outPath) && !force) {
-    throw new Error(`${outPath} already exists. Re-run with --force to overwrite it.`);
-  }
-}
-
-async function writeOutput(
-  source: string,
-  report: string,
-  outPath: string,
-  dryRun: boolean | undefined
-): Promise<void> {
-  if (dryRun) {
+  if (options.dryRun) {
     process.stdout.write(source);
     process.stderr.write(report);
     return;
@@ -87,32 +77,80 @@ async function writeOutput(
   process.stderr.write(`Wrote ${outPath}\n`);
 }
 
-async function runGcpStep(migration: NormalizedMigration, options: CliOptions): Promise<void> {
-  if (options.skipGcp) return;
+async function runProjectName(options: ProjectNameOptions): Promise<void> {
+  const migration = await loadMigration();
+  const providers = collectProviders(migration);
+
+  if (providers.size === 0) {
+    process.stderr.write("No secret bindings found; nothing to migrate.\n");
+    return;
+  }
+
+  for (const provider of providers) {
+    await migrateProvider(provider, migration, options);
+  }
+}
+
+async function migrateProvider(
+  provider: ProviderRef["name"],
+  migration: NormalizedMigration,
+  options: ProjectNameOptions
+): Promise<void> {
+  switch (provider) {
+    case "age":
+    case "sops":
+      process.stderr.write(
+        `${provider}: no-op (secrets stay co-located with the project; no remote namespacing required).\n`
+      );
+      return;
+    case "gcp":
+      await runGcpMigration(migration, options);
+      return;
+    default: {
+      const exhaustive: never = provider;
+      throw new Error(`Unsupported provider for project-name migration: ${String(exhaustive)}`);
+    }
+  }
+}
+
+async function runGcpMigration(
+  migration: NormalizedMigration,
+  options: ProjectNameOptions
+): Promise<void> {
   if (!hasGcpBindings(migration)) return;
 
   process.stderr.write(
-    "Migrating GCP secret ids to be namespaced by config name (this runs before keyshelf.config.ts is written so v4 stays usable on failure).\n"
+    "gcp: re-namespacing secret ids under the project name. v4 secrets are left in place unless --delete-legacy is set.\n"
   );
   const result = await migrateGcpSecrets(migration, {
     dryRun: options.dryRun,
-    deleteLegacy: options.deleteLegacyGcp
+    deleteLegacy: options.deleteLegacy
   });
 
-  reportGcpResult(result);
-}
-
-function reportGcpResult(result: {
-  rows: Parameters<typeof formatGcpRows>[0];
-  hadError: boolean;
-}): void {
   const formatted = formatGcpRows(result.rows);
   if (formatted.length > 0) {
     process.stderr.write(`${formatted}\n`);
   }
   if (result.hadError) {
     throw new Error(
-      "GCP secret-id migration finished with errors (see rows above). Resolve the conflicts or re-run with a different --out, then re-run keyshelf-migrate. v4 keyshelf.yaml was left untouched."
+      "GCP secret-id migration finished with errors (see rows above). Resolve the conflicts and re-run."
     );
   }
+}
+
+function collectProviders(migration: NormalizedMigration): Set<ProviderRef["name"]> {
+  const providers = new Set<ProviderRef["name"]>();
+  for (const record of migration.keys) {
+    if (record.kind !== "secret") continue;
+    if (record.default !== undefined) providers.add(record.default.name);
+    for (const value of Object.values(record.values ?? {})) {
+      providers.add(value.name);
+    }
+  }
+  return providers;
+}
+
+async function loadMigration(): Promise<NormalizedMigration> {
+  const project = await loadV4Project(process.cwd());
+  return normalizeProject(project);
 }

--- a/packages/migrate/src/cli.ts
+++ b/packages/migrate/src/cli.ts
@@ -4,7 +4,12 @@ import { resolve } from "node:path";
 import { Command } from "commander";
 import { emitConfig } from "./emit.js";
 import { loadV4Project } from "./load-v4.js";
-import { normalizeProject, type NormalizedMigration, type ProviderRef } from "./normalize.js";
+import {
+  normalizeProject,
+  type NormalizedMigration,
+  type NormalizedRecord,
+  type ProviderRef
+} from "./normalize.js";
 import { buildReport } from "./report.js";
 import { formatGcpRows, hasGcpBindings, migrateGcpSecrets } from "./migrate-gcp.js";
 
@@ -59,10 +64,6 @@ await program.parseAsync(process.argv);
 async function runYamlToTypescript(options: YamlToTsOptions): Promise<void> {
   const migration = await loadMigration();
   const outPath = resolve(process.cwd(), options.out);
-  if (!options.dryRun && existsSync(outPath) && !options.force) {
-    throw new Error(`${outPath} already exists. Re-run with --force to overwrite it.`);
-  }
-
   const source = emitConfig(migration);
   const report = buildReport(migration);
 
@@ -72,9 +73,16 @@ async function runYamlToTypescript(options: YamlToTsOptions): Promise<void> {
     return;
   }
 
+  assertWritable(outPath, options.force === true);
   await writeFile(outPath, source, "utf-8");
   process.stderr.write(report);
   process.stderr.write(`Wrote ${outPath}\n`);
+}
+
+function assertWritable(outPath: string, force: boolean): void {
+  if (!force && existsSync(outPath)) {
+    throw new Error(`${outPath} already exists. Re-run with --force to overwrite it.`);
+  }
 }
 
 async function runProjectName(options: ProjectNameOptions): Promise<void> {
@@ -139,15 +147,15 @@ async function runGcpMigration(
 }
 
 function collectProviders(migration: NormalizedMigration): Set<ProviderRef["name"]> {
-  const providers = new Set<ProviderRef["name"]>();
-  for (const record of migration.keys) {
-    if (record.kind !== "secret") continue;
-    if (record.default !== undefined) providers.add(record.default.name);
-    for (const value of Object.values(record.values ?? {})) {
-      providers.add(value.name);
-    }
-  }
-  return providers;
+  return new Set(migration.keys.flatMap(providerNamesOf));
+}
+
+function providerNamesOf(record: NormalizedRecord): ProviderRef["name"][] {
+  if (record.kind !== "secret") return [];
+  const bindings = [record.default, ...Object.values(record.values ?? {})];
+  return bindings
+    .filter((binding): binding is ProviderRef => binding !== undefined)
+    .map((binding) => binding.name);
 }
 
 async function loadMigration(): Promise<NormalizedMigration> {

--- a/packages/migrate/src/normalize.ts
+++ b/packages/migrate/src/normalize.ts
@@ -37,25 +37,15 @@ export interface NormalizedMigration {
   groups: string[];
   keys: NormalizedRecord[];
   appMapping: AppMapping[];
-  renamedName?: {
-    from: string;
-    to: string;
-  };
 }
 
-export interface NormalizeOptions {
-  acceptRenamedName?: boolean;
-}
-
-const V5_NAME_RE = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
 const V5_PATH_SEGMENT_RE = /^[A-Za-z_][A-Za-z0-9_-]*$/;
 const SUPPORTED_PROVIDERS = new Set(["age", "gcp", "sops"]);
 
-export function normalizeProject(
-  project: V4Project,
-  options: NormalizeOptions = {}
-): NormalizedMigration {
-  const name = normalizeName(project.name, options.acceptRenamedName === true);
+export function normalizeProject(project: V4Project): NormalizedMigration {
+  if (project.name === undefined) {
+    throw new Error('keyshelf.yaml must set top-level "name" before it can be migrated');
+  }
   const envs = project.envs.map((env) => env.name).sort((a, b) => a.localeCompare(b));
   const keys = [...project.schema]
     .sort((a, b) => a.path.localeCompare(b.path))
@@ -64,39 +54,11 @@ export function normalizeProject(
   validatePaths(keys);
 
   return {
-    name: name.value,
+    name: project.name,
     envs,
     groups: [],
     keys,
-    appMapping: project.appMapping,
-    renamedName: name.renamed
-  };
-}
-
-function normalizeName(
-  name: string | undefined,
-  acceptRenamedName: boolean
-): { value: string; renamed?: { from: string; to: string } } {
-  if (name === undefined) {
-    throw new Error('keyshelf.yaml must set top-level "name" before it can be migrated');
-  }
-
-  const lower = name.toLowerCase();
-  const kebab = lower.replaceAll("_", "-");
-  if (name.includes("_") && !acceptRenamedName) {
-    throw new Error(
-      `v4 name "${name}" must be renamed to "${kebab}" for v5. Re-run with --accept-renamed-name to accept this change.`
-    );
-  }
-  if (!V5_NAME_RE.test(kebab)) {
-    throw new Error(
-      `v4 name "${name}" cannot be migrated to a valid v5 name. v5 names must match ${V5_NAME_RE}.`
-    );
-  }
-
-  return {
-    value: kebab,
-    renamed: name === kebab ? undefined : { from: name, to: kebab }
+    appMapping: project.appMapping
   };
 }
 

--- a/packages/migrate/src/report.ts
+++ b/packages/migrate/src/report.ts
@@ -5,16 +5,9 @@ export function buildReport(migration: NormalizedMigration): string {
   const configCount = migration.keys.filter((record) => record.kind === "config").length;
   const secretCount = migration.keys.filter((record) => record.kind === "secret").length;
   const lines: string[] = [
-    `Migrated ${migration.keys.length} keys (${configCount} config, ${secretCount} secret) across ${migration.envs.length} envs.`
+    `Migrated ${migration.keys.length} keys (${configCount} config, ${secretCount} secret) across ${migration.envs.length} envs.`,
+    ""
   ];
-
-  if (migration.renamedName !== undefined) {
-    lines.push(
-      `Renamed project name: ${migration.renamedName.from} -> ${migration.renamedName.to}`
-    );
-  }
-
-  lines.push("");
   lines.push("Secret rebind commands:");
   const commands = buildRebindCommands(migration.keys, migration.envs);
   if (commands.length === 0) {

--- a/packages/migrate/test/__snapshots__/emit.test.ts.snap
+++ b/packages/migrate/test/__snapshots__/emit.test.ts.snap
@@ -83,7 +83,7 @@ exports[`emitConfig > emits stable v5 config for name-rename 1`] = `
 import { defineConfig, gcp, secret } from "keyshelf/config";
 
 export default defineConfig({
-  name: "my-project",
+  name: "My_Project",
   envs: ["dev"],
   // TODO: Add v5 groups and assign group names to records as needed.
   groups: [],

--- a/packages/migrate/test/cli.test.ts
+++ b/packages/migrate/test/cli.test.ts
@@ -21,9 +21,12 @@ describe("keyshelf-migrate CLI", () => {
     roots = [];
   });
 
-  it("writes generated config from the compiled CLI", async () => {
+  it("yaml-to-typescript writes generated config to disk", async () => {
     const root = await copyFixture("basic");
-    const result = spawnSync(process.execPath, [CLI], { cwd: root, encoding: "utf-8" });
+    const result = spawnSync(process.execPath, [CLI, "yaml-to-typescript"], {
+      cwd: root,
+      encoding: "utf-8"
+    });
 
     expect(result.status).toBe(0);
     expect(result.stderr).toContain("Wrote");
@@ -32,9 +35,9 @@ describe("keyshelf-migrate CLI", () => {
     );
   });
 
-  it("writes dry-run output to stdout", async () => {
+  it("yaml-to-typescript writes dry-run output to stdout", async () => {
     const root = await copyFixture("nested");
-    const result = spawnSync(process.execPath, [CLI, "--dry-run"], {
+    const result = spawnSync(process.execPath, [CLI, "yaml-to-typescript", "--dry-run"], {
       cwd: root,
       encoding: "utf-8"
     });
@@ -44,23 +47,40 @@ describe("keyshelf-migrate CLI", () => {
     expect(existsSync(join(root, "keyshelf.config.ts"))).toBe(false);
   });
 
-  it("refuses to overwrite without --force", async () => {
+  it("yaml-to-typescript refuses to overwrite without --force", async () => {
     const root = await copyFixture("basic");
     const out = join(root, "keyshelf.config.ts");
     await writeFile(out, "existing", "utf-8");
 
-    const result = spawnSync(process.execPath, [CLI], { cwd: root, encoding: "utf-8" });
+    const result = spawnSync(process.execPath, [CLI, "yaml-to-typescript"], {
+      cwd: root,
+      encoding: "utf-8"
+    });
 
     expect(result.status).toBe(1);
     expect(result.stderr).toContain("already exists");
     await expect(readFile(out, "utf-8")).resolves.toBe("existing");
   });
 
+  it("project-name reports no-op for age-only fixtures under --dry-run", async () => {
+    const root = await copyFixture("basic");
+    const result = spawnSync(process.execPath, [CLI, "project-name", "--dry-run"], {
+      cwd: root,
+      encoding: "utf-8"
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain("age: no-op");
+  });
+
   it("fails clearly when keyshelf.yaml is absent", async () => {
     const root = await mkdtemp(join(tmpdir(), "keyshelf-migrate-empty-"));
     roots.push(root);
 
-    const result = spawnSync(process.execPath, [CLI], { cwd: root, encoding: "utf-8" });
+    const result = spawnSync(process.execPath, [CLI, "yaml-to-typescript"], {
+      cwd: root,
+      encoding: "utf-8"
+    });
 
     expect(result.status).toBe(1);
     expect(result.stderr).toContain("Could not find keyshelf.yaml");

--- a/packages/migrate/test/emit.test.ts
+++ b/packages/migrate/test/emit.test.ts
@@ -6,7 +6,7 @@ describe("emitConfig", () => {
   it.each(["basic", "multi-env", "optional", "nested", "name-rename"])(
     "emits stable v5 config for %s",
     async (fixture) => {
-      const migration = await loadFixture(fixture, { acceptRenamedName: true });
+      const migration = await loadFixture(fixture);
       expect(emitConfig(migration)).toMatchSnapshot();
     }
   );

--- a/packages/migrate/test/normalize.test.ts
+++ b/packages/migrate/test/normalize.test.ts
@@ -83,12 +83,8 @@ describe("normalizeProject", () => {
     });
   });
 
-  it("requires an explicit acknowledgement for underscore name renames", async () => {
+  it("preserves v4 names with underscores and mixed case as-is", async () => {
     const project = await loadV4Project(fixturePath("name-rename"));
-    expect(() => normalizeProject(project)).toThrow("--accept-renamed-name");
-    expect(normalizeProject(project, { acceptRenamedName: true })).toMatchObject({
-      name: "my-project",
-      renamedName: { from: "My_Project", to: "my-project" }
-    });
+    expect(normalizeProject(project)).toMatchObject({ name: "My_Project" });
   });
 });

--- a/packages/migrate/test/round-trip.test.ts
+++ b/packages/migrate/test/round-trip.test.ts
@@ -21,7 +21,7 @@ describe("round-trip through the keyshelf loader", () => {
   it.each(["basic", "multi-env", "optional", "nested", "name-rename"])(
     "loads emitted %s config",
     async (fixture) => {
-      const migration = await loadFixture(fixture, { acceptRenamedName: true });
+      const migration = await loadFixture(fixture);
       const root = await mkdtemp(join(tmpdir(), `keyshelf-migrate-roundtrip-${fixture}-`));
       roots.push(root);
       await writeFile(join(root, "keyshelf.config.ts"), emitConfig(migration), "utf-8");

--- a/packages/migrate/test/test-utils.ts
+++ b/packages/migrate/test/test-utils.ts
@@ -9,9 +9,6 @@ export function fixturePath(name: string): string {
   return join(here, "fixtures", name);
 }
 
-export async function loadFixture(
-  name: string,
-  options: { acceptRenamedName?: boolean } = {}
-): Promise<NormalizedMigration> {
-  return normalizeProject(await loadV4Project(fixturePath(name)), options);
+export async function loadFixture(name: string): Promise<NormalizedMigration> {
+  return normalizeProject(await loadV4Project(fixturePath(name)));
 }


### PR DESCRIPTION
## Summary

- Now that v4 yaml loads as-is at runtime (#123), most v4 → v5 migrations are a no-op. This PR shrinks `@keyshelf/migrate` to the two non-automatic cases:
  - `keyshelf-migrate yaml-to-typescript` — convert `keyshelf.yaml` + `.keyshelf/*.yaml` to a single `keyshelf.config.ts` (stylistic preference).
  - `keyshelf-migrate project-name` — re-namespace remote secret stores under the project name. Provider-dispatched: `age`/`sops` are explicit no-ops, `gcp` runs the existing rewrite, the exhaustive switch leaves a clean extension point for a future `aws` provider.
- Drop `--accept-renamed-name` and the `V5_NAME_RE` rewriting in `normalize.ts`; relax `CONFIG_NAME_RE` in the cli to v4's `[A-Za-z0-9_-]+`. The name is an opaque string (only used as a segment in GCP secret ids), so canonicalization buys nothing and the kebab-case requirement was a gratuitous breaking change.
- Update `@keyshelf/migrate` README around the new subcommand surface.

Top-level docs (`docs/spec.md`, `docs/migrating-from-v4.md`, `docs/migrating-without-v4-name.md`, cli README) still reference the old flow and the strict name regex — those will follow in a separate doc-only PR.

## Test plan

- [x] `npm test -w @keyshelf/migrate` (30/30 green)
- [x] `npm test -w keyshelf` (164/164 green)
- [x] `npm run typecheck -w keyshelf -w @keyshelf/migrate`
- [ ] CI run on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)