### PR TITLE
fix(action): write identity for sops-only configs (#125)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1737,6 +1737,7 @@
       "version": "4.0.9",
       "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
       "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
@@ -5313,7 +5314,6 @@
       "license": "MIT",
       "dependencies": {
         "@google-cloud/secret-manager": "^6.1.1",
-        "@types/js-yaml": "^4.0.9",
         "age-encryption": "^0.3.0",
         "commander": "^14.0.3",
         "cross-spawn": "^7.0.6",
@@ -5326,6 +5326,7 @@
       },
       "devDependencies": {
         "@types/cross-spawn": "^6.0.6",
+        "@types/js-yaml": "^4.0.9",
         "@types/node": "^25.5.0",
         "tsup": "^8.5.1",
         "tsx": "^4.21.0",

--- a/packages/action/action.yml
+++ b/packages/action/action.yml
@@ -13,7 +13,7 @@ inputs:
     description: Path(s) to .env.keyshelf mapping file(s); newline-separated for multiple
     required: true
   identity:
-    description: Raw identity material (e.g. age private key). Written to the path declared on the matching age provider with mode 0600. Pass via secrets.* — never hard-code.
+    description: Raw identity material (e.g. age private key). Written with mode 0600 to every identityFile path declared by age and sops providers in the config. Pass via secrets.* — never hard-code.
     required: false
     default: ""
   working-directory:

--- a/packages/action/dist/write-identity.mjs
+++ b/packages/action/dist/write-identity.mjs
@@ -2664,22 +2664,24 @@ async function loadAppMapping(mappingPath, required) {
     throw err;
   }
 }
-function ageIdentityFile(binding) {
-  if (binding?.__kind !== "provider:age") return void 0;
+var IDENTITY_PROVIDER_KINDS = /* @__PURE__ */ new Set(["provider:age", "provider:sops"]);
+function identityFile(binding) {
+  if (typeof binding !== "object" || binding === null) return void 0;
+  if (!IDENTITY_PROVIDER_KINDS.has(binding.__kind)) return void 0;
   const file = binding.options?.identityFile;
   return typeof file === "string" && file.length > 0 ? file : void 0;
 }
-function collectAgeIdentityFiles(config2) {
+function collectIdentityFiles(config2) {
   const seen = /* @__PURE__ */ new Set();
   for (const record of config2.keys) {
     if (record.kind !== "secret") continue;
-    addIfAge(seen, record.value);
-    for (const v of Object.values(record.values ?? {})) addIfAge(seen, v);
+    addIfIdentity(seen, record.value);
+    for (const v of Object.values(record.values ?? {})) addIfIdentity(seen, v);
   }
   return [...seen];
 }
-function addIfAge(seen, binding) {
-  const file = ageIdentityFile(binding);
+function addIfIdentity(seen, binding) {
+  const file = identityFile(binding);
   if (file !== void 0) seen.add(file);
 }
 function resolveIdentityPath(filePath, rootDir) {
@@ -2701,10 +2703,10 @@ if (!identity) {
   process.exit(0);
 }
 var loaded = await loadConfig(cwd);
-var identityFiles = collectAgeIdentityFiles(loaded.config);
+var identityFiles = collectIdentityFiles(loaded.config);
 if (identityFiles.length === 0) {
   process.stdout.write(
-    `::warning::'identity' input was provided but config "${loaded.config.name}" declares no age providers. Ignoring.
+    `::warning::'identity' input was provided but config "${loaded.config.name}" declares no providers that consume an identity file. Ignoring.
 `
   );
   process.exit(0);

--- a/packages/action/scripts/identity-paths.mjs
+++ b/packages/action/scripts/identity-paths.mjs
@@ -1,24 +1,27 @@
 import { homedir } from "node:os";
 import { isAbsolute, join, resolve as pathResolve } from "node:path";
 
-export function ageIdentityFile(binding) {
-  if (binding?.__kind !== "provider:age") return undefined;
+const IDENTITY_PROVIDER_KINDS = new Set(["provider:age", "provider:sops"]);
+
+export function identityFile(binding) {
+  if (typeof binding !== "object" || binding === null) return undefined;
+  if (!IDENTITY_PROVIDER_KINDS.has(binding.__kind)) return undefined;
   const file = binding.options?.identityFile;
   return typeof file === "string" && file.length > 0 ? file : undefined;
 }
 
-export function collectAgeIdentityFiles(config) {
+export function collectIdentityFiles(config) {
   const seen = new Set();
   for (const record of config.keys) {
     if (record.kind !== "secret") continue;
-    addIfAge(seen, record.value);
-    for (const v of Object.values(record.values ?? {})) addIfAge(seen, v);
+    addIfIdentity(seen, record.value);
+    for (const v of Object.values(record.values ?? {})) addIfIdentity(seen, v);
   }
   return [...seen];
 }
 
-function addIfAge(seen, binding) {
-  const file = ageIdentityFile(binding);
+function addIfIdentity(seen, binding) {
+  const file = identityFile(binding);
   if (file !== undefined) seen.add(file);
 }
 

--- a/packages/action/scripts/write-identity.mjs
+++ b/packages/action/scripts/write-identity.mjs
@@ -3,7 +3,7 @@ import { writeFile, mkdir, chmod } from "node:fs/promises";
 import { dirname } from "node:path";
 import { loadConfig } from "keyshelf";
 import {
-  collectAgeIdentityFiles,
+  collectIdentityFiles,
   ensureTrailingNewline,
   resolveIdentityPath
 } from "./identity-paths.mjs";
@@ -17,11 +17,11 @@ if (!identity) {
 }
 
 const loaded = await loadConfig(cwd);
-const identityFiles = collectAgeIdentityFiles(loaded.config);
+const identityFiles = collectIdentityFiles(loaded.config);
 
 if (identityFiles.length === 0) {
   process.stdout.write(
-    `::warning::'identity' input was provided but config "${loaded.config.name}" declares no age providers. Ignoring.\n`
+    `::warning::'identity' input was provided but config "${loaded.config.name}" declares no providers that consume an identity file. Ignoring.\n`
   );
   process.exit(0);
 }

--- a/packages/action/test/identity-paths.test.ts
+++ b/packages/action/test/identity-paths.test.ts
@@ -2,53 +2,58 @@ import { describe, it, expect } from "vitest";
 import { homedir } from "node:os";
 import { join, isAbsolute } from "node:path";
 import {
-  ageIdentityFile,
-  collectAgeIdentityFiles,
+  identityFile,
+  collectIdentityFiles,
   ensureTrailingNewline,
   resolveIdentityPath
 } from "../scripts/identity-paths.mjs";
 
-describe("ageIdentityFile", () => {
+describe("identityFile", () => {
   it("returns the identityFile when binding is an age provider with a string path", () => {
-    expect(
-      ageIdentityFile({ __kind: "provider:age", options: { identityFile: "./key.txt" } })
-    ).toBe("./key.txt");
+    expect(identityFile({ __kind: "provider:age", options: { identityFile: "./key.txt" } })).toBe(
+      "./key.txt"
+    );
   });
 
-  it("returns undefined for non-age providers", () => {
+  it("returns the identityFile when binding is a sops provider with a string path", () => {
+    expect(identityFile({ __kind: "provider:sops", options: { identityFile: "./key.txt" } })).toBe(
+      "./key.txt"
+    );
+  });
+
+  it("returns undefined for providers that don't consume an identity file", () => {
     expect(
-      ageIdentityFile({ __kind: "provider:gcp", options: { identityFile: "./key.txt" } })
+      identityFile({ __kind: "provider:gcp", options: { identityFile: "./key.txt" } })
     ).toBeUndefined();
   });
 
   it("returns undefined for null/undefined/non-object bindings", () => {
-    expect(ageIdentityFile(null)).toBeUndefined();
-    expect(ageIdentityFile(undefined)).toBeUndefined();
-    expect(ageIdentityFile("string")).toBeUndefined();
-    expect(ageIdentityFile(42)).toBeUndefined();
+    expect(identityFile(null)).toBeUndefined();
+    expect(identityFile(undefined)).toBeUndefined();
+    expect(identityFile("string")).toBeUndefined();
+    expect(identityFile(42)).toBeUndefined();
   });
 
   it("returns undefined when identityFile is missing or empty", () => {
-    expect(ageIdentityFile({ __kind: "provider:age", options: {} })).toBeUndefined();
+    expect(identityFile({ __kind: "provider:age", options: {} })).toBeUndefined();
+    expect(identityFile({ __kind: "provider:age", options: { identityFile: "" } })).toBeUndefined();
     expect(
-      ageIdentityFile({ __kind: "provider:age", options: { identityFile: "" } })
+      identityFile({ __kind: "provider:age", options: { identityFile: 123 } })
     ).toBeUndefined();
-    expect(
-      ageIdentityFile({ __kind: "provider:age", options: { identityFile: 123 } })
-    ).toBeUndefined();
-    expect(ageIdentityFile({ __kind: "provider:age" })).toBeUndefined();
+    expect(identityFile({ __kind: "provider:age" })).toBeUndefined();
+    expect(identityFile({ __kind: "provider:sops", options: {} })).toBeUndefined();
   });
 });
 
-describe("collectAgeIdentityFiles", () => {
+describe("collectIdentityFiles", () => {
   it("returns empty array when there are no secret records", () => {
     const config = {
       keys: [{ kind: "config", path: "db/host" }]
     };
-    expect(collectAgeIdentityFiles(config)).toEqual([]);
+    expect(collectIdentityFiles(config)).toEqual([]);
   });
 
-  it("collects identityFile from a record's `value` binding", () => {
+  it("collects identityFile from a record's `value` binding (age)", () => {
     const config = {
       keys: [
         {
@@ -58,10 +63,26 @@ describe("collectAgeIdentityFiles", () => {
         }
       ]
     };
-    expect(collectAgeIdentityFiles(config)).toEqual(["./a.txt"]);
+    expect(collectIdentityFiles(config)).toEqual(["./a.txt"]);
   });
 
-  it("collects identityFile from per-env `values` bindings", () => {
+  it("collects identityFile from a record's `value` binding (sops)", () => {
+    const config = {
+      keys: [
+        {
+          kind: "secret",
+          path: "db/password",
+          value: {
+            __kind: "provider:sops",
+            options: { identityFile: "./s.txt", secretsFile: "./s.json" }
+          }
+        }
+      ]
+    };
+    expect(collectIdentityFiles(config)).toEqual(["./s.txt"]);
+  });
+
+  it("collects identityFile from per-env `values` bindings across age and sops", () => {
     const config = {
       keys: [
         {
@@ -69,26 +90,33 @@ describe("collectAgeIdentityFiles", () => {
           path: "db/password",
           values: {
             dev: { __kind: "provider:age", options: { identityFile: "./dev.txt" } },
-            prod: { __kind: "provider:age", options: { identityFile: "./prod.txt" } }
+            prod: {
+              __kind: "provider:sops",
+              options: { identityFile: "./prod.txt", secretsFile: "./prod.json" }
+            }
           }
         }
       ]
     };
-    expect(collectAgeIdentityFiles(config).sort()).toEqual(["./dev.txt", "./prod.txt"]);
+    expect(collectIdentityFiles(config).sort()).toEqual(["./dev.txt", "./prod.txt"]);
   });
 
-  it("deduplicates repeated paths across records and envs", () => {
-    const same = { __kind: "provider:age", options: { identityFile: "./shared.txt" } };
+  it("deduplicates repeated paths across records, envs, and provider kinds", () => {
+    const age = { __kind: "provider:age", options: { identityFile: "./shared.txt" } };
+    const sops = {
+      __kind: "provider:sops",
+      options: { identityFile: "./shared.txt", secretsFile: "./s.json" }
+    };
     const config = {
       keys: [
-        { kind: "secret", path: "a", value: same },
-        { kind: "secret", path: "b", value: same, values: { dev: same } }
+        { kind: "secret", path: "a", value: age },
+        { kind: "secret", path: "b", value: sops, values: { dev: age } }
       ]
     };
-    expect(collectAgeIdentityFiles(config)).toEqual(["./shared.txt"]);
+    expect(collectIdentityFiles(config)).toEqual(["./shared.txt"]);
   });
 
-  it("ignores non-age provider bindings and config keys", () => {
+  it("ignores provider bindings that don't consume an identity file", () => {
     const config = {
       keys: [
         { kind: "config", path: "db/host", value: "localhost" },
@@ -99,7 +127,7 @@ describe("collectAgeIdentityFiles", () => {
         }
       ]
     };
-    expect(collectAgeIdentityFiles(config)).toEqual([]);
+    expect(collectIdentityFiles(config)).toEqual([]);
   });
 });
 

--- a/packages/action/test/scripts.test.ts
+++ b/packages/action/test/scripts.test.ts
@@ -81,7 +81,7 @@ describe("write-identity.mjs", () => {
     expect((await stat(target)).mode & 0o777).toBe(0o600);
   });
 
-  it("warns and skips when the config declares no age providers", async () => {
+  it("warns and skips when the config declares no providers that consume an identity file", async () => {
     const root = await mkdtemp(join(tmpdir(), "keyshelf-action-noage-"));
     await writeFile(
       join(root, "keyshelf.config.ts"),
@@ -104,7 +104,47 @@ describe("write-identity.mjs", () => {
 
     expect(res.status).toBe(0);
     expect(res.stdout).toContain("::warning::");
-    expect(res.stdout).toContain("declares no age providers");
+    expect(res.stdout).toContain("no providers that consume an identity file");
+  });
+
+  it("writes identity for sops-only configs", async () => {
+    const root = await mkdtemp(join(tmpdir(), "keyshelf-action-sops-"));
+    const identity = await generateIdentity();
+
+    await writeFile(
+      join(root, "keyshelf.config.ts"),
+      [
+        'import { defineConfig, secret, sops } from "keyshelf/config";',
+        "",
+        "export default defineConfig({",
+        '  name: "sops-only",',
+        '  envs: ["test"],',
+        "  keys: {",
+        "    db: {",
+        "      password: secret({",
+        "        values: {",
+        '          test: sops({ identityFile: "./keys/sops.txt", secretsFile: "./.keyshelf/secrets/test.json" })',
+        "        }",
+        "      })",
+        "    }",
+        "  }",
+        "});"
+      ].join("\n")
+    );
+
+    const res = spawnSync(process.execPath, [WRITE_IDENTITY], {
+      cwd: root,
+      env: { ...process.env, KEYSHELF_IDENTITY: identity, KEYSHELF_CWD: root },
+      encoding: "utf-8"
+    });
+
+    expect(res.status, res.stderr).toBe(0);
+    expect(res.stdout).toContain("Wrote identity to");
+    expect(res.stdout).toContain("keys/sops.txt");
+
+    const target = join(root, "keys/sops.txt");
+    expect((await readFile(target, "utf-8")).trim()).toBe(identity.trim());
+    expect((await stat(target)).mode & 0o777).toBe(0o600);
   });
 
   it("is a no-op when no identity is provided", async () => {


### PR DESCRIPTION
## Summary

- `keyshelf-action`'s `write-identity` only walked `provider:age` bindings, so configs that exclusively use `sops()` never got the identity file written. CI then failed with `ENOENT` on `SopsProviderOptions.identityFile` for every encrypted key.
- Generalize the walker to collect `identityFile` from both `provider:age` and `provider:sops` bindings, rename `collectAgeIdentityFiles` → `collectIdentityFiles` (and `ageIdentityFile` → `identityFile`), and update the `identity` input description plus the no-providers warning to reflect both kinds.
- Adds a sops-only end-to-end test in `scripts.test.ts` and broadens `identity-paths.test.ts` unit coverage to both provider kinds (single, per-env, dedup, mixed).
- Includes a small lockfile reconciliation: `@types/js-yaml` had drifted into both `dependencies` and `devDependencies` in `package-lock.json`; `npm install` cleaned it up to match `packages/cli/package.json`.

Closes #125.

## Test plan

- [x] `npm test` (workspaces): action 24/24, cli 164/164, migrate 29/29
- [x] `npm run typecheck` clean across all workspaces
- [x] `dist/write-identity.mjs` rebuilt; bundle now references `provider:sops` in the identity walker
- [ ] Re-pin downstream `keyshelf-action` consumers once a new tag ships

🤖 Generated with [Claude Code](https://claude.com/claude-code)