### PR TITLE
feat(cli): keyshelf up apply (phase 4 of keyshelf up)

### DIFF
--- a/packages/action/dist/emit-env.mjs
+++ b/packages/action/dist/emit-env.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { appendFileSync, existsSync } from 'fs';
 import { randomBytes as randomBytes$1, createDecipheriv, createCipheriv, createHmac } from 'crypto';
-import { readFile, mkdir, writeFile, readdir } from 'fs/promises';
+import { readFile, mkdir, writeFile, copyFile, rm, readdir } from 'fs/promises';
 import { dirname, resolve, join, isAbsolute } from 'path';
 import { fileURLToPath } from 'url';
 import { performance } from 'perf_hooks';
@@ -3024,6 +3024,10 @@ var PlaintextProvider = class {
   }
   async list() {
     return [];
+  }
+  async copy() {
+  }
+  async delete() {
   }
 };
 
@@ -11680,6 +11684,18 @@ var AgeProvider = class {
     await mkdir(dirname(filePath), { recursive: true });
     await writeFile(filePath, ciphertext);
   }
+  async copy(from, to) {
+    const opts2 = this.resolveOptions(from);
+    const fromPath = secretFilePath(opts2.secretsDir, from.keyPath);
+    const toPath = secretFilePath(opts2.secretsDir, to.keyPath);
+    await mkdir(dirname(toPath), { recursive: true });
+    await copyFile(fromPath, toPath);
+  }
+  async delete(ctx) {
+    const opts2 = this.resolveOptions(ctx);
+    const filePath = secretFilePath(opts2.secretsDir, ctx.keyPath);
+    await rm(filePath, { force: true });
+  }
   async list(ctx) {
     const secretsDir = resolvePath(requireStringConfig("age", ctx, "secretsDir"), ctx.rootDir);
     let entries;
@@ -11804,6 +11820,37 @@ var SopsProvider = class {
       };
     }
     file.entries[ctx.keyPath] = encryptValue(dataKey, value);
+    file.sops.mac = computeMac(dataKey, file.entries);
+    await writeSecretsFile(opts2.secretsFile, file);
+  }
+  async copy(from, to) {
+    const opts2 = this.resolveOptions(from);
+    const file = await readSecretsFile(opts2.secretsFile);
+    const identity = await readIdentity(opts2.identityFile);
+    const dataKey = await decryptDataKey(file.sops.dataKey, identity);
+    verifyMac(dataKey, file);
+    const entry = file.entries[from.keyPath];
+    if (!entry) {
+      throw new Error(`sops: source key "${from.keyPath}" not found in ${opts2.secretsFile}`);
+    }
+    file.entries[to.keyPath] = entry;
+    file.sops.mac = computeMac(dataKey, file.entries);
+    await writeSecretsFile(opts2.secretsFile, file);
+  }
+  async delete(ctx) {
+    const opts2 = this.resolveOptions(ctx);
+    let file;
+    try {
+      file = await readSecretsFile(opts2.secretsFile);
+    } catch (err) {
+      if (err.code === "ENOENT") return;
+      throw err;
+    }
+    if (!(ctx.keyPath in file.entries)) return;
+    const identity = await readIdentity(opts2.identityFile);
+    const dataKey = await decryptDataKey(file.sops.dataKey, identity);
+    verifyMac(dataKey, file);
+    delete file.entries[ctx.keyPath];
     file.sops.mac = computeMac(dataKey, file.entries);
     await writeSecretsFile(opts2.secretsFile, file);
   }

--- a/packages/action/dist/emit-env.mjs
+++ b/packages/action/dist/emit-env.mjs
@@ -11779,15 +11779,22 @@ var SopsProvider = class {
   }
   async resolve(ctx) {
     const opts2 = this.resolveOptions(ctx);
-    const file = await readSecretsFile(opts2.secretsFile);
-    const identity = await readIdentity(opts2.identityFile);
-    const dataKey = await decryptDataKey(file.sops.dataKey, identity);
-    verifyMac(dataKey, file);
+    const { file, dataKey } = await this.openVerified(opts2);
     const entry = file.entries[ctx.keyPath];
     if (!entry) {
       throw new Error(`sops: secret "${ctx.keyPath}" not found in ${opts2.secretsFile}`);
     }
     return decryptValue(dataKey, entry);
+  }
+  // Read the secrets file, decrypt the data key with the provider identity,
+  // and verify the MAC. Shared between read paths (resolve, copy) so the
+  // tamper-detection sequence stays in one place.
+  async openVerified(opts2) {
+    const file = await readSecretsFile(opts2.secretsFile);
+    const identity = await readIdentity(opts2.identityFile);
+    const dataKey = await decryptDataKey(file.sops.dataKey, identity);
+    verifyMac(dataKey, file);
+    return { file, dataKey };
   }
   async validate(ctx) {
     try {
@@ -11825,10 +11832,7 @@ var SopsProvider = class {
   }
   async copy(from, to) {
     const opts2 = this.resolveOptions(from);
-    const file = await readSecretsFile(opts2.secretsFile);
-    const identity = await readIdentity(opts2.identityFile);
-    const dataKey = await decryptDataKey(file.sops.dataKey, identity);
-    verifyMac(dataKey, file);
+    const { file, dataKey } = await this.openVerified(opts2);
     const entry = file.entries[from.keyPath];
     if (!entry) {
       throw new Error(`sops: source key "${from.keyPath}" not found in ${opts2.secretsFile}`);
@@ -11839,17 +11843,15 @@ var SopsProvider = class {
   }
   async delete(ctx) {
     const opts2 = this.resolveOptions(ctx);
-    let file;
+    let probe;
     try {
-      file = await readSecretsFile(opts2.secretsFile);
+      probe = await readSecretsFile(opts2.secretsFile);
     } catch (err) {
       if (err.code === "ENOENT") return;
       throw err;
     }
-    if (!(ctx.keyPath in file.entries)) return;
-    const identity = await readIdentity(opts2.identityFile);
-    const dataKey = await decryptDataKey(file.sops.dataKey, identity);
-    verifyMac(dataKey, file);
+    if (!(ctx.keyPath in probe.entries)) return;
+    const { file, dataKey } = await this.openVerified(opts2);
     delete file.entries[ctx.keyPath];
     file.sops.mac = computeMac(dataKey, file.entries);
     await writeSecretsFile(opts2.secretsFile, file);

--- a/packages/cli/src/cli/up.ts
+++ b/packages/cli/src/cli/up.ts
@@ -2,7 +2,7 @@ import { Command } from "commander";
 import { createInterface } from "node:readline/promises";
 import { loadConfig } from "../config/index.js";
 import { createDefaultRegistry } from "../providers/setup.js";
-import { ProviderRegistry } from "../providers/registry.js";
+import type { ProviderRegistry } from "../providers/registry.js";
 import {
   AmbiguousActionsError,
   ApplyValidationError,

--- a/packages/cli/src/cli/up.ts
+++ b/packages/cli/src/cli/up.ts
@@ -1,36 +1,41 @@
 import { Command } from "commander";
+import { createInterface } from "node:readline/promises";
 import { loadConfig } from "../config/index.js";
 import { createDefaultRegistry } from "../providers/setup.js";
+import { ProviderRegistry } from "../providers/registry.js";
+import {
+  AmbiguousActionsError,
+  ApplyValidationError,
+  applyPlan,
+  type ApplyResult
+} from "../reconcile/apply.js";
 import { gatherListings, type ListingFailure } from "../reconcile/listings.js";
 import { planReconciliation } from "../reconcile/planner.js";
 import { countMutatingActions, renderPlan } from "../reconcile/format.js";
+import type { Plan } from "../reconcile/plan.js";
+import type { NormalizedConfig } from "../config/types.js";
 
 interface UpOptions {
   plan?: boolean;
+  yes?: boolean;
 }
 
 export const upCommand = new Command("up")
-  .description("Reconcile config against provider storage (Phase 3: read-only --plan)")
+  .description("Reconcile config against provider storage (plan + apply)")
   .option("--plan", "Show the reconciliation plan without mutating storage")
+  .option("--yes", "Skip the confirmation prompt and apply immediately")
   .action(async (opts: UpOptions) => {
-    // Phase 3 only ships read-only behavior. Whether or not --plan is passed,
-    // `up` does not mutate storage. Phase 4 will add the apply path.
-    void opts;
-    await runPlan();
+    try {
+      const exitCode = await runUp(opts);
+      process.exit(exitCode);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`error: ${msg}`);
+      process.exit(1);
+    }
   });
 
-async function runPlan(): Promise<void> {
-  try {
-    const exitCode = await computePlanExitCode();
-    process.exit(exitCode);
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    console.error(`error: ${msg}`);
-    process.exit(1);
-  }
-}
-
-async function computePlanExitCode(): Promise<number> {
+async function runUp(opts: UpOptions): Promise<number> {
   const loaded = await loadConfig(process.cwd());
   const registry = createDefaultRegistry();
 
@@ -39,13 +44,84 @@ async function computePlanExitCode(): Promise<number> {
     registry,
     rootDir: loaded.rootDir
   });
-
   reportFailures(failures);
 
   const plan = planReconciliation(loaded.config, listings);
   process.stdout.write(renderPlan(plan));
 
-  return countMutatingActions(plan) === 0 ? 0 : 2;
+  // --plan: read-only drift-check.
+  if (opts.plan) {
+    return countMutatingActions(plan) === 0 ? 0 : 2;
+  }
+
+  if (countMutatingActions(plan) === 0) return 0;
+
+  // Apply path. Refuse on Ambiguous before prompting so the user sees the
+  // message immediately rather than after typing 'y'.
+  if (planHasAmbiguous(plan)) {
+    console.error(
+      "error: cannot apply — plan contains ambiguous actions. " +
+        "Add a movedFrom annotation on each ambiguous key, then re-run."
+    );
+    return 1;
+  }
+
+  if (!opts.yes) {
+    const confirmed = await confirm("\nApply these changes? [y/N] ");
+    if (!confirmed) {
+      process.stdout.write("Apply cancelled.\n");
+      return 0;
+    }
+  }
+
+  return runApply(plan, loaded.config, registry, loaded.rootDir);
+}
+
+async function runApply(
+  plan: Plan,
+  config: NormalizedConfig,
+  registry: ProviderRegistry,
+  rootDir: string
+): Promise<number> {
+  try {
+    const result = await applyPlan({ config, registry, rootDir }, plan);
+    process.stdout.write(`\n${formatApplySummary(result)}\n`);
+    return 0;
+  } catch (err) {
+    if (err instanceof AmbiguousActionsError || err instanceof ApplyValidationError) {
+      console.error(`error: ${err.message}`);
+      return 1;
+    }
+    throw err;
+  }
+}
+
+function planHasAmbiguous(plan: Plan): boolean {
+  for (const a of plan) if (a.kind === "ambiguous") return true;
+  return false;
+}
+
+function formatApplySummary(result: ApplyResult): string {
+  const parts: string[] = [];
+  if (result.renamesApplied > 0) {
+    parts.push(`${result.renamesApplied} rename${result.renamesApplied === 1 ? "" : "s"}`);
+  }
+  if (result.deletesApplied > 0) {
+    parts.push(`${result.deletesApplied} delete${result.deletesApplied === 1 ? "" : "s"}`);
+  }
+  if (parts.length === 0) parts.push("no changes");
+  return `Applied: ${parts.join(", ")}.`;
+}
+
+async function confirm(prompt: string): Promise<boolean> {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const answer = await rl.question(prompt);
+    const normalized = answer.trim().toLowerCase();
+    return normalized === "y" || normalized === "yes";
+  } finally {
+    rl.close();
+  }
 }
 
 function reportFailures(failures: ListingFailure[]): void {

--- a/packages/cli/src/providers/age.ts
+++ b/packages/cli/src/providers/age.ts
@@ -1,4 +1,4 @@
-import { readFile, writeFile, mkdir, readdir } from "node:fs/promises";
+import { readFile, writeFile, mkdir, readdir, copyFile, rm } from "node:fs/promises";
 import type { Dirent } from "node:fs";
 import { dirname, join } from "node:path";
 import { Encrypter, Decrypter, generateIdentity, identityToRecipient } from "age-encryption";
@@ -73,6 +73,22 @@ export class AgeProvider implements Provider {
     const filePath = secretFilePath(opts.secretsDir, ctx.keyPath);
     await mkdir(dirname(filePath), { recursive: true });
     await writeFile(filePath, ciphertext);
+  }
+
+  async copy(from: ProviderContext, to: ProviderContext): Promise<void> {
+    // Recipient is fixed in v5, so a byte-level copy is sufficient — no
+    // need to decrypt and re-encrypt.
+    const opts = this.resolveOptions(from);
+    const fromPath = secretFilePath(opts.secretsDir, from.keyPath);
+    const toPath = secretFilePath(opts.secretsDir, to.keyPath);
+    await mkdir(dirname(toPath), { recursive: true });
+    await copyFile(fromPath, toPath);
+  }
+
+  async delete(ctx: ProviderContext): Promise<void> {
+    const opts = this.resolveOptions(ctx);
+    const filePath = secretFilePath(opts.secretsDir, ctx.keyPath);
+    await rm(filePath, { force: true });
   }
 
   async list(ctx: ProviderListContext): Promise<StoredKey[]> {

--- a/packages/cli/src/providers/gcp-sm.ts
+++ b/packages/cli/src/providers/gcp-sm.ts
@@ -114,32 +114,8 @@ export class GcpSmProvider implements Provider {
     const secretId = toSecretId(ctx.keyshelfName, ctx.envName, ctx.keyPath);
     const parent = `projects/${opts.project}`;
 
-    // Create secret if it doesn't exist
-    try {
-      await this.client.createSecret({
-        parent,
-        secretId,
-        secret: { replication: { automatic: {} } }
-      });
-    } catch (err: unknown) {
-      if (isAuthError(err)) throw new GcpAuthError(err as Error);
-      const code = (err as { code?: number }).code;
-      if (code !== 6) {
-        // 6 = ALREADY_EXISTS
-        throw err;
-      }
-    }
-
-    // Add new version
-    try {
-      await this.client.addSecretVersion({
-        parent: `${parent}/secrets/${secretId}`,
-        payload: { data: Buffer.from(value, "utf-8") }
-      });
-    } catch (err) {
-      if (isAuthError(err)) throw new GcpAuthError(err as Error);
-      throw err;
-    }
+    await this.ensureSecret(parent, secretId);
+    await this.addVersion(parent, secretId, Buffer.from(value, "utf-8"));
   }
 
   async copy(from: ProviderContext, to: ProviderContext): Promise<void> {
@@ -149,11 +125,17 @@ export class GcpSmProvider implements Provider {
     const parent = `projects/${opts.project}`;
 
     const payload = await this.readPayload(parent, fromId);
+    await this.ensureSecret(parent, toId);
+    await this.addVersion(parent, toId, payload);
+  }
 
+  // Idempotent: a 6/ALREADY_EXISTS response is treated as success so callers
+  // can use this for both create and copy paths.
+  private async ensureSecret(parent: string, secretId: string): Promise<void> {
     try {
       await this.client.createSecret({
         parent,
-        secretId: toId,
+        secretId,
         secret: { replication: { automatic: {} } }
       });
     } catch (err: unknown) {
@@ -161,11 +143,13 @@ export class GcpSmProvider implements Provider {
       const code = (err as { code?: number }).code;
       if (code !== 6) throw err;
     }
+  }
 
+  private async addVersion(parent: string, secretId: string, data: Buffer): Promise<void> {
     try {
       await this.client.addSecretVersion({
-        parent: `${parent}/secrets/${toId}`,
-        payload: { data: payload }
+        parent: `${parent}/secrets/${secretId}`,
+        payload: { data }
       });
     } catch (err) {
       if (isAuthError(err)) throw new GcpAuthError(err as Error);

--- a/packages/cli/src/providers/gcp-sm.ts
+++ b/packages/cli/src/providers/gcp-sm.ts
@@ -142,6 +142,70 @@ export class GcpSmProvider implements Provider {
     }
   }
 
+  async copy(from: ProviderContext, to: ProviderContext): Promise<void> {
+    const opts = this.resolveOptions(from);
+    const fromId = toSecretId(from.keyshelfName, from.envName, from.keyPath);
+    const toId = toSecretId(to.keyshelfName, to.envName, to.keyPath);
+    const parent = `projects/${opts.project}`;
+
+    const payload = await this.readPayload(parent, fromId);
+
+    try {
+      await this.client.createSecret({
+        parent,
+        secretId: toId,
+        secret: { replication: { automatic: {} } }
+      });
+    } catch (err: unknown) {
+      if (isAuthError(err)) throw new GcpAuthError(err as Error);
+      const code = (err as { code?: number }).code;
+      if (code !== 6) throw err;
+    }
+
+    try {
+      await this.client.addSecretVersion({
+        parent: `${parent}/secrets/${toId}`,
+        payload: { data: payload }
+      });
+    } catch (err) {
+      if (isAuthError(err)) throw new GcpAuthError(err as Error);
+      throw err;
+    }
+  }
+
+  async delete(ctx: ProviderContext): Promise<void> {
+    const opts = this.resolveOptions(ctx);
+    const id = toSecretId(ctx.keyshelfName, ctx.envName, ctx.keyPath);
+    try {
+      await this.client.deleteSecret({
+        name: `projects/${opts.project}/secrets/${id}`
+      });
+    } catch (err) {
+      if (isAuthError(err)) throw new GcpAuthError(err as Error);
+      // 5 = NOT_FOUND. Idempotent: deleting an already-gone secret succeeds.
+      const code = (err as { code?: number }).code;
+      if (code === 5) return;
+      throw err;
+    }
+  }
+
+  private async readPayload(parent: string, secretId: string): Promise<Buffer> {
+    let version;
+    try {
+      [version] = await this.client.accessSecretVersion({
+        name: `${parent}/secrets/${secretId}/versions/latest`
+      });
+    } catch (err) {
+      if (isAuthError(err)) throw new GcpAuthError(err as Error);
+      throw err;
+    }
+    const data = version.payload?.data;
+    if (data === null || data === undefined) {
+      throw new Error(`gcp: source secret "${secretId}" has no payload`);
+    }
+    return typeof data === "string" ? Buffer.from(data, "utf-8") : Buffer.from(data);
+  }
+
   async list(ctx: ProviderListContext): Promise<StoredKey[]> {
     const project = ctx.config.project;
     if (typeof project !== "string") {

--- a/packages/cli/src/providers/plaintext.ts
+++ b/packages/cli/src/providers/plaintext.ts
@@ -25,4 +25,12 @@ export class PlaintextProvider implements Provider {
   async list(): Promise<StoredKey[]> {
     return [];
   }
+
+  async copy(): Promise<void> {
+    // No-op: plaintext has no storage to move bytes between.
+  }
+
+  async delete(): Promise<void> {
+    // No-op: plaintext has no storage to remove.
+  }
 }

--- a/packages/cli/src/providers/sops.ts
+++ b/packages/cli/src/providers/sops.ts
@@ -115,11 +115,7 @@ export class SopsProvider implements Provider {
 
   async resolve(ctx: ProviderContext): Promise<string> {
     const opts = this.resolveOptions(ctx);
-    const file = await readSecretsFile(opts.secretsFile);
-    const identity = await readIdentity(opts.identityFile);
-    const dataKey = await decryptDataKey(file.sops.dataKey, identity);
-
-    verifyMac(dataKey, file);
+    const { file, dataKey } = await this.openVerified(opts);
 
     const entry = file.entries[ctx.keyPath];
     if (!entry) {
@@ -127,6 +123,19 @@ export class SopsProvider implements Provider {
     }
 
     return decryptValue(dataKey, entry);
+  }
+
+  // Read the secrets file, decrypt the data key with the provider identity,
+  // and verify the MAC. Shared between read paths (resolve, copy) so the
+  // tamper-detection sequence stays in one place.
+  private async openVerified(
+    opts: SopsProviderOptions
+  ): Promise<{ file: SecretsFile; dataKey: Buffer }> {
+    const file = await readSecretsFile(opts.secretsFile);
+    const identity = await readIdentity(opts.identityFile);
+    const dataKey = await decryptDataKey(file.sops.dataKey, identity);
+    verifyMac(dataKey, file);
+    return { file, dataKey };
   }
 
   async validate(ctx: ProviderContext): Promise<boolean> {
@@ -173,10 +182,7 @@ export class SopsProvider implements Provider {
 
   async copy(from: ProviderContext, to: ProviderContext): Promise<void> {
     const opts = this.resolveOptions(from);
-    const file = await readSecretsFile(opts.secretsFile);
-    const identity = await readIdentity(opts.identityFile);
-    const dataKey = await decryptDataKey(file.sops.dataKey, identity);
-    verifyMac(dataKey, file);
+    const { file, dataKey } = await this.openVerified(opts);
 
     const entry = file.entries[from.keyPath];
     if (!entry) {
@@ -189,19 +195,16 @@ export class SopsProvider implements Provider {
 
   async delete(ctx: ProviderContext): Promise<void> {
     const opts = this.resolveOptions(ctx);
-    let file: SecretsFile;
+    let probe: SecretsFile;
     try {
-      file = await readSecretsFile(opts.secretsFile);
+      probe = await readSecretsFile(opts.secretsFile);
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code === "ENOENT") return;
       throw err;
     }
-    if (!(ctx.keyPath in file.entries)) return;
+    if (!(ctx.keyPath in probe.entries)) return;
 
-    const identity = await readIdentity(opts.identityFile);
-    const dataKey = await decryptDataKey(file.sops.dataKey, identity);
-    verifyMac(dataKey, file);
-
+    const { file, dataKey } = await this.openVerified(opts);
     delete file.entries[ctx.keyPath];
     file.sops.mac = computeMac(dataKey, file.entries);
     await writeSecretsFile(opts.secretsFile, file);

--- a/packages/cli/src/providers/sops.ts
+++ b/packages/cli/src/providers/sops.ts
@@ -171,6 +171,42 @@ export class SopsProvider implements Provider {
     await writeSecretsFile(opts.secretsFile, file);
   }
 
+  async copy(from: ProviderContext, to: ProviderContext): Promise<void> {
+    const opts = this.resolveOptions(from);
+    const file = await readSecretsFile(opts.secretsFile);
+    const identity = await readIdentity(opts.identityFile);
+    const dataKey = await decryptDataKey(file.sops.dataKey, identity);
+    verifyMac(dataKey, file);
+
+    const entry = file.entries[from.keyPath];
+    if (!entry) {
+      throw new Error(`sops: source key "${from.keyPath}" not found in ${opts.secretsFile}`);
+    }
+    file.entries[to.keyPath] = entry;
+    file.sops.mac = computeMac(dataKey, file.entries);
+    await writeSecretsFile(opts.secretsFile, file);
+  }
+
+  async delete(ctx: ProviderContext): Promise<void> {
+    const opts = this.resolveOptions(ctx);
+    let file: SecretsFile;
+    try {
+      file = await readSecretsFile(opts.secretsFile);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return;
+      throw err;
+    }
+    if (!(ctx.keyPath in file.entries)) return;
+
+    const identity = await readIdentity(opts.identityFile);
+    const dataKey = await decryptDataKey(file.sops.dataKey, identity);
+    verifyMac(dataKey, file);
+
+    delete file.entries[ctx.keyPath];
+    file.sops.mac = computeMac(dataKey, file.entries);
+    await writeSecretsFile(opts.secretsFile, file);
+  }
+
   async list(ctx: ProviderListContext): Promise<StoredKey[]> {
     const identityFile = resolvePath(requireStringConfig("sops", ctx, "identityFile"), ctx.rootDir);
     const secretsFile = resolvePath(requireStringConfig("sops", ctx, "secretsFile"), ctx.rootDir);

--- a/packages/cli/src/providers/types.ts
+++ b/packages/cli/src/providers/types.ts
@@ -36,4 +36,12 @@ export interface Provider {
   validate(ctx: ProviderContext): Promise<boolean>;
   set(ctx: ProviderContext, value: string): Promise<void>;
   list(ctx: ProviderListContext): Promise<StoredKey[]>;
+  // Move bytes from one storage location to another within this provider
+  // instance. Both contexts share rootDir/config/keyshelfName; only the
+  // keyPath/envName differ. Implementations should NOT delete `from` —
+  // the apply pipeline calls `delete` separately after validating `to`.
+  copy(from: ProviderContext, to: ProviderContext): Promise<void>;
+  // Remove a single storage entry. Idempotent: succeeds if the entry is
+  // already absent.
+  delete(ctx: ProviderContext): Promise<void>;
 }

--- a/packages/cli/src/reconcile/apply.ts
+++ b/packages/cli/src/reconcile/apply.ts
@@ -1,0 +1,112 @@
+import type { NormalizedConfig } from "../config/types.js";
+import type { ProviderRegistry } from "../providers/registry.js";
+import type { ProviderContext } from "../providers/types.js";
+import type { DeleteAction, Plan, RenameAction } from "./plan.js";
+
+export interface ApplyContext {
+  config: NormalizedConfig;
+  registry: ProviderRegistry;
+  rootDir: string;
+}
+
+export interface ApplyResult {
+  renamesApplied: number;
+  deletesApplied: number;
+}
+
+export class AmbiguousActionsError extends Error {
+  readonly count: number;
+  constructor(count: number) {
+    super(
+      `Refusing to apply: plan contains ${count} ambiguous action${count === 1 ? "" : "s"}. ` +
+        `Add a movedFrom annotation to disambiguate, then re-run.`
+    );
+    this.name = "AmbiguousActionsError";
+    this.count = count;
+  }
+}
+
+// Thrown when copy succeeds but the new location does not validate. We do
+// NOT call delete in this case, so the source bytes remain intact and a
+// follow-up `up` will simply replan.
+export class ApplyValidationError extends Error {
+  readonly action: RenameAction;
+  readonly envName: string | undefined;
+  constructor(action: RenameAction, envName: string | undefined) {
+    const envSuffix = envName === undefined ? "" : ` [${envName}]`;
+    super(
+      `Apply aborted: copied "${action.from.keyPath}" → "${action.to.keyPath}"${envSuffix}, ` +
+        `but validate failed at the new location. Source is intact; investigate and re-run.`
+    );
+    this.name = "ApplyValidationError";
+    this.action = action;
+    this.envName = envName;
+  }
+}
+
+// Execute a plan against provider storage. Sequential by design: failures are
+// easier to reason about, and provider rate limits are real. Per-Rename order
+// is copy → validate → delete; standalone Deletes run after all renames so a
+// validate-fail can abort before any orphans are removed.
+export async function applyPlan(ctx: ApplyContext, plan: Plan): Promise<ApplyResult> {
+  const ambiguousCount = countAmbiguous(plan);
+  if (ambiguousCount > 0) throw new AmbiguousActionsError(ambiguousCount);
+
+  let renamesApplied = 0;
+  let deletesApplied = 0;
+
+  for (const action of plan) {
+    if (action.kind === "rename") {
+      await applyRename(ctx, action);
+      renamesApplied += 1;
+    }
+  }
+
+  for (const action of plan) {
+    if (action.kind === "delete") {
+      await applyDelete(ctx, action);
+      deletesApplied += 1;
+    }
+  }
+
+  return { renamesApplied, deletesApplied };
+}
+
+function countAmbiguous(plan: Plan): number {
+  let n = 0;
+  for (const a of plan) if (a.kind === "ambiguous") n += 1;
+  return n;
+}
+
+async function applyRename(ctx: ApplyContext, action: RenameAction): Promise<void> {
+  const provider = ctx.registry.get(action.providerName);
+  for (const envName of action.envBindings) {
+    const fromCtx = buildCtx(ctx, action.providerParams, action.from.keyPath, envName);
+    const toCtx = buildCtx(ctx, action.providerParams, action.to.keyPath, envName);
+    await provider.copy(fromCtx, toCtx);
+    const ok = await provider.validate(toCtx);
+    if (!ok) throw new ApplyValidationError(action, envName);
+    await provider.delete(fromCtx);
+  }
+}
+
+async function applyDelete(ctx: ApplyContext, action: DeleteAction): Promise<void> {
+  const provider = ctx.registry.get(action.providerName);
+  const target = buildCtx(ctx, action.providerParams, action.keyPath, action.envName);
+  await provider.delete(target);
+}
+
+function buildCtx(
+  ctx: ApplyContext,
+  providerParams: unknown,
+  keyPath: string,
+  envName: string | undefined
+): ProviderContext {
+  return {
+    keyPath,
+    envName,
+    rootDir: ctx.rootDir,
+    config: (providerParams ?? {}) as unknown as Record<string, unknown>,
+    keyshelfName: ctx.config.name
+  };
+}

--- a/packages/cli/src/reconcile/internal/emit.ts
+++ b/packages/cli/src/reconcile/internal/emit.ts
@@ -19,18 +19,27 @@ export function appendLeafActions(
 ): void {
   for (const [path, envs] of byPath) {
     for (const env of envs) {
-      actions.push(buildLeafAction(state.providerName, kind, path, env));
+      actions.push(buildLeafAction(state, kind, path, env));
     }
   }
 }
 
 function buildLeafAction(
-  providerName: string,
+  state: InstanceState,
   kind: LeafKind,
   path: string,
   env: string
 ): NoOpAction | CreateAction | DeleteAction {
-  return { kind, keyPath: path, envName: envKeyValue(env), providerName };
+  if (kind === "delete") {
+    return {
+      kind,
+      keyPath: path,
+      envName: envKeyValue(env),
+      providerName: state.providerName,
+      providerParams: state.providerParams
+    };
+  }
+  return { kind, keyPath: path, envName: envKeyValue(env), providerName: state.providerName };
 }
 
 export function appendList<T extends RenameAction | AmbiguousAction>(

--- a/packages/cli/src/reconcile/internal/rename.ts
+++ b/packages/cli/src/reconcile/internal/rename.ts
@@ -149,7 +149,7 @@ class RenameResolver {
     desiredEnvs: EnvSet,
     orphanEnvs: EnvSet
   ): void {
-    const rename = buildRename(this.state.providerName, fromPath, toPath, desiredEnvs, orphanEnvs);
+    const rename = buildRename(this.state, fromPath, toPath, desiredEnvs, orphanEnvs);
     this.renames.push(rename);
     consumeEnvs(this.unmetByPath, toPath, rename.envBindings);
     consumeEnvs(this.orphansByPath, fromPath, rename.envBindings);
@@ -189,7 +189,7 @@ function consumeEnvs(
 }
 
 function buildRename(
-  providerName: string,
+  state: InstanceState,
   fromPath: string,
   toPath: string,
   desiredEnvs: EnvSet,
@@ -208,7 +208,8 @@ function buildRename(
     kind: "rename",
     from: { keyPath: fromPath },
     to: { keyPath: toPath },
-    providerName,
+    providerName: state.providerName,
+    providerParams: state.providerParams,
     envBindings
   };
 }

--- a/packages/cli/src/reconcile/plan.ts
+++ b/packages/cli/src/reconcile/plan.ts
@@ -16,6 +16,10 @@ export interface RenameAction {
   from: { keyPath: string };
   to: { keyPath: string };
   providerName: string;
+  // Provider params for the instance both endpoints belong to. Apply uses
+  // this to construct the ProviderContext that copy/delete need; the
+  // formatter ignores it.
+  providerParams: unknown;
   envBindings: Array<string | undefined>;
 }
 
@@ -24,6 +28,9 @@ export interface DeleteAction {
   keyPath: string;
   envName: string | undefined;
   providerName: string;
+  // Provider params for the instance the orphan belongs to. Apply uses
+  // this to scope the delete to the correct instance.
+  providerParams: unknown;
 }
 
 export interface NoOpAction {

--- a/packages/cli/test/e2e/up.test.ts
+++ b/packages/cli/test/e2e/up.test.ts
@@ -322,14 +322,9 @@ describe("keyshelf up --yes (apply)", () => {
     expect(result.status).toBe(1);
     expect(result.stderr).toContain("ambiguous");
     // Storage left untouched.
-    const ctxFor = (keyPath: string) => ({
-      keyPath,
-      envName: undefined,
-      rootDir: root,
-      config: { identityFile, secretsDir }
-    });
-    expect(await provider.validate(ctxFor("oldA"))).toBe(true);
-    expect(await provider.validate(ctxFor("oldB"))).toBe(true);
+    const baseCtx = { envName: undefined, rootDir: root, config: { identityFile, secretsDir } };
+    expect(await provider.validate({ ...baseCtx, keyPath: "oldA" })).toBe(true);
+    expect(await provider.validate({ ...baseCtx, keyPath: "oldB" })).toBe(true);
   });
 
   it("interactive default: 'n' on the prompt cancels without mutating storage (exit 0)", async () => {

--- a/packages/cli/test/e2e/up.test.ts
+++ b/packages/cli/test/e2e/up.test.ts
@@ -13,12 +13,13 @@ interface CliResult {
   status: number;
 }
 
-function runUp(cwd: string, args: string[] = []): CliResult {
+function runUp(cwd: string, args: string[] = [], stdin = ""): CliResult {
   try {
     const stdout = execFileSync(TSX, [CLI, "up", ...args], {
       cwd,
       encoding: "utf-8",
-      stdio: ["ignore", "pipe", "pipe"]
+      input: stdin,
+      stdio: ["pipe", "pipe", "pipe"]
     });
     return { stdout, stderr: "", status: 0 };
   } catch (err) {
@@ -169,5 +170,230 @@ describe("keyshelf up --plan", () => {
     const result = runUp(root, ["--plan"]);
     expect(result.status).toBe(1);
     expect(result.stderr).toContain("error:");
+  });
+});
+
+describe("keyshelf up --yes (apply)", () => {
+  let root: string;
+  let identityFile: string;
+  let secretsDir: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "keyshelf-up-apply-"));
+    ({ identityFile, secretsDir } = await setupAgeFixtureDir(root));
+  });
+
+  it("applies a Rename: bytes move from old keyPath to new keyPath, source removed", async () => {
+    await writeKeyshelfConfig(root, [
+      `name: "demo",`,
+      `envs: ["dev"],`,
+      `keys: {`,
+      `  databases: {`,
+      `    auth: {`,
+      `      dbPassword: secret({`,
+      `        value: age({ identityFile: ${JSON.stringify(identityFile)}, secretsDir: ${JSON.stringify(secretsDir)} }),`,
+      `        movedFrom: "supabase/db-password",`,
+      `      }),`,
+      `    },`,
+      `  },`,
+      `},`
+    ]);
+
+    const provider = new AgeProvider();
+    await provider.set(
+      {
+        keyPath: "supabase/db-password",
+        envName: undefined,
+        rootDir: root,
+        config: { identityFile, secretsDir }
+      },
+      "the-password"
+    );
+
+    const result = runUp(root, ["--yes"]);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("1 to rename");
+    expect(result.stdout).toContain("Applied: 1 rename");
+
+    // Source removed, destination present with the same value.
+    const newCtx = {
+      keyPath: "databases/auth/dbPassword",
+      envName: undefined,
+      rootDir: root,
+      config: { identityFile, secretsDir }
+    };
+    const oldCtx = { ...newCtx, keyPath: "supabase/db-password" };
+    expect(await provider.validate(newCtx)).toBe(true);
+    expect(await provider.validate(oldCtx)).toBe(false);
+    expect(await provider.resolve(newCtx)).toBe("the-password");
+  });
+
+  it("applies a Delete: orphan storage is removed", async () => {
+    await writeKeyshelfConfig(root, [
+      `name: "demo",`,
+      `envs: ["dev"],`,
+      `keys: {`,
+      `  token: secret({ value: age({ identityFile: ${JSON.stringify(identityFile)}, secretsDir: ${JSON.stringify(secretsDir)} }) }),`,
+      `},`
+    ]);
+    const provider = new AgeProvider();
+    await provider.set(
+      { keyPath: "token", envName: undefined, rootDir: root, config: { identityFile, secretsDir } },
+      "current"
+    );
+    await provider.set(
+      {
+        keyPath: "legacy",
+        envName: undefined,
+        rootDir: root,
+        config: { identityFile, secretsDir }
+      },
+      "old"
+    );
+
+    const result = runUp(root, ["--yes"]);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("Applied: 1 delete");
+
+    expect(
+      await provider.validate({
+        keyPath: "legacy",
+        envName: undefined,
+        rootDir: root,
+        config: { identityFile, secretsDir }
+      })
+    ).toBe(false);
+    expect(
+      await provider.validate({
+        keyPath: "token",
+        envName: undefined,
+        rootDir: root,
+        config: { identityFile, secretsDir }
+      })
+    ).toBe(true);
+  });
+
+  it("is idempotent: running --yes twice leaves the second invocation as a no-op", async () => {
+    await writeKeyshelfConfig(root, [
+      `name: "demo",`,
+      `envs: ["dev"],`,
+      `keys: {`,
+      `  token: secret({ value: age({ identityFile: ${JSON.stringify(identityFile)}, secretsDir: ${JSON.stringify(secretsDir)} }) }),`,
+      `},`
+    ]);
+    const provider = new AgeProvider();
+    await provider.set(
+      { keyPath: "token", envName: undefined, rootDir: root, config: { identityFile, secretsDir } },
+      "v"
+    );
+    await provider.set(
+      { keyPath: "stale", envName: undefined, rootDir: root, config: { identityFile, secretsDir } },
+      "old"
+    );
+
+    const first = runUp(root, ["--yes"]);
+    expect(first.status).toBe(0);
+    expect(first.stdout).toContain("Applied: 1 delete");
+
+    const second = runUp(root, ["--yes"]);
+    expect(second.status).toBe(0);
+    expect(second.stdout).toContain("No changes. Storage is in sync with the config.");
+  });
+
+  it("refuses to apply when the plan contains Ambiguous actions (exit 1)", async () => {
+    await writeKeyshelfConfig(root, [
+      `name: "demo",`,
+      `envs: ["dev"],`,
+      `keys: {`,
+      `  newKey: secret({ value: age({ identityFile: ${JSON.stringify(identityFile)}, secretsDir: ${JSON.stringify(secretsDir)} }) }),`,
+      `},`
+    ]);
+    const provider = new AgeProvider();
+    await provider.set(
+      { keyPath: "oldA", envName: undefined, rootDir: root, config: { identityFile, secretsDir } },
+      "a"
+    );
+    await provider.set(
+      { keyPath: "oldB", envName: undefined, rootDir: root, config: { identityFile, secretsDir } },
+      "b"
+    );
+
+    const result = runUp(root, ["--yes"]);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("ambiguous");
+    // Storage left untouched.
+    const ctxFor = (keyPath: string) => ({
+      keyPath,
+      envName: undefined,
+      rootDir: root,
+      config: { identityFile, secretsDir }
+    });
+    expect(await provider.validate(ctxFor("oldA"))).toBe(true);
+    expect(await provider.validate(ctxFor("oldB"))).toBe(true);
+  });
+
+  it("interactive default: 'n' on the prompt cancels without mutating storage (exit 0)", async () => {
+    await writeKeyshelfConfig(root, [
+      `name: "demo",`,
+      `envs: ["dev"],`,
+      `keys: {`,
+      `  token: secret({ value: age({ identityFile: ${JSON.stringify(identityFile)}, secretsDir: ${JSON.stringify(secretsDir)} }) }),`,
+      `},`
+    ]);
+    const provider = new AgeProvider();
+    // token in storage matches the desired key — `stale` is therefore a
+    // pure orphan, not a rename candidate.
+    await provider.set(
+      { keyPath: "token", envName: undefined, rootDir: root, config: { identityFile, secretsDir } },
+      "current"
+    );
+    await provider.set(
+      { keyPath: "stale", envName: undefined, rootDir: root, config: { identityFile, secretsDir } },
+      "old"
+    );
+
+    const result = runUp(root, [], "n\n");
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("Apply cancelled.");
+    // Stale remains.
+    expect(
+      await provider.validate({
+        keyPath: "stale",
+        envName: undefined,
+        rootDir: root,
+        config: { identityFile, secretsDir }
+      })
+    ).toBe(true);
+  });
+
+  it("interactive default: 'y' on the prompt applies the plan", async () => {
+    await writeKeyshelfConfig(root, [
+      `name: "demo",`,
+      `envs: ["dev"],`,
+      `keys: {`,
+      `  token: secret({ value: age({ identityFile: ${JSON.stringify(identityFile)}, secretsDir: ${JSON.stringify(secretsDir)} }) }),`,
+      `},`
+    ]);
+    const provider = new AgeProvider();
+    await provider.set(
+      { keyPath: "token", envName: undefined, rootDir: root, config: { identityFile, secretsDir } },
+      "current"
+    );
+    await provider.set(
+      { keyPath: "stale", envName: undefined, rootDir: root, config: { identityFile, secretsDir } },
+      "old"
+    );
+
+    const result = runUp(root, [], "y\n");
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("Applied: 1 delete");
+    expect(
+      await provider.validate({
+        keyPath: "stale",
+        envName: undefined,
+        rootDir: root,
+        config: { identityFile, secretsDir }
+      })
+    ).toBe(false);
   });
 });

--- a/packages/cli/test/unit/providers/age.test.ts
+++ b/packages/cli/test/unit/providers/age.test.ts
@@ -69,4 +69,35 @@ describe("AgeProvider", () => {
       ).rejects.toThrow('age provider requires "secretsDir" config for list');
     });
   });
+
+  describe("copy", () => {
+    it("copies bytes from source to destination, leaving source intact", async () => {
+      await state.provider.set(state.ctx("old/path"), "value-x");
+      await state.provider.copy(state.ctx("old/path"), state.ctx("new/path"));
+
+      expect(await state.provider.resolve(state.ctx("new/path"))).toBe("value-x");
+      // Source still present until delete is called separately.
+      expect(await state.provider.resolve(state.ctx("old/path"))).toBe("value-x");
+    });
+
+    it("throws when source does not exist", async () => {
+      await expect(
+        state.provider.copy(state.ctx("missing"), state.ctx("destination"))
+      ).rejects.toThrow();
+    });
+  });
+
+  describe("delete", () => {
+    it("removes the storage entry", async () => {
+      await state.provider.set(state.ctx("victim"), "v");
+      expect(await state.provider.validate(state.ctx("victim"))).toBe(true);
+
+      await state.provider.delete(state.ctx("victim"));
+      expect(await state.provider.validate(state.ctx("victim"))).toBe(false);
+    });
+
+    it("is idempotent — succeeds when entry is already absent", async () => {
+      await expect(state.provider.delete(state.ctx("never-existed"))).resolves.toBeUndefined();
+    });
+  });
 });

--- a/packages/cli/test/unit/providers/gcp-sm.test.ts
+++ b/packages/cli/test/unit/providers/gcp-sm.test.ts
@@ -8,7 +8,8 @@ function mockClient() {
     getSecret: vi.fn(),
     createSecret: vi.fn(),
     addSecretVersion: vi.fn(),
-    listSecrets: vi.fn()
+    listSecrets: vi.fn(),
+    deleteSecret: vi.fn()
   };
 }
 
@@ -320,6 +321,96 @@ describe("GcpSmProvider", () => {
         Object.assign(new Error("UNAUTHENTICATED"), { code: 16 })
       );
       await expect(provider.list(listCtx())).rejects.toThrow(GcpAuthError);
+    });
+  });
+
+  describe("copy", () => {
+    function copyCtx(keyPath: string, envName: string | undefined = "prod") {
+      return { keyPath, envName, rootDir: "/tmp", config: { project: "my-proj" } };
+    }
+
+    it("reads payload from source then creates target and adds version", async () => {
+      client.accessSecretVersion.mockResolvedValue([
+        { payload: { data: Buffer.from("payload-bytes") } }
+      ]);
+      client.createSecret.mockResolvedValue([{}]);
+      client.addSecretVersion.mockResolvedValue([{}]);
+
+      await provider.copy(copyCtx("old/key"), copyCtx("new/key"));
+
+      expect(client.accessSecretVersion).toHaveBeenCalledWith({
+        name: "projects/my-proj/secrets/keyshelf__prod__old__key/versions/latest"
+      });
+      expect(client.createSecret).toHaveBeenCalledWith({
+        parent: "projects/my-proj",
+        secretId: "keyshelf__prod__new__key",
+        secret: { replication: { automatic: {} } }
+      });
+      expect(client.addSecretVersion).toHaveBeenCalledWith({
+        parent: "projects/my-proj/secrets/keyshelf__prod__new__key",
+        payload: { data: Buffer.from("payload-bytes") }
+      });
+      // copy must NOT delete the source — apply pipeline does that after validate.
+      expect(client.deleteSecret).not.toHaveBeenCalled();
+    });
+
+    it("treats ALREADY_EXISTS on createSecret as recoverable (still adds version)", async () => {
+      client.accessSecretVersion.mockResolvedValue([{ payload: { data: Buffer.from("v") } }]);
+      client.createSecret.mockRejectedValue(
+        Object.assign(new Error("ALREADY_EXISTS"), { code: 6 })
+      );
+      client.addSecretVersion.mockResolvedValue([{}]);
+
+      await provider.copy(copyCtx("a"), copyCtx("b"));
+      expect(client.addSecretVersion).toHaveBeenCalled();
+    });
+
+    it("rethrows non-recoverable createSecret errors", async () => {
+      client.accessSecretVersion.mockResolvedValue([{ payload: { data: Buffer.from("v") } }]);
+      client.createSecret.mockRejectedValue(
+        Object.assign(new Error("PERMISSION_DENIED"), { code: 7 })
+      );
+
+      await expect(provider.copy(copyCtx("a"), copyCtx("b"))).rejects.toThrow("PERMISSION_DENIED");
+    });
+
+    it("throws when source has no payload", async () => {
+      client.accessSecretVersion.mockResolvedValue([{ payload: { data: null } }]);
+      await expect(provider.copy(copyCtx("a"), copyCtx("b"))).rejects.toThrow("has no payload");
+    });
+
+    it("wraps auth errors during accessSecretVersion as GcpAuthError", async () => {
+      client.accessSecretVersion.mockRejectedValue(
+        Object.assign(new Error("UNAUTHENTICATED"), { code: 16 })
+      );
+      await expect(provider.copy(copyCtx("a"), copyCtx("b"))).rejects.toThrow(GcpAuthError);
+    });
+  });
+
+  describe("delete", () => {
+    it("calls deleteSecret with the derived id", async () => {
+      client.deleteSecret.mockResolvedValue([{}]);
+      await provider.delete(ctx("legacy/key"));
+      expect(client.deleteSecret).toHaveBeenCalledWith({
+        name: "projects/my-proj/secrets/keyshelf__prod__legacy__key"
+      });
+    });
+
+    it("is idempotent on NOT_FOUND (gRPC code 5)", async () => {
+      client.deleteSecret.mockRejectedValue(Object.assign(new Error("NOT_FOUND"), { code: 5 }));
+      await expect(provider.delete(ctx("ghost"))).resolves.toBeUndefined();
+    });
+
+    it("rethrows other errors", async () => {
+      client.deleteSecret.mockRejectedValue(Object.assign(new Error("INTERNAL"), { code: 13 }));
+      await expect(provider.delete(ctx("k"))).rejects.toThrow("INTERNAL");
+    });
+
+    it("wraps auth errors as GcpAuthError", async () => {
+      client.deleteSecret.mockRejectedValue(
+        Object.assign(new Error("UNAUTHENTICATED"), { code: 16 })
+      );
+      await expect(provider.delete(ctx("k"))).rejects.toThrow(GcpAuthError);
     });
   });
 });

--- a/packages/cli/test/unit/providers/sops.test.ts
+++ b/packages/cli/test/unit/providers/sops.test.ts
@@ -133,4 +133,55 @@ describe("SopsProvider", () => {
       ).rejects.toThrow('sops provider requires "identityFile" config for list');
     });
   });
+
+  describe("copy", () => {
+    it("copies the encrypted entry under a new key, preserving the source", async () => {
+      await state.provider.set(state.ctx("old/path"), "value-x");
+      await state.provider.copy(state.ctx("old/path"), state.ctx("new/path"));
+
+      expect(await state.provider.resolve(state.ctx("new/path"))).toBe("value-x");
+      expect(await state.provider.resolve(state.ctx("old/path"))).toBe("value-x");
+    });
+
+    it("re-MACs after copy so list/resolve still validate", async () => {
+      await state.provider.set(state.ctx("a"), "v1");
+      await state.provider.copy(state.ctx("a"), state.ctx("b"));
+      // resolve verifies the MAC; if it weren't recomputed this would throw.
+      expect(await state.provider.resolve(state.ctx("b"))).toBe("v1");
+    });
+
+    it("throws when source key is absent", async () => {
+      await state.provider.set(state.ctx("only"), "v");
+      await expect(
+        state.provider.copy(state.ctx("missing"), state.ctx("destination"))
+      ).rejects.toThrow('source key "missing" not found');
+    });
+  });
+
+  describe("delete", () => {
+    it("removes the entry and re-MACs", async () => {
+      await state.provider.set(state.ctx("a"), "v1");
+      await state.provider.set(state.ctx("b"), "v2");
+      await state.provider.delete(state.ctx("a"));
+
+      expect(await state.provider.validate(state.ctx("a"))).toBe(false);
+      // MAC must remain valid for the surviving entry.
+      expect(await state.provider.resolve(state.ctx("b"))).toBe("v2");
+    });
+
+    it("is idempotent on missing entry", async () => {
+      await state.provider.set(state.ctx("a"), "v1");
+      await expect(state.provider.delete(state.ctx("never"))).resolves.toBeUndefined();
+    });
+
+    it("is idempotent on missing file", async () => {
+      const ctx = {
+        keyPath: "k",
+        envName: "test",
+        rootDir: state.tmpDir,
+        config: { identityFile: state.identityFile, secretsFile: join(state.tmpDir, "nope.json") }
+      };
+      await expect(state.provider.delete(ctx)).resolves.toBeUndefined();
+    });
+  });
 });

--- a/packages/cli/test/unit/reconcile/apply.test.ts
+++ b/packages/cli/test/unit/reconcile/apply.test.ts
@@ -1,0 +1,291 @@
+import { describe, expect, it, vi } from "vitest";
+import { defineConfig, normalizeConfig } from "../../../src/config/index.js";
+import { ProviderRegistry } from "../../../src/providers/registry.js";
+import type {
+  Provider,
+  ProviderContext,
+  ProviderListContext,
+  StorageScope,
+  StoredKey
+} from "../../../src/providers/types.js";
+import {
+  AmbiguousActionsError,
+  ApplyValidationError,
+  applyPlan
+} from "../../../src/reconcile/apply.js";
+import type { Plan } from "../../../src/reconcile/plan.js";
+
+class StubProvider implements Provider {
+  name: string;
+  storageScope: StorageScope;
+  copy = vi.fn<(from: ProviderContext, to: ProviderContext) => Promise<void>>().mockResolvedValue();
+  validate = vi.fn<(ctx: ProviderContext) => Promise<boolean>>().mockResolvedValue(true);
+  delete = vi.fn<(ctx: ProviderContext) => Promise<void>>().mockResolvedValue();
+
+  constructor(name: string, storageScope: StorageScope = "envless") {
+    this.name = name;
+    this.storageScope = storageScope;
+  }
+
+  resolve(): Promise<string> {
+    return Promise.reject(new Error("not used"));
+  }
+  set(): Promise<void> {
+    return Promise.resolve();
+  }
+  list(_ctx: ProviderListContext): Promise<StoredKey[]> {
+    void _ctx;
+    return Promise.resolve([]);
+  }
+}
+
+function buildRegistry(providers: Provider[]): ProviderRegistry {
+  const registry = new ProviderRegistry();
+  for (const p of providers) registry.register(p);
+  return registry;
+}
+
+const cfg = normalizeConfig(
+  defineConfig({
+    name: "myapp",
+    envs: ["dev", "prod"],
+    keys: { _placeholder: "x" }
+  })
+);
+
+const ageParams = { identityFile: "./id.txt", secretsDir: "./secrets" };
+
+describe("applyPlan", () => {
+  it("executes a Rename as copy → validate → delete, in that order, per env binding", async () => {
+    const age = new StubProvider("age");
+    const callOrder: string[] = [];
+    age.copy.mockImplementation(async () => {
+      callOrder.push("copy");
+    });
+    age.validate.mockImplementation(async () => {
+      callOrder.push("validate");
+      return true;
+    });
+    age.delete.mockImplementation(async () => {
+      callOrder.push("delete");
+    });
+
+    const plan: Plan = [
+      {
+        kind: "rename",
+        from: { keyPath: "old/path" },
+        to: { keyPath: "new/path" },
+        providerName: "age",
+        providerParams: ageParams,
+        envBindings: [undefined]
+      }
+    ];
+
+    const result = await applyPlan(
+      { config: cfg, registry: buildRegistry([age]), rootDir: "/tmp/root" },
+      plan
+    );
+
+    expect(callOrder).toEqual(["copy", "validate", "delete"]);
+    expect(result).toEqual({ renamesApplied: 1, deletesApplied: 0 });
+  });
+
+  it("propagates providerParams and rootDir into the ProviderContext", async () => {
+    const age = new StubProvider("age");
+    const plan: Plan = [
+      {
+        kind: "rename",
+        from: { keyPath: "old" },
+        to: { keyPath: "new" },
+        providerName: "age",
+        providerParams: ageParams,
+        envBindings: [undefined]
+      }
+    ];
+
+    await applyPlan({ config: cfg, registry: buildRegistry([age]), rootDir: "/tmp/root" }, plan);
+
+    const fromArg = age.copy.mock.calls[0][0];
+    const toArg = age.copy.mock.calls[0][1];
+    expect(fromArg.config).toEqual(ageParams);
+    expect(fromArg.rootDir).toBe("/tmp/root");
+    expect(fromArg.keyshelfName).toBe("myapp");
+    expect(fromArg.keyPath).toBe("old");
+    expect(toArg.keyPath).toBe("new");
+  });
+
+  it("processes each envBinding sequentially for a per-env rename", async () => {
+    const gcp = new StubProvider("gcp", "perEnv");
+    const order: string[] = [];
+    gcp.copy.mockImplementation(async (_from, to) => {
+      order.push(`copy:${to.envName}`);
+    });
+    gcp.validate.mockImplementation(async (ctx) => {
+      order.push(`validate:${ctx.envName}`);
+      return true;
+    });
+    gcp.delete.mockImplementation(async (ctx) => {
+      order.push(`delete:${ctx.envName}`);
+    });
+
+    const plan: Plan = [
+      {
+        kind: "rename",
+        from: { keyPath: "old" },
+        to: { keyPath: "new" },
+        providerName: "gcp",
+        providerParams: { project: "p" },
+        envBindings: ["dev", "prod"]
+      }
+    ];
+
+    await applyPlan({ config: cfg, registry: buildRegistry([gcp]), rootDir: "/r" }, plan);
+
+    expect(order).toEqual([
+      "copy:dev",
+      "validate:dev",
+      "delete:dev",
+      "copy:prod",
+      "validate:prod",
+      "delete:prod"
+    ]);
+  });
+
+  it("aborts on validate failure: source remains intact (delete never called)", async () => {
+    const age = new StubProvider("age");
+    age.validate.mockResolvedValue(false);
+
+    const plan: Plan = [
+      {
+        kind: "rename",
+        from: { keyPath: "old" },
+        to: { keyPath: "new" },
+        providerName: "age",
+        providerParams: ageParams,
+        envBindings: [undefined]
+      }
+    ];
+
+    await expect(
+      applyPlan({ config: cfg, registry: buildRegistry([age]), rootDir: "/r" }, plan)
+    ).rejects.toBeInstanceOf(ApplyValidationError);
+
+    expect(age.copy).toHaveBeenCalledTimes(1);
+    expect(age.delete).not.toHaveBeenCalled();
+  });
+
+  it("executes a standalone Delete as a single delete call", async () => {
+    const age = new StubProvider("age");
+
+    const plan: Plan = [
+      {
+        kind: "delete",
+        keyPath: "legacy/orphan",
+        envName: undefined,
+        providerName: "age",
+        providerParams: ageParams
+      }
+    ];
+
+    const result = await applyPlan(
+      { config: cfg, registry: buildRegistry([age]), rootDir: "/r" },
+      plan
+    );
+
+    expect(age.delete).toHaveBeenCalledTimes(1);
+    expect(age.delete.mock.calls[0][0].keyPath).toBe("legacy/orphan");
+    expect(result).toEqual({ renamesApplied: 0, deletesApplied: 1 });
+  });
+
+  it("runs all renames before any standalone deletes", async () => {
+    const age = new StubProvider("age");
+    const order: string[] = [];
+    age.copy.mockImplementation(async (_from, to) => {
+      order.push(`copy:${to.keyPath}`);
+    });
+    age.delete.mockImplementation(async (ctx) => {
+      order.push(`delete:${ctx.keyPath}`);
+    });
+
+    const plan: Plan = [
+      {
+        kind: "delete",
+        keyPath: "orphan",
+        envName: undefined,
+        providerName: "age",
+        providerParams: ageParams
+      },
+      {
+        kind: "rename",
+        from: { keyPath: "from" },
+        to: { keyPath: "to" },
+        providerName: "age",
+        providerParams: ageParams,
+        envBindings: [undefined]
+      }
+    ];
+
+    await applyPlan({ config: cfg, registry: buildRegistry([age]), rootDir: "/r" }, plan);
+
+    expect(order).toEqual(["copy:to", "delete:from", "delete:orphan"]);
+  });
+
+  it("skips Create and NoOp actions (they don't touch storage in apply)", async () => {
+    const age = new StubProvider("age");
+
+    const plan: Plan = [
+      { kind: "create", keyPath: "new", envName: undefined, providerName: "age" },
+      { kind: "noop", keyPath: "stable", envName: undefined, providerName: "age" }
+    ];
+
+    const result = await applyPlan(
+      { config: cfg, registry: buildRegistry([age]), rootDir: "/r" },
+      plan
+    );
+
+    expect(age.copy).not.toHaveBeenCalled();
+    expect(age.delete).not.toHaveBeenCalled();
+    expect(result).toEqual({ renamesApplied: 0, deletesApplied: 0 });
+  });
+
+  it("refuses to apply when the plan contains Ambiguous actions", async () => {
+    const age = new StubProvider("age");
+
+    const plan: Plan = [
+      {
+        kind: "ambiguous",
+        desired: { keyPath: "new", providerName: "age" },
+        candidates: [
+          { keyPath: "oldA", providerName: "age" },
+          { keyPath: "oldB", providerName: "age" }
+        ],
+        hint: "..."
+      },
+      {
+        kind: "delete",
+        keyPath: "other",
+        envName: undefined,
+        providerName: "age",
+        providerParams: ageParams
+      }
+    ];
+
+    await expect(
+      applyPlan({ config: cfg, registry: buildRegistry([age]), rootDir: "/r" }, plan)
+    ).rejects.toBeInstanceOf(AmbiguousActionsError);
+
+    expect(age.copy).not.toHaveBeenCalled();
+    expect(age.delete).not.toHaveBeenCalled();
+  });
+
+  it("is idempotent: an empty plan applies cleanly with zero counts", async () => {
+    const age = new StubProvider("age");
+    const result = await applyPlan(
+      { config: cfg, registry: buildRegistry([age]), rootDir: "/r" },
+      []
+    );
+    expect(result).toEqual({ renamesApplied: 0, deletesApplied: 0 });
+    expect(age.copy).not.toHaveBeenCalled();
+    expect(age.delete).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/test/unit/reconcile/format.test.ts
+++ b/packages/cli/test/unit/reconcile/format.test.ts
@@ -32,7 +32,13 @@ describe("renderPlan", () => {
 
   it("renders delete actions with orphan annotation", () => {
     const plan: Plan = [
-      { kind: "delete", keyPath: "legacy", envName: undefined, providerName: "age" }
+      {
+        kind: "delete",
+        keyPath: "legacy",
+        envName: undefined,
+        providerName: "age",
+        providerParams: {}
+      }
     ];
     const out = renderPlan(plan);
     expect(out).toContain("- legacy   (orphan; will be deleted on apply)");
@@ -46,6 +52,7 @@ describe("renderPlan", () => {
         from: { keyPath: "supabase/db-password" },
         to: { keyPath: "databases/auth/dbPassword" },
         providerName: "age",
+        providerParams: {},
         envBindings: [undefined]
       }
     ];
@@ -80,12 +87,19 @@ describe("renderPlan", () => {
     const plan: Plan = [
       { kind: "noop", keyPath: "a", envName: undefined, providerName: "age" },
       { kind: "create", keyPath: "b", envName: undefined, providerName: "age" },
-      { kind: "delete", keyPath: "c", envName: undefined, providerName: "age" },
+      {
+        kind: "delete",
+        keyPath: "c",
+        envName: undefined,
+        providerName: "age",
+        providerParams: {}
+      },
       {
         kind: "rename",
         from: { keyPath: "d-old" },
         to: { keyPath: "d" },
         providerName: "age",
+        providerParams: {},
         envBindings: [undefined]
       },
       {

--- a/packages/cli/test/unit/reconcile/planner.test.ts
+++ b/packages/cli/test/unit/reconcile/planner.test.ts
@@ -114,7 +114,8 @@ describe("planReconciliation", () => {
         kind: "delete",
         keyPath: "legacy/old-thing",
         envName: undefined,
-        providerName: "age"
+        providerName: "age",
+        providerParams: ageOpts
       }
     ]);
   });
@@ -140,6 +141,7 @@ describe("planReconciliation", () => {
         from: { keyPath: "supabase/db-password" },
         to: { keyPath: "databases/auth/dbPassword" },
         providerName: "age",
+        providerParams: ageOpts,
         envBindings: [undefined]
       }
     ]);
@@ -193,6 +195,7 @@ describe("planReconciliation", () => {
         from: { keyPath: "old-a" },
         to: { keyPath: "newKey" },
         providerName: "age",
+        providerParams: ageOpts,
         envBindings: [undefined]
       }
     ]);
@@ -203,7 +206,8 @@ describe("planReconciliation", () => {
         kind: "delete",
         keyPath: "old-b",
         envName: undefined,
-        providerName: "age"
+        providerName: "age",
+        providerParams: ageOpts
       }
     ]);
   });
@@ -237,7 +241,8 @@ describe("planReconciliation", () => {
         kind: "delete",
         keyPath: "old-key",
         envName: "dev",
-        providerName: "gcp"
+        providerName: "gcp",
+        providerParams: gcpOpts
       }
     ]);
   });
@@ -267,6 +272,7 @@ describe("planReconciliation", () => {
         from: { keyPath: "old-key" },
         to: { keyPath: "newKey" },
         providerName: "gcp",
+        providerParams: gcpOpts,
         envBindings: ["dev"]
       }
     ]);
@@ -325,7 +331,8 @@ describe("planReconciliation", () => {
         kind: "delete",
         keyPath: "token",
         envName: "dev",
-        providerName: "gcp"
+        providerName: "gcp",
+        providerParams: { project: "proj-a" }
       }
     ]);
   });


### PR DESCRIPTION
## Summary

Phase 4 of the keyshelf up plan — `keyshelf up` now mutates storage.

- **`copy` / `delete` on the Provider interface**: `copy(from, to)` clones bytes between storage locations without deleting the source; `delete(ctx)` is idempotent. Implemented for age (file copy + rm), sops (clone encrypted entry + re-MAC; delete entry + re-MAC), gcp (`createSecret` + `addSecretVersion` at the new id; `deleteSecret` on NOT_FOUND-tolerant), and plaintext (no-ops).
- **Apply pipeline** (`reconcile/apply.ts`): per-Rename order is copy → validate → delete; if validate fails the source is left intact so a re-plan can fix it. Standalone Deletes run after all renames. Refuses on Ambiguous via `AmbiguousActionsError`.
- **CLI wiring**: `keyshelf up` (no flags) prints the plan, prompts `Apply? [y/N]`, applies on confirmation; `--yes` skips the prompt; `--plan` keeps the Phase 3 read-only drift-check (exit 0/2/1). Prints `Applied: 2 renames, 1 delete` on success.
- `RenameAction` and `DeleteAction` now carry `providerParams` so apply can route to the correct instance; the formatter ignores it.

## Test plan
- [x] `npm run typecheck` — pass
- [x] `npm run lint` — pass
- [x] `npm run format:check` — pass
- [x] `npm run build` — pass
- [x] cli unit + e2e (215 tests) — pass
- [x] action (21 tests) — pass
- [x] migrate (29 tests) — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)