### PR TITLE
docs: reflect v4-yaml runtime support and migrate restructure

### DIFF
--- a/docs/migrating-from-v4.md
+++ b/docs/migrating-from-v4.md
@@ -1,53 +1,29 @@
 # Migrating from keyshelf v4
 
-v5 is a clean rewrite. Configs are TypeScript, every key is a self-contained record, and `set` no longer touches the config file. There is no in-place upgrade — generate a starter config with the migrator, then review.
+In v5, your existing `keyshelf.yaml` + `.keyshelf/<env>.yaml` files are still a valid runtime format — the v5 CLI parses them into the same internal shape as `keyshelf.config.ts`. For most projects, **upgrading is no migration at all**: bump the `keyshelf` version, run the CLI, and your YAML keeps working.
 
-## Run the migrator
+The `@keyshelf/migrate` package covers the two cases that aren't automatic:
 
-From the repo root that contains your v4 `keyshelf.yaml`:
+- You want to switch authoring formats from YAML to TypeScript (autocomplete on key paths, IDE help on provider options).
+- You're using GCP secrets that were written before v4.6 added a `name:` field, and you want their secret IDs re-namespaced under the new `name`.
 
-```sh
-npx @keyshelf/migrate
-```
+If neither applies, you can stop reading here. Run `keyshelf ls --env <env>` against your existing config and confirm everything resolves.
 
-This reads `keyshelf.yaml`, every `.keyshelf/<env>.yaml`, and the root `.env.keyshelf` (if present), and writes a starter `keyshelf.config.ts`. The v4 YAML files are left in place. App-level `.env.keyshelf` mappings keep working as-is.
+## What changed at runtime
 
-Useful flags:
-
-```sh
-npx @keyshelf/migrate --dry-run                 # print the generated config to stdout
-npx @keyshelf/migrate --out ./keyshelf.config.ts --force
-npx @keyshelf/migrate --accept-renamed-name     # if your v4 name has underscores
-```
-
-## What changed
-
-### Config file
-
-| v4                                                     | v5                                                       |
-| ------------------------------------------------------ | -------------------------------------------------------- |
-| `keyshelf.yaml` + `.keyshelf/<env>.yaml` (one per env) | One `keyshelf.config.ts`                                 |
-| `default-provider:` block per env file                 | Provider binding lives on each `secret(...)` record      |
-| `!secret`, `!age`, `!gcp`, `!sops` YAML tags           | `secret(...)`, `age(...)`, `gcp(...)`, `sops(...)` calls |
-| Plaintext values in env files override schema defaults | `values: { <env>: ... }` on the record itself            |
-| `name:` introduced in v4.6 to namespace GCP secrets    | `name:` is required and validated as `lower-kebab-case`  |
-
-Every key's full story is now local to its declaration. There are no env-file-level overrides — to override a value per env, set `values` on the record:
-
-```ts
-db: {
-  host: config({
-    default: "localhost",
-    values: { production: "prod-db.internal" }
-  });
-}
-```
+| v4                                                     | v5                                                                                    |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------- |
+| `keyshelf.yaml` + `.keyshelf/<env>.yaml`               | Same files still work, **or** a single `keyshelf.config.ts`                           |
+| `default-provider:` block per env file                 | YAML form unchanged; TS form binds providers per `secret(...)` record                 |
+| `!secret`, `!age`, `!gcp`, `!sops` YAML tags           | Still valid in YAML; TS uses `secret(...)`, `age(...)`, `gcp(...)`, `sops(...)` calls |
+| Plaintext values in env files override schema defaults | YAML form unchanged; TS form expresses the same thing as `values: { <env>: ... }`     |
+| `name:` introduced in v4.6 to namespace GCP secrets    | `name:` is required (`/^[A-Za-z0-9_-]+$/`) — same rule the v4 loader applied          |
 
 ### `keyshelf set`
 
 v4: `set` could write a plaintext value into `.keyshelf/<env>.yaml` _or_ encrypt through a provider. The CLI picked based on `--provider`.
 
-v5: `set` only writes to providers. Config keys are hand-edited in `keyshelf.config.ts`. The provider used is the one bound on the record (`values[env]` or `default`/`value`); there is no `--provider` flag.
+v5: `set` only writes to providers. Config keys are hand-edited. The provider used is the one bound on the record (the `default-provider` for the env in YAML, or `values[env]` / `default` in TS); there is no `--provider` flag.
 
 ```sh
 # v4
@@ -57,7 +33,7 @@ keyshelf set --env production --provider age db/password --value "s3cret"
 keyshelf set --env production db/password --value "s3cret"
 ```
 
-If you used `set` to update plaintext config values in v4, edit `keyshelf.config.ts` directly in v5.
+If you used `set` to update plaintext config values in v4, edit the YAML file (or `keyshelf.config.ts`) directly in v5.
 
 ### `--env` is optional
 
@@ -72,24 +48,64 @@ v5 introduces two new selectors. Both live on the CLI; nothing in `.env.keyshelf
 
 When a filter excludes a key referenced by an `.env.keyshelf` template, that env var is skipped with a stderr warning, not failed and not emitted as empty. Same rule for optional unresolved keys.
 
+Group filtering is only available in the TypeScript config format — YAML configs have no `groups:` field.
+
+## Optional: switch to TypeScript
+
+If you want the IDE help, run the converter from the repo root that contains your v4 `keyshelf.yaml`:
+
+```sh
+npx @keyshelf/migrate yaml-to-typescript                 # writes keyshelf.config.ts
+npx @keyshelf/migrate yaml-to-typescript --dry-run       # print to stdout instead
+npx @keyshelf/migrate yaml-to-typescript --out ./keyshelf.config.ts --force
+```
+
+The converter reads `keyshelf.yaml`, every `.keyshelf/<env>.yaml`, and the root `.env.keyshelf` (if present). The v4 YAML files are left in place. App-level `.env.keyshelf` mappings keep working as-is.
+
+After conversion, review:
+
+1. **`groups: []`** — placeholder. Add group names if you want `--group` filtering, then assign `group:` on each record.
+2. **Provider paths** — `identityFile`, `secretsDir`, `secretsFile` are copied verbatim. They must resolve from the directory containing `keyshelf.config.ts`.
+3. **`.env.keyshelf` references** — load-time validation rejects references to keys that don't exist. Run `keyshelf ls` once to confirm.
+
+Once the new config resolves correctly (`keyshelf ls --env <env>`), delete `keyshelf.yaml` and `.keyshelf/`.
+
 ### Editor setup
 
-v4 needed YAML custom-tag configuration to silence `unknown tag !secret` warnings. v5 doesn't — `keyshelf.config.ts` is a normal TypeScript module. You can delete the `yaml.customTags` and `yamllint custom-tags` entries from your editor config.
+v4 needed YAML custom-tag configuration to silence `unknown tag !secret` warnings. After switching to TypeScript, you can delete the `yaml.customTags` and `yamllint custom-tags` entries from your editor config.
 
-## Review checklist after running the migrator
+## Optional: re-namespace GCP secret IDs
 
-1. **`name`** — confirm the generated value. v4 names with underscores are converted to kebab-case (`my_app` → `my-app`) only with `--accept-renamed-name`.
-2. **`groups: []`** — placeholder. Add group names if you want `--group` filtering, then assign `group:` on each record.
-3. **Provider paths** — `identityFile`, `secretsDir`, `secretsFile` are copied from v4 verbatim. They must resolve from the directory containing `keyshelf.config.ts`.
-4. **Secrets are not migrated automatically.** The migrator prints a list of `keyshelf set` commands at the end of its run; copy those out and re-bind each secret with the value from your old store. (Drop any `--provider <name>` flag — v5 picks the provider from the record's binding.)
-5. **`.env.keyshelf` references** — load-time validation rejects references to keys that don't exist in the new config. Run `keyshelf ls` once to confirm.
+If your project uses GCP and was created before v4.6 (when `name:` was added), your stored secret IDs look like `keyshelf__<env>__<key>` instead of the v5 form `keyshelf__<name>__<env>__<key>`. The `project-name` subcommand copies the legacy IDs to the namespaced ones:
 
-## Best-effort caveats
+```sh
+npx @keyshelf/migrate project-name --dry-run
+npx @keyshelf/migrate project-name
+npx @keyshelf/migrate project-name --delete-legacy
+```
 
-The migrator is best-effort, not exact. Known limitations:
+The dry run reports each row with one of these statuses:
 
-- Per-key provider overrides spread across multiple v4 env files collapse into one `secret(...)` declaration. If a single key was bound to providers with conflicting options, the migrator picks one and reports the rest in the migration log.
-- Multi-mapping `.env.keyshelf` files in subdirectories aren't relocated — they keep working from their existing paths.
-- Comments in v4 YAML are not preserved.
+| Status             | Meaning                                                                      |
+| ------------------ | ---------------------------------------------------------------------------- |
+| `migrated`         | Will copy legacy → new. With `--dry-run`, no write happens.                  |
+| `already-migrated` | New secret already exists and matches the legacy value. No action needed.    |
+| `no-legacy`        | No legacy secret found at that ID. Probably already cleaned up, or unbound.  |
+| `value-mismatch`   | New secret exists with a **different** value. The migrator refuses to write. |
+| `deleted-legacy`   | Only with `--delete-legacy` (and not `--dry-run`).                           |
 
-When in doubt, run `keyshelf ls --env <env>` against the migrated config and compare to `keyshelf ls --env <env>` on the old install before deleting v4 YAML.
+`value-mismatch` is the one to investigate. It usually means someone created the namespaced secret manually with a different value, or you ran a partial migration before. Resolve it (delete one, copy the right value over) before re-running.
+
+For `age` and `sops`, the subcommand is a no-op — those providers store secrets co-located with the project and have no remote namespace to migrate.
+
+See [`migrating-without-v4-name.md`](./migrating-without-v4-name.md) for the case where your v4 config never had a `name:` at all.
+
+## Authentication note (GCP only)
+
+The GCP step uses application-default credentials. If you see a `GcpAuthError`, run:
+
+```sh
+gcloud auth application-default login
+```
+
+and re-run the migrator. Legacy secrets are kept in place by default, so it's safe to retry.

--- a/docs/migrating-without-v4-name.md
+++ b/docs/migrating-without-v4-name.md
@@ -1,23 +1,18 @@
 # Migrating from v4 without a `name`
 
-The `name:` field was introduced in v4.6 to namespace GCP secret IDs. v5 requires it. If your `keyshelf.yaml` has no `name:`, the migrator stops with:
+The `name:` field was introduced in v4.6 to namespace GCP secret IDs. v5 requires it, both for `keyshelf.config.ts` and for v4-style YAML configs at runtime. If your `keyshelf.yaml` has no `name:`, you'll see:
 
 ```
-keyshelf.yaml must set top-level "name" before it can be migrated
+keyshelf.yaml requires a top-level "name" string
 ```
 
-The migrator refuses to invent a name because that name becomes the namespace for your GCP secret IDs and your v5 project identity — guessing wrong would silently fork your secret store. Pick one yourself, add it to `keyshelf.yaml`, then run the migrator.
+The runtime refuses to invent a name because that name becomes the namespace for your GCP secret IDs and your v5 project identity — guessing wrong would silently fork your secret store. Pick one yourself, add it to `keyshelf.yaml`, then carry on.
 
 This guide covers the two cases: projects that don't use GCP, and projects that do.
 
 ## 1. Pick a name
 
-Constraints, in the order they're applied:
-
-- v4 load-time check: matches `/^[a-zA-Z0-9_-]+$/` (letters, digits, `-`, `_`).
-- v5 normalization: lowercased and `_` → `-`, then must match `/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/`.
-
-If the v4 name you write contains `_`, you'll need `--accept-renamed-name` later to acknowledge `my_app` → `my-app`. Easiest path: write it in lower-kebab-case to begin with.
+The name must match `/^[A-Za-z0-9_-]+$/` (letters, digits, `-`, `_`). Anything that was a valid v4 name is still a valid v5 name — no rename required.
 
 Add it at the top of `keyshelf.yaml`:
 
@@ -29,25 +24,19 @@ keys:
 
 Don't change anything else yet.
 
-## 2a. No GCP bindings — run the migrator
+## 2a. No GCP bindings — you're done
 
-If none of your secrets use `!gcp`, you're done with the prep. Run:
-
-```sh
-npx @keyshelf/migrate --dry-run
-```
-
-Inspect the generated config on stdout. If it looks right:
+If none of your secrets use `!gcp`, adding `name:` is the entire migration. The v5 CLI accepts your existing YAML as-is. Verify:
 
 ```sh
-npx @keyshelf/migrate
+keyshelf ls --env <env>
 ```
 
-Then follow the standard post-migration checklist in [`migrating-from-v4.md`](./migrating-from-v4.md).
+If you'd rather author in TypeScript, see the optional converter in [`migrating-from-v4.md`](./migrating-from-v4.md#optional-switch-to-typescript).
 
-## 2b. GCP bindings — expect a secret-id rename
+## 2b. GCP bindings — re-namespace the secret IDs
 
-Adding a `name` changes how the migrator addresses GCP secrets. Secret IDs in v5 are built as:
+Adding a `name` changes how v5 addresses GCP secrets. v5 secret IDs are built as:
 
 ```
 keyshelf__<name>__<env>__<key/path with / -> __>
@@ -59,15 +48,15 @@ Pre-4.6 secrets in your project were written without the `<name>` segment:
 keyshelf__<env>__<key/path with / -> __>
 ```
 
-The migrator's GCP step reads each legacy ID, copies the value to the new namespaced ID, and reports each row. It runs **before** `keyshelf.config.ts` is written, so a failure leaves your v4 setup fully usable.
+The `project-name` subcommand reads each legacy ID, copies the value to the new namespaced ID, and reports each row. It does not touch your config file — only remote secret stores.
 
 ### Dry-run first
 
 ```sh
-npx @keyshelf/migrate --dry-run
+npx @keyshelf/migrate project-name --dry-run
 ```
 
-This dry-runs the GCP copy too. Each row prints one of these statuses:
+Each row prints one of these statuses:
 
 | Status             | Meaning                                                                      |
 | ------------------ | ---------------------------------------------------------------------------- |
@@ -75,7 +64,7 @@ This dry-runs the GCP copy too. Each row prints one of these statuses:
 | `already-migrated` | New secret already exists and matches the legacy value. No action needed.    |
 | `no-legacy`        | No legacy secret found at that ID. Probably already cleaned up, or unbound.  |
 | `value-mismatch`   | New secret exists with a **different** value. The migrator refuses to write. |
-| `deleted-legacy`   | Only with `--delete-legacy-gcp` (and not `--dry-run`).                       |
+| `deleted-legacy`   | Only with `--delete-legacy` (and not `--dry-run`).                           |
 
 `value-mismatch` is the one to investigate. It usually means someone already created the namespaced secret manually with a different value, or you ran a partial migration before. Resolve it (delete one, copy the right value over) before re-running.
 
@@ -84,17 +73,17 @@ This dry-runs the GCP copy too. Each row prints one of these statuses:
 Once the dry-run is clean:
 
 ```sh
-npx @keyshelf/migrate
+npx @keyshelf/migrate project-name
 ```
 
-This writes new namespaced secrets and emits `keyshelf.config.ts`. Legacy secrets are kept by default.
+This writes the new namespaced secrets. Legacy secrets are kept by default.
 
 ### Optional: clean up legacy secrets
 
-After verifying v5 reads the new secrets correctly (`keyshelf ls --env <env>` against the new config), you can delete the legacy un-namespaced secrets in one shot:
+After verifying v5 reads the new secrets correctly (`keyshelf ls --env <env>`), you can delete the legacy un-namespaced secrets in one shot:
 
 ```sh
-npx @keyshelf/migrate --force --delete-legacy-gcp
+npx @keyshelf/migrate project-name --delete-legacy
 ```
 
 Or delete them manually in the GCP console once you're confident nothing else reads them.
@@ -108,8 +97,6 @@ keyshelf ls --env <env>          # all keys resolve
 keyshelf get --env <env> <path>  # spot-check a secret value
 ```
 
-Compare against the same commands on the old v4 install before deleting `keyshelf.yaml` and `.keyshelf/`.
-
 ## Authentication note (GCP only)
 
 The GCP step uses application-default credentials. If you see a `GcpAuthError`, run:
@@ -118,4 +105,4 @@ The GCP step uses application-default credentials. If you see a `GcpAuthError`, 
 gcloud auth application-default login
 ```
 
-and re-run the migrator. v4 was left untouched, so it's safe to retry.
+and re-run the migrator. Legacy secrets are kept in place by default, so it's safe to retry.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -7,8 +7,11 @@ the source of truth.
 
 ## Configuration entry point
 
-A keyshelf project has exactly one `keyshelf.config.ts` at the repo root. It
-must default-export the result of `defineConfig({ ... })`.
+A keyshelf project has exactly one config file at the repo root. The supported
+formats are `keyshelf.config.ts` (default-exporting the result of
+`defineConfig({ ... })`) and v4-style `keyshelf.yaml` + `.keyshelf/<env>.yaml`.
+Both are first-class at runtime; the YAML form is parsed into the same internal
+shape `defineConfig` produces.
 
 ```ts
 import { defineConfig } from "keyshelf/config";
@@ -31,7 +34,7 @@ The `.env.keyshelf` file (app-name → key-path mapping) is unchanged from v4.
 
 ```ts
 defineConfig({
-  name:   string;            // required; lower-kebab-case identity for this config
+  name:   string;            // required; stable identity for this config
   envs:   string[];          // required, non-empty, unique
   groups?: string[];          // optional, unique; if omitted, no group filtering
   keys:   KeyTree;           // required, non-empty
@@ -41,8 +44,8 @@ defineConfig({
 - `name` is the keyshelf project's stable identity. Providers that share a
   backend with other keyshelf configs (e.g. multiple apps using one GCP
   project) use `name` to namespace their secrets so they don't collide. Must
-  match `/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/` — lowercase letters, digits, and
-  internal dashes only. Required; there is no fallback.
+  match `/^[A-Za-z0-9_-]+$/` — letters, digits, hyphens, and underscores.
+  Required; there is no fallback.
 - `envs` enumerates every environment name the config recognises. Any
   `values` map elsewhere in the config may only use names from this list. There
   is no implicit / dynamic env support in v5.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -383,10 +383,13 @@ const rendered = renderAppMapping(loaded.appMapping, resolution);
 
 ## Migrating from v4
 
-v5 is a clean rewrite. There is no implicit upgrade path — run the migrator to generate a starter `keyshelf.config.ts` from your existing YAML, then review.
+In most cases, upgrading is not a migration — v5 accepts v4-style `keyshelf.yaml` + `.keyshelf/<env>.yaml` as a runtime config format. Bump the `keyshelf` version and your existing YAML keeps working.
+
+`@keyshelf/migrate` covers the two cases that aren't automatic:
 
 ```sh
-npx @keyshelf/migrate
+npx @keyshelf/migrate yaml-to-typescript   # opt-in: convert YAML to keyshelf.config.ts
+npx @keyshelf/migrate project-name         # opt-in: re-namespace pre-v4.6 GCP secret IDs under name:
 ```
 
 See the [migration guide](https://github.com/pantoninho/keyshelf/blob/main/docs/migrating-from-v4.md) for the full walk-through.


### PR DESCRIPTION
## Summary
- Spec: config entry point lists both `keyshelf.config.ts` and v4 YAML as first-class runtime formats; `name` regex relaxed to `/^[A-Za-z0-9_-]+$/` (matches v4).
- `docs/migrating-from-v4.md`: reframed around the post-#123 reality — v4 YAML keeps working at runtime, so most upgrades aren't migrations. `@keyshelf/migrate` is presented as two opt-in subcommands: `yaml-to-typescript` (authoring switch) and `project-name` (re-namespace pre-v4.6 GCP secret IDs).
- `docs/migrating-without-v4-name.md`: name no longer needs to be lowercased; `--accept-renamed-name` story removed; GCP flow uses `project-name --delete-legacy`. The no-GCP path collapses to "add `name:` and you're done".
- `packages/cli/README.md`: migration section now points at the two-subcommand surface.

## Test plan
- [ ] Skim rendered docs on the PR for layout / link integrity
- [ ] Confirm no doc still mentions `--accept-renamed-name` or `--delete-legacy-gcp`
- [ ] Confirm name regex matches the one enforced in `packages/cli/src/config/schema.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)