### PR TITLE
feat(config): forbid underscore in path segments (phase 5 of keyshelf up)

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -298,8 +298,10 @@ The Phase 2 validator must enforce, in addition to the type-level constraints:
 6. A leaf path may not be a prefix of any other leaf path. Declaring `foo`
    as a leaf and `'foo/x'` as another leaf in the same config is rejected:
    any given path is either a leaf or a namespace prefix, never both.
-7. Path segments must match `/^[A-Za-z_][A-Za-z0-9_-]*$/`. The `/` separator
-   is reserved.
+7. Path segments must match `/^[A-Za-z][A-Za-z0-9-]*$/`. The `/` separator
+   is reserved. `_` is forbidden so per-provider storage ids (which mangle
+   `/` into `_` for age and `__` for gcp) round-trip unambiguously when
+   listed.
 8. Template references in `config` bindings must resolve to declared key
    paths and must not form cycles.
 9. `.env.keyshelf` references must point to declared key paths

--- a/packages/action/dist/emit-env.mjs
+++ b/packages/action/dist/emit-env.mjs
@@ -40,7 +40,7 @@ function parseAppMapping(content) {
   }
   return mappings;
 }
-var PATH_SEGMENT_RE = /^[A-Za-z_][A-Za-z0-9_-]*$/;
+var PATH_SEGMENT_RE = /^[A-Za-z][A-Za-z0-9-]*$/;
 var TEMPLATE_RE2 = /(?<!\$)\$\{([^}]+)\}/g;
 var CONFIG_NAME_RE = /^[A-Za-z0-9_-]+$/;
 var configScalarSchema = z.union([z.string(), z.number(), z.boolean()]);

--- a/packages/action/dist/write-identity.mjs
+++ b/packages/action/dist/write-identity.mjs
@@ -39,7 +39,7 @@ function parseAppMapping(content) {
   }
   return mappings;
 }
-var PATH_SEGMENT_RE = /^[A-Za-z_][A-Za-z0-9_-]*$/;
+var PATH_SEGMENT_RE = /^[A-Za-z][A-Za-z0-9-]*$/;
 var TEMPLATE_RE2 = /(?<!\$)\$\{([^}]+)\}/g;
 var CONFIG_NAME_RE = /^[A-Za-z0-9_-]+$/;
 var configScalarSchema = z.union([z.string(), z.number(), z.boolean()]);

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -11,7 +11,7 @@ import type {
   SecretRecord
 } from "./types.js";
 
-const PATH_SEGMENT_RE = /^[A-Za-z_][A-Za-z0-9_-]*$/;
+const PATH_SEGMENT_RE = /^[A-Za-z][A-Za-z0-9-]*$/;
 const TEMPLATE_RE = /(?<!\$)\$\{([^}]+)\}/g;
 const CONFIG_NAME_RE = /^[A-Za-z0-9_-]+$/;
 

--- a/packages/cli/test/unit/config.test.ts
+++ b/packages/cli/test/unit/config.test.ts
@@ -185,6 +185,32 @@ describe("config factories and validation", () => {
     ).toThrow('invalid path segment "db.host"');
   });
 
+  it("rejects underscore in path segments (reserved by per-provider storage ids)", () => {
+    expect(() =>
+      normalizeConfig(
+        defineConfig({
+          name: "test",
+          envs: ["dev"],
+          keys: {
+            db_host: "localhost"
+          }
+        })
+      )
+    ).toThrow('invalid path segment "db_host"');
+
+    expect(() =>
+      normalizeConfig(
+        defineConfig({
+          name: "test",
+          envs: ["dev"],
+          keys: {
+            _leading: "x"
+          }
+        })
+      )
+    ).toThrow('invalid path segment "_leading"');
+  });
+
   it("validates template references and cycles", () => {
     expect(() =>
       normalizeConfig(

--- a/packages/cli/test/unit/reconcile/apply.test.ts
+++ b/packages/cli/test/unit/reconcile/apply.test.ts
@@ -49,7 +49,7 @@ const cfg = normalizeConfig(
   defineConfig({
     name: "myapp",
     envs: ["dev", "prod"],
-    keys: { _placeholder: "x" }
+    keys: { placeholder: "x" }
   })
 );
 


### PR DESCRIPTION
## Summary

Phase 5 of the [keyshelf up plan](.claude/plans/keyshelf-up.md) — schema hygiene.

- Tighten the path-segment regex from `/^[A-Za-z_][A-Za-z0-9_-]*$/` to `/^[A-Za-z][A-Za-z0-9-]*$/`. `_` is no longer allowed.
- Per-provider storage ids encode `/` as `_` (age) and `__` (gcp). Allowing `_` in user-declared segments made `provider.list`'s reverse-mapping ambiguous (e.g. an age path `a_b` collides with the encoding of `a/b`). Forbidding `_` keeps the round-trip unambiguous so `keyshelf up`'s drift detection stays sound.
- Updated `docs/spec.md` rule 7 with the new regex and the rationale.

## Migration

Any existing v5 user with `_` in a key-path segment will now get `invalid path segment "..."` from `normalizeConfig`. They must rename the segment (e.g. `db_host` → `db-host` or `db/host`) before upgrading. This is the same kind of break flagged for phase 5 in the plan.

In-tree, only `apply.test.ts` had `_placeholder` as a synthetic key — renamed to `placeholder`.

## Test plan

- [x] `npm test` — 216 tests pass
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] New `config.test.ts` case asserts both `db_host` and `_leading` are rejected with `invalid path segment` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)