### PR TITLE
feat(cli): hint at keyshelf up after set/import drift (phase 6 of keyshelf up)

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -282,6 +282,56 @@ hint to make sense.
 
 ---
 
+## Commands
+
+`keyshelf up` is the canonical verb for reconciling provider storage with
+the config. The other commands are helpers around it:
+
+| Command                  | Mutates config? | Mutates storage?         | Role                                                     |
+| ------------------------ | --------------- | ------------------------ | -------------------------------------------------------- |
+| `keyshelf up`            | no              | yes (renames + deletes)  | reconcile storage with config                            |
+| `keyshelf up --plan`     | no              | no                       | preview the reconciliation plan; exits non-zero on drift |
+| `keyshelf set <key>`     | no              | yes (writes one value)   | write a single secret value                              |
+| `keyshelf import --file` | no              | yes (writes many values) | bulk-write secrets from a `.env` file                    |
+| `keyshelf run -- ...`    | no              | no                       | resolve and inject env, then exec                        |
+| `keyshelf ls`            | no              | no                       | list resolved values                                     |
+
+`set` and `import` only write values — they never edit the config. The
+config is hand-edited; `up` is what propagates structural changes (renames,
+deletions) into storage.
+
+### Renaming a key
+
+The intended flow for renaming a stored key is:
+
+1. Edit `keyshelf.config.ts`: rename the key and add `movedFrom: "<old-path>"`
+   so the planner knows where to look for the existing value.
+2. Run `keyshelf up --plan` to preview the rename.
+3. Run `keyshelf up` to apply: the value is copied to the new path, validated,
+   and the old entry is deleted.
+
+`movedFrom` is the disambiguation knob: without it, multiple orphan entries
+in storage may plausibly match a new key, and `up` will refuse to guess.
+With it, the planner emits a deterministic `Rename` action.
+
+If the user runs `set` (or `import`) on a key whose `movedFrom` predecessor
+still exists in storage, the command prints a hint suggesting `keyshelf up`
+to clean up the old entry. The hint is best-effort and only checks the
+single key being written.
+
+### Permissions
+
+`keyshelf up` requires `list` access on every provider configured in
+the project: it must enumerate stored entries to detect orphans and
+plan renames. For GCP Secret Manager this means
+`roles/secretmanager.viewer` on the project (in addition to
+`roles/secretmanager.secretAccessor` which `run` already needs). For
+file-based providers (age, sops) read access on the secrets directory or
+file is enough. `set` and `import` only need write access; they do not
+list.
+
+---
+
 ## Validation rules (for Phase 2)
 
 The Phase 2 validator must enforce, in addition to the type-level constraints:

--- a/packages/cli/src/cli/import.ts
+++ b/packages/cli/src/cli/import.ts
@@ -1,8 +1,10 @@
 import { Command } from "commander";
 import { readFile } from "node:fs/promises";
-import { loadConfig } from "../config/index.js";
+import { loadConfig, type LoadedConfig } from "../config/index.js";
 import { isTemplateMapping, iterDotEnvEntries } from "../config/app-mapping.js";
 import { createDefaultRegistry } from "../providers/setup.js";
+import type { ProviderRegistry } from "../providers/registry.js";
+import type { NormalizedRecord } from "../config/types.js";
 import { splitList } from "./options.js";
 import { findStaleRenameSource, pickProviderRef, writeSecret } from "./secret-binding.js";
 
@@ -12,6 +14,19 @@ interface ImportOptions {
   map?: string;
   group?: string;
 }
+
+interface ImportContext {
+  loaded: LoadedConfig;
+  registry: ProviderRegistry;
+  recordByPath: Map<string, NormalizedRecord>;
+  reverseMap: Map<string, string>;
+  groupSet: Set<string> | undefined;
+  envName: string | undefined;
+}
+
+type ImportOutcome =
+  | { kind: "imported"; stale: string | undefined }
+  | { kind: "skipped"; warning?: string };
 
 function parseDotEnv(content: string): Record<string, string> {
   const vars: Record<string, string> = {};
@@ -33,72 +48,39 @@ export const importCommand = new Command("import")
     const appDir = process.cwd();
     const loaded = await loadConfig(appDir, { mappingFile: opts.map });
 
-    const recordByPath = new Map(loaded.config.keys.map((record) => [record.path, record]));
-    const reverseMap = new Map(
-      loaded.appMapping
-        .filter((mapping) => !isTemplateMapping(mapping))
-        .map((mapping) => [mapping.envVar, (mapping as { keyPath: string }).keyPath])
-    );
-
     const groupList = splitList(opts.group);
-    const groupSet = groupList ? new Set(groupList) : undefined;
-
     const dotEnvContent = await readFile(opts.file, "utf-8");
     const dotEnvVars = parseDotEnv(dotEnvContent);
 
-    const registry = createDefaultRegistry();
+    const ctx: ImportContext = {
+      loaded,
+      registry: createDefaultRegistry(),
+      recordByPath: new Map(loaded.config.keys.map((record) => [record.path, record])),
+      reverseMap: new Map(
+        loaded.appMapping
+          .filter((mapping) => !isTemplateMapping(mapping))
+          .map((mapping) => [mapping.envVar, (mapping as { keyPath: string }).keyPath])
+      ),
+      groupSet: groupList ? new Set(groupList) : undefined,
+      envName: opts.env
+    };
+
     let imported = 0;
     let skipped = 0;
     const staleRenames: string[] = [];
 
     for (const [envVar, value] of Object.entries(dotEnvVars)) {
-      const keyPath = reverseMap.get(envVar);
-      if (keyPath === undefined) {
+      const outcome = await importOne(ctx, envVar, value);
+      if (outcome.kind === "imported") {
+        imported++;
+        if (outcome.stale !== undefined) staleRenames.push(outcome.stale);
+      } else {
         skipped++;
-        continue;
+        if (outcome.warning !== undefined) console.error(outcome.warning);
       }
-
-      const record = recordByPath.get(keyPath);
-      if (record === undefined) {
-        console.error(`warning: ${envVar} maps to "${keyPath}" which is not declared in config`);
-        skipped++;
-        continue;
-      }
-
-      if (record.kind === "config") {
-        console.error(
-          `warning: ${envVar} -> ${keyPath} is a config key; keyshelf does not write config via import (edit keyshelf.config.ts directly)`
-        );
-        skipped++;
-        continue;
-      }
-
-      if (groupSet !== undefined && (record.group === undefined || !groupSet.has(record.group))) {
-        console.error(`warning: ${envVar} -> ${keyPath} filtered out by --group; skipping`);
-        skipped++;
-        continue;
-      }
-
-      const providerRef = pickProviderRef(record, opts.env);
-      if (providerRef === undefined) {
-        const envHint = opts.env ?? "(envless)";
-        console.error(
-          `warning: ${envVar} -> ${keyPath} has no provider binding for env ${envHint}; skipping`
-        );
-        skipped++;
-        continue;
-      }
-
-      await writeSecret(registry, loaded, providerRef, keyPath, opts.env, value);
-      console.log(`  secret: ${envVar} -> ${keyPath} (via ${providerRef.name})`);
-      imported++;
-
-      const stale = await findStaleRenameSource(registry, loaded, record, providerRef, opts.env);
-      if (stale !== undefined) staleRenames.push(stale);
     }
 
     console.log(`\nImported ${imported} values, skipped ${skipped}`);
-
     if (staleRenames.length > 0) {
       const list = staleRenames.map((p) => `"${p}"`).join(", ");
       console.log(
@@ -106,3 +88,56 @@ export const importCommand = new Command("import")
       );
     }
   });
+
+async function importOne(
+  ctx: ImportContext,
+  envVar: string,
+  value: string
+): Promise<ImportOutcome> {
+  const keyPath = ctx.reverseMap.get(envVar);
+  if (keyPath === undefined) return { kind: "skipped" };
+
+  const record = ctx.recordByPath.get(keyPath);
+  if (record === undefined) {
+    return {
+      kind: "skipped",
+      warning: `warning: ${envVar} maps to "${keyPath}" which is not declared in config`
+    };
+  }
+  if (record.kind === "config") {
+    return {
+      kind: "skipped",
+      warning: `warning: ${envVar} -> ${keyPath} is a config key; keyshelf does not write config via import (edit keyshelf.config.ts directly)`
+    };
+  }
+  if (
+    ctx.groupSet !== undefined &&
+    (record.group === undefined || !ctx.groupSet.has(record.group))
+  ) {
+    return {
+      kind: "skipped",
+      warning: `warning: ${envVar} -> ${keyPath} filtered out by --group; skipping`
+    };
+  }
+
+  const providerRef = pickProviderRef(record, ctx.envName);
+  if (providerRef === undefined) {
+    const envHint = ctx.envName ?? "(envless)";
+    return {
+      kind: "skipped",
+      warning: `warning: ${envVar} -> ${keyPath} has no provider binding for env ${envHint}; skipping`
+    };
+  }
+
+  await writeSecret(ctx.registry, ctx.loaded, providerRef, keyPath, ctx.envName, value);
+  console.log(`  secret: ${envVar} -> ${keyPath} (via ${providerRef.name})`);
+
+  const stale = await findStaleRenameSource(
+    ctx.registry,
+    ctx.loaded,
+    record,
+    providerRef,
+    ctx.envName
+  );
+  return { kind: "imported", stale };
+}

--- a/packages/cli/src/cli/import.ts
+++ b/packages/cli/src/cli/import.ts
@@ -4,7 +4,7 @@ import { loadConfig } from "../config/index.js";
 import { isTemplateMapping, iterDotEnvEntries } from "../config/app-mapping.js";
 import { createDefaultRegistry } from "../providers/setup.js";
 import { splitList } from "./options.js";
-import { pickProviderRef, writeSecret } from "./secret-binding.js";
+import { findStaleRenameSource, pickProviderRef, writeSecret } from "./secret-binding.js";
 
 interface ImportOptions {
   env?: string;
@@ -49,6 +49,7 @@ export const importCommand = new Command("import")
     const registry = createDefaultRegistry();
     let imported = 0;
     let skipped = 0;
+    const staleRenames: string[] = [];
 
     for (const [envVar, value] of Object.entries(dotEnvVars)) {
       const keyPath = reverseMap.get(envVar);
@@ -91,7 +92,17 @@ export const importCommand = new Command("import")
       await writeSecret(registry, loaded, providerRef, keyPath, opts.env, value);
       console.log(`  secret: ${envVar} -> ${keyPath} (via ${providerRef.name})`);
       imported++;
+
+      const stale = await findStaleRenameSource(registry, loaded, record, providerRef, opts.env);
+      if (stale !== undefined) staleRenames.push(stale);
     }
 
     console.log(`\nImported ${imported} values, skipped ${skipped}`);
+
+    if (staleRenames.length > 0) {
+      const list = staleRenames.map((p) => `"${p}"`).join(", ");
+      console.log(
+        `hint: storage still holds old path${staleRenames.length === 1 ? "" : "s"} ${list}. Run \`keyshelf up\` to clean up.`
+      );
+    }
   });

--- a/packages/cli/src/cli/secret-binding.ts
+++ b/packages/cli/src/cli/secret-binding.ts
@@ -36,3 +36,37 @@ export async function writeSecret(
     value
   );
 }
+
+// After a successful set/import, check whether storage still holds any
+// `movedFrom` predecessor of the just-written record under the same
+// provider binding. If so, return the first old path found — the caller
+// hints the user to run `keyshelf up` to clean it up. validate() failures
+// are swallowed: the hint is best-effort, never a hard error.
+export async function findStaleRenameSource(
+  registry: ProviderRegistry,
+  loaded: LoadedConfig,
+  record: NormalizedRecord & { kind: "secret" },
+  providerRef: BuiltinProviderRef,
+  envName: string | undefined
+): Promise<string | undefined> {
+  const movedFrom = record.movedFrom ?? [];
+  if (movedFrom.length === 0) return undefined;
+
+  const provider = registry.get(providerRef.name);
+  const baseCtx = {
+    envName,
+    rootDir: loaded.rootDir,
+    config: { ...(providerRef.options as unknown as Record<string, unknown>) },
+    keyshelfName: loaded.config.name
+  };
+
+  for (const oldPath of movedFrom) {
+    try {
+      const exists = await provider.validate({ ...baseCtx, keyPath: oldPath });
+      if (exists) return oldPath;
+    } catch {
+      // best-effort hint; ignore provider errors
+    }
+  }
+  return undefined;
+}

--- a/packages/cli/src/cli/set.ts
+++ b/packages/cli/src/cli/set.ts
@@ -2,7 +2,7 @@ import { Command } from "commander";
 import { createInterface } from "node:readline";
 import { loadConfig } from "../config/index.js";
 import { createDefaultRegistry } from "../providers/setup.js";
-import { pickProviderRef, writeSecret } from "./secret-binding.js";
+import { findStaleRenameSource, pickProviderRef, writeSecret } from "./secret-binding.js";
 
 interface SetOptions {
   env?: string;
@@ -52,6 +52,13 @@ export const setCommand = new Command("set")
 
     const where = opts.env ? ` for ${opts.env}` : "";
     console.log(`Stored "${keyPath}" via ${providerRef.name} provider${where}`);
+
+    const stale = await findStaleRenameSource(registry, loaded, record, providerRef, opts.env);
+    if (stale !== undefined) {
+      console.log(
+        `hint: storage still holds old path "${stale}". Run \`keyshelf up\` to clean it up.`
+      );
+    }
   });
 
 async function readValue(keyPath: string, explicit: string | undefined): Promise<string> {

--- a/packages/cli/test/e2e/import.test.ts
+++ b/packages/cli/test/e2e/import.test.ts
@@ -84,6 +84,45 @@ describe("keyshelf-next import", () => {
     expect(out).toContain("Imported 1 values, skipped 1");
   });
 
+  it("hints at `keyshelf up` when imported keys have stale movedFrom predecessors in storage", async () => {
+    const driftRoot = await mkdtemp(join(tmpdir(), "keyshelf-import-drift-"));
+    const { identityFile, secretsDir } = await setupAgeFixtureDir(driftRoot);
+    await writeKeyshelfConfig(driftRoot, [
+      `name: "demo",`,
+      `envs: ["dev"],`,
+      `keys: {`,
+      `  db: {`,
+      `    password: secret({`,
+      `      value: age({ identityFile: ${JSON.stringify(identityFile)}, secretsDir: ${JSON.stringify(secretsDir)} }),`,
+      `      movedFrom: "db/old-password",`,
+      `    }),`,
+      `  },`,
+      `},`
+    ]);
+    await writeEnvKeyshelf(driftRoot, ["DB_PASSWORD=db/password"]);
+
+    // Pre-seed storage at the OLD path by setting under the current path then
+    // renaming the file. age stores `<path-with-_-instead-of-/>.age`.
+    execFileSync(TSX, [CLI, "set", "--env", "dev", "--value", "old-pw", "db/password"], {
+      cwd: driftRoot,
+      encoding: "utf-8"
+    });
+    const { rename } = await import("node:fs/promises");
+    await rename(`${secretsDir}/db_password.age`, `${secretsDir}/db_old-password.age`);
+
+    const envFile = join(driftRoot, ".env.values");
+    writeFileSync(envFile, ["DB_PASSWORD=new-pw"]);
+
+    const out = execFileSync(TSX, [CLI, "import", "--env", "dev", "--file", envFile], {
+      cwd: driftRoot,
+      encoding: "utf-8",
+      stdio: ["inherit", "pipe", "pipe"]
+    });
+
+    expect(out).toContain('hint: storage still holds old path "db/old-password"');
+    expect(out).toContain("keyshelf up");
+  });
+
   it("skips keys outside the --group filter", async () => {
     const groupedRoot = await mkdtemp(join(tmpdir(), "keyshelf-import-group-"));
     const { identityFile, secretsDir } = await setupAgeFixtureDir(groupedRoot);

--- a/packages/cli/test/e2e/set.test.ts
+++ b/packages/cli/test/e2e/set.test.ts
@@ -83,4 +83,51 @@ describe("keyshelf-next set", () => {
     );
     expect(result.trim()).toBe("piped-pw");
   });
+
+  it("hints at `keyshelf up` when storage still holds a movedFrom predecessor", async () => {
+    const { identityFile, secretsDir } = await setupAgeFixtureDir(root);
+    await writeKeyshelfConfig(root, [
+      `name: "demo",`,
+      `envs: ["dev"],`,
+      `keys: {`,
+      `  db: {`,
+      `    password: secret({`,
+      `      value: age({ identityFile: ${JSON.stringify(identityFile)}, secretsDir: ${JSON.stringify(secretsDir)} }),`,
+      `      movedFrom: "db/old-password",`,
+      `    }),`,
+      `  },`,
+      `},`
+    ]);
+    await writeEnvKeyshelf(root, ["DB_PASSWORD=db/password"]);
+
+    // Seed the OLD path in storage so the rename predecessor is "stale".
+    // Files are named `<path-with-_-instead-of-/>.age`. Set the current path,
+    // then move the resulting file to the predecessor's location so the next
+    // set sees stale storage at db/old-password.
+    execFileSync(TSX, [CLI, "set", "--env", "dev", "--value", "old-pw", "db/password"], {
+      cwd: root,
+      encoding: "utf-8"
+    });
+    const { rename } = await import("node:fs/promises");
+    await rename(`${secretsDir}/db_password.age`, `${secretsDir}/db_old-password.age`);
+
+    // Now set db/password again — its movedFrom points to the file we just renamed.
+    const out = execFileSync(
+      TSX,
+      [CLI, "set", "--env", "dev", "--value", "new-pw", "db/password"],
+      { cwd: root, encoding: "utf-8" }
+    );
+
+    expect(out).toContain('hint: storage still holds old path "db/old-password"');
+    expect(out).toContain("keyshelf up");
+  });
+
+  it("does not print a drift hint when there is no movedFrom or no stale storage", () => {
+    const out = execFileSync(
+      TSX,
+      [CLI, "set", "--env", "dev", "--value", "stored-pw", "db/password"],
+      { cwd: root, encoding: "utf-8" }
+    );
+    expect(out).not.toContain("hint:");
+  });
 });


### PR DESCRIPTION
## Summary

Phase 6 (final) of the [keyshelf up plan](.claude/plans/keyshelf-up.md) — drift hint + docs.

- **Task 6.1** — After a successful `set` or `import`, run `provider.validate` on each `movedFrom` predecessor of the just-written key. If any predecessor still exists in storage, print a one-liner suggesting `keyshelf up`. Errors from `validate` are swallowed: the hint is best-effort and never breaks the command.
- **Task 6.2** — New "Commands" section in `docs/spec.md` positioning `up` as the canonical reconcile verb, with a "Renaming a key" walk-through, `movedFrom` framed as the disambiguation knob, and a permissions note (GCP needs `roles/secretmanager.viewer` for `up`'s list call in addition to the accessor role).

The plan also mentions `README.md`, but the repo doesn't ship one — left out.

## Test plan

- [x] `npm test` (cli) — 219 tests pass (3 new e2e cases: set drift hint, set no-hint negative, import drift hint)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] Drift hint verified end-to-end via age provider fixture (file moved to predecessor path, then `set` / `import` of current path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)