### PR TITLE
feat(providers): add aws secrets manager provider

### DIFF
--- a/.claude/plans/aws-provider.md
+++ b/.claude/plans/aws-provider.md
@@ -1,0 +1,302 @@
+# Feature: AWS Secrets Manager Provider
+
+## Overview
+
+Add a fourth secret provider, `aws`, backed by AWS Secrets Manager. It is the
+AWS analogue of the existing `gcp` provider (GCP Secret Manager): a remote,
+per-env secret store keyed off the keyshelf project name, the env name, and
+the key path. Users in AWS-hosted monorepos should be able to write
+`secret({ value: aws({ region: "eu-west-1" }) })` in `keyshelf.config.ts` (or
+`!aws { region: eu-west-1 }` in YAML) and have `keyshelf run / set / up` work
+end-to-end against AWS.
+
+## Agreed Approach
+
+- **Mirror `gcp`, don't reinvent.** The GCP provider already encodes the
+  exact storage model we want for AWS: `keyshelf/<name?>/<env?>/<path>` ids,
+  per-env scope, idempotent ensure/version/delete, listing via prefix filter,
+  typed auth errors. The AWS provider is a port of that file, swapping the
+  Google client for `@aws-sdk/client-secrets-manager`.
+- **`storageScope: "perEnv"`.** Env is part of the secret id, like `gcp`. The
+  reconcile planner already handles per-env fan-out via this field — no
+  planner work needed.
+- **Use `/` as the path separator in the secret name.** AWS Secrets Manager
+  permits `/` in names (it's the conventional hierarchy character there) and
+  the AWS console renders the slashes as folders. This is the one storage-id
+  difference vs GCP, which had to mangle `/` to `__`. Keeping `/` natural
+  means no path-segment restriction is needed (the existing
+  "no underscore in path segments" rule from the keyshelf-up plan still
+  applies for `age`, but does not constrain AWS).
+- **No required options.** Region is resolved by the AWS SDK's default
+  region chain (`AWS_REGION` → `AWS_DEFAULT_REGION` → active profile's
+  `region` in `~/.aws/config`). Users who already have an AWS profile
+  configured shouldn't have to repeat themselves in keyshelf config. If the
+  SDK cannot resolve a region, the first call fails with the SDK's own
+  region-missing error, which we wrap into a typed message pointing at
+  `AWS_REGION` or `aws configure`. An explicit `region` in the binding is
+  still supported and overrides the SDK chain — useful when one keyshelf
+  config talks to multiple regions. `kmsKeyId` is optional too, passed
+  straight through to `CreateSecret` for customer-managed KMS encryption.
+  No account id (the SDK gets that from credentials).
+- **Auth follows the AWS SDK default credential chain.** Env vars, shared
+  credentials file, SSO, IAM role — all handled by the SDK. We wrap auth
+  failures in a typed `AwsAuthError` with a "configure AWS credentials"
+  message, parallel to `GcpAuthError`.
+- **Listing uses `ListSecrets` with a name-prefix filter.** Filter by
+  `keyshelf/<keyshelfName>/` (or just `keyshelf/` when no name) so we don't
+  enumerate the whole account. Paginate with `NextToken`.
+- **Tests are unit-only with a mocked client.** No live AWS calls in CI.
+  Mirror the structure of `test/unit/providers/gcp-sm.test.ts` exactly so
+  reviewers can diff the two side-by-side.
+
+## Implementation Roadmap
+
+Single PR is fine — the surface is small, the planner already supports
+per-env providers, and there's no destructive migration. If the diff feels
+unwieldy at review time, split Phase 3 (docs + examples) out.
+
+### Phase 1: Provider implementation
+
+#### Task 1.1: Add the AWS SDK dependency
+
+- **Description**: Add `@aws-sdk/client-secrets-manager` to
+  `packages/cli/package.json` dependencies. Pick the latest stable v3.x.
+- **Files**: `packages/cli/package.json`, `package-lock.json`
+- **Details**: Match the dependency-style of `@google-cloud/secret-manager`
+  (caret range, runtime dep not devDep). The AWS SDK v3 is modular — only
+  pull the secrets-manager client, not the umbrella `aws-sdk` package.
+
+#### Task 1.2: Implement `AwsSmProvider`
+
+- **Description**: New file `packages/cli/src/providers/aws-sm.ts` with an
+  `AwsSmProvider` class implementing the full `Provider` interface
+  (`resolve`, `validate`, `set`, `copy`, `delete`, `list`).
+- **Files**: `packages/cli/src/providers/aws-sm.ts` (new)
+- **Details**:
+  - Class shape mirrors `GcpSmProvider` (`packages/cli/src/providers/gcp-sm.ts`).
+    Constructor takes an optional `SecretsManagerClient` for injection in
+    tests; otherwise the provider lazily constructs one per region key
+    (the resolved region string, or `"__default__"` when ctx has none —
+    the SDK does its own resolution from env/profile in that case).
+  - Secret id helper:
+    ```ts
+    export function toSecretId(
+      keyshelfName: string | undefined,
+      envName: string | undefined,
+      keyPath: string
+    ): string {
+      const segments = ["keyshelf"];
+      if (keyshelfName !== undefined) segments.push(keyshelfName);
+      if (envName !== undefined && envName !== "") segments.push(envName);
+      segments.push(keyPath); // already `/`-separated
+      return segments.join("/");
+    }
+    ```
+    Treat `envName === ""` as envless, identical to `gcp-sm.ts`.
+  - `resolve` → `GetSecretValueCommand`. Read `SecretString` (string), or
+    decode `SecretBinary` (Uint8Array) as UTF-8 if string is empty. Throw
+    "has no payload" parallel to gcp.
+  - `validate` → `DescribeSecretCommand`. True on success, false on
+    `ResourceNotFoundException`, throw `AwsAuthError` on auth errors.
+  - `set` → `CreateSecretCommand` first; on `ResourceExistsException`, fall
+    back to `PutSecretValueCommand` (AWS doesn't have a single
+    upsert call). Pass `KmsKeyId` to `CreateSecretCommand` when configured.
+    Idempotent: matches gcp's `ensureSecret` + `addVersion` split.
+  - `delete` → `DeleteSecretCommand` with `ForceDeleteWithoutRecovery: true`
+    so reconcile is genuinely removing storage (the default 30-day recovery
+    window would leave orphans visible in `list`). Treat
+    `ResourceNotFoundException` as success (idempotent).
+  - `copy(from, to)` → read source via `GetSecretValueCommand`, write target
+    via the same `set` flow. Don't delete source — apply pipeline calls
+    `delete` separately.
+  - `list` → `ListSecretsCommand` with
+    `Filters: [{ Key: "name", Values: [prefix] }]` where prefix is
+    `keyshelf/<name>/` or `keyshelf/`. Paginate via `NextToken`. Parse each
+    secret name back into `{ keyPath, envName }` using the env set passed in
+    `ctx.envs`, parallel to `parseSecretId` in gcp-sm.
+  - `AwsAuthError` class + `isAuthError` helper. Detect:
+    - SDK error names: `CredentialsProviderError`,
+      `ExpiredTokenException`, `UnrecognizedClientException`,
+      `InvalidSignatureException`, `AccessDeniedException` (latter only when
+      it's actually a missing-credentials shape — be conservative).
+    - HTTP status 401/403 from `$metadata.httpStatusCode`.
+    Message: `"AWS authentication failed. Run 'aws sso login' or check your AWS credentials."`
+  - Region resolution: read optional `ctx.config.region`. If present, pass
+    it to the `SecretsManagerClient` constructor. If absent, construct the
+    client with no region option and let the SDK's default chain resolve it
+    (`AWS_REGION`, `AWS_DEFAULT_REGION`, or `~/.aws/config` profile).
+  - Detect "no region resolvable" failures from the SDK (error name
+    `ConfigurationError` / message includes `"Region is missing"`) and
+    rethrow with a keyshelf-flavoured message:
+    `"aws provider could not resolve a region for \"${keyPath}\". Set AWS_REGION, configure a default in your AWS profile, or pass region: '...' in the binding."`
+    This is distinct from `AwsAuthError` — it's a configuration error, not
+    a credential error.
+  - Optional `kmsKeyId` from `ctx.config`. Only forwarded to
+    `CreateSecretCommand`; `PutSecretValueCommand` inherits the secret's
+    existing KMS key, so we don't pass it on updates.
+  - Cache the client per region: lazy-create on first call, key by the
+    resolved region string (or a `"__default__"` sentinel when the binding
+    omits region — all such calls share one client and let the SDK pick).
+- **Commit message**: `feat(providers): add aws secrets manager provider`
+
+#### Task 1.3: Register `AwsSmProvider` in the default registry
+
+- **Description**: Add the AWS provider to the registry constructed in
+  `setup.ts`.
+- **Files**: `packages/cli/src/providers/setup.ts`
+- **Details**: One import + one `registry.register(new AwsSmProvider());`
+  line. Keep alphabetical order (age, aws, gcp, plaintext, sops) for
+  readability.
+
+### Phase 2: Config-side wiring
+
+#### Task 2.1: Add `AwsProviderOptions` type and `aws()` factory
+
+- **Description**: Define the public-facing types and factory, parallel to
+  `GcpProviderOptions` / `gcp()`.
+- **Files**:
+  - `packages/cli/src/config/types.ts`
+  - `packages/cli/src/config/factories.ts`
+  - `packages/cli/src/config/index.ts`
+- **Details**:
+  - `AwsProviderOptions = { region?: string; kmsKeyId?: string }`. Both
+    optional — the SDK's region chain handles the common case where the
+    user already has `AWS_REGION` or a profile default set.
+  - Add `ProviderRef<"aws", AwsProviderOptions>` to the
+    `BuiltinProviderRef` union.
+  - Add `aws<const Options extends AwsProviderOptions>(options): ProviderRef<"aws", Options>`
+    factory returning `{ __kind: "provider:aws", name: "aws", options }`.
+  - Re-export `aws` and the `AwsProviderOptions` type from
+    `config/index.ts` so consumers get them via `keyshelf/config`.
+
+#### Task 2.2: Extend the zod schema
+
+- **Description**: Add an `awsProviderSchema` to the discriminated union in
+  `schema.ts`.
+- **Files**: `packages/cli/src/config/schema.ts`
+- **Details**: Mirror `gcpProviderSchema`. Both options optional:
+  `region: z.string().min(1).optional()` and
+  `kmsKeyId: z.string().min(1).optional()`. The options object is
+  `.strict()` like the others so unknown keys still get rejected at parse
+  time. Add to `providerRefSchema`'s `discriminatedUnion` entries.
+
+#### Task 2.3: Extend the YAML loader
+
+- **Description**: Recognise `!aws` in `keyshelf.yaml` and per-env files.
+- **Files**: `packages/cli/src/config/yaml-loader.ts`
+- **Details**:
+  - Add `"aws"` to `PROVIDER_TAGS`.
+  - Add an `aws` case to `providerRef`:
+    ```ts
+    case "aws":
+      return aws(requireOptions<AwsProviderOptions>(options, [], label, "aws"));
+    ```
+    Empty required list — both `region` and `kmsKeyId` are optional.
+    Re-read `requireOptions` to confirm it passes through optional keys
+    when none are required; if it strips unknowns, switch to a manual pick
+    that allows `region` and `kmsKeyId`.
+  - Import `aws` factory and `AwsProviderOptions` at the top alongside the
+    existing provider imports.
+
+### Phase 3: Tests, docs, examples
+
+#### Task 3.1: Unit tests for `AwsSmProvider`
+
+- **Description**: New `packages/cli/test/unit/providers/aws-sm.test.ts`.
+- **Files**: `packages/cli/test/unit/providers/aws-sm.test.ts` (new)
+- **Details**: Port the GCP test file 1:1, replacing the GCP client mock
+  with one that returns `Promise<...>` for each AWS command (the AWS SDK v3
+  `client.send(command)` shape — mock `client.send` and switch on the
+  command constructor). Cover:
+  - Secret id derivation (with/without keyshelfName, with/without env,
+    deeply nested paths, empty-string env). Note: paths use `/` not `__`,
+    so the expected names differ from gcp's tests.
+  - `resolve`: SecretString, SecretBinary, missing payload.
+  - `validate`: 200 → true, ResourceNotFoundException → false, auth error
+    → `AwsAuthError`.
+  - `set`: create-then-version path, create-conflict → put path, KmsKeyId
+    forwarded to create.
+  - `copy`: reads source, writes target, does not delete source.
+  - `delete`: idempotent on ResourceNotFoundException, force-deletes
+    without recovery window.
+  - `list`: prefix filter applied, pagination via NextToken, env
+    disambiguation via `ctx.envs`.
+  - `AwsAuthError` raised on each command's auth-failure shapes.
+
+#### Task 3.2: Config-side tests
+
+- **Description**: Extend existing config tests to cover the `aws` factory
+  and `!aws` YAML tag.
+- **Files**:
+  - `packages/cli/test/unit/config.test.ts` (add a test alongside the
+    existing `gcp` ones around line 279)
+  - `packages/cli/test/unit/config/yaml-loader.test.ts` (or wherever
+    `!gcp` is currently tested — locate by grep)
+- **Details**: One test per: factory roundtrip, schema acceptance with
+  no options (zero-config case — relying on SDK region chain), schema
+  acceptance with explicit `region`, schema acceptance with `kmsKeyId`,
+  schema rejection with unknown keys (strict mode), YAML `!aws` parsing
+  in all three shapes (`!aws`, `!aws { region: ... }`,
+  `!aws { region: ..., kmsKeyId: ... }`), and (if such a test exists for
+  `!gcp`) env-file fallback merging.
+
+#### Task 3.3: Spec, migration docs, examples
+
+- **Description**: Document `aws` everywhere the other providers are
+  documented.
+- **Files**:
+  - `docs/spec.md` — add an `### aws(options)` section after the existing
+    `### gcp(options)` section (line ~199). Document `region` (optional —
+    falls back to `AWS_REGION` / `AWS_DEFAULT_REGION` / profile default;
+    explicit value overrides the chain), `kmsKeyId` (optional), the secret
+    id format (`keyshelf/<name?>/<env?>/<path>`), and the AWS SDK
+    credential chain. Call out that the zero-config form `aws()` works
+    when the user already has an AWS profile.
+  - `docs/migrating-from-v4.md` — add `!aws` to the YAML tags row.
+  - `docs/migrating-without-v4-name.md` — add `!aws` next to the
+    `!gcp` mention (line 29) so users with name-less v4 configs know they
+    need to add `name:` if any secret uses `!aws`.
+  - `examples/07-full.config.ts` — add an `aws({ region: "eu-west-1" })`
+    binding to one key (e.g. a new `aws/staging` value alongside the
+    existing `gcp` production binding) so the "full" example covers all
+    four providers.
+- **Commit message**: `docs: document aws secrets manager provider`
+
+### Phase 4: Reconcile-side verification (sanity check, not new work)
+
+The reconcile planner is provider-agnostic and keys off `storageScope` +
+`providerName`. With AWS as `perEnv`, no planner code should need to
+change. Verify by:
+
+- Re-reading `packages/cli/src/reconcile/planner.ts` for any
+  `name === "gcp"` special-cases (there shouldn't be any; if there are,
+  it's a latent bug — flag and fix in a separate PR).
+- Adding one planner test using `aws()` bindings parallel to the
+  `gcp()` cases at `test/unit/reconcile/planner.test.ts:215` to lock in
+  that the per-env partial-move logic works for any `perEnv` provider,
+  not just gcp.
+
+## Out of scope
+
+- **Cross-region replication.** Secrets Manager supports it via
+  `ReplicaRegions` on `CreateSecret`, but a single-region default keeps the
+  config surface small. Add later if a user asks.
+- **AWS Parameter Store (SSM) backend.** Different service, different
+  semantics (no per-secret KMS key, hierarchical paths native, free tier).
+  Could ship as `awsSsm` later; not bundled with this PR.
+- **Resource policies / IAM grants.** The provider creates secrets under
+  the credential's identity; managing IAM is the user's responsibility.
+- **Migration tooling from `gcp` → `aws`.** `keyshelf up` + manual edits
+  cover this: change the binding in the config, run `up`, it'll see the GCP
+  entry as orphan and the AWS entry as missing. (It will *not* auto-rename
+  across providers — by design, since byte-copying across clouds is a
+  separate operational decision.)
+
+## Open questions
+
+- **Should `kmsKeyId` be settable per-env or only at the binding level?**
+  Today it's per-binding (one `aws()` call = one KmsKey). If a user wants
+  different KMS keys per env, they already declare separate `aws()` calls
+  in `values:`. Probably fine; flag in review.
+- **Do we want a `secretNamePrefix` override?** GCP doesn't have one. Skip
+  unless someone asks — easier to add than to remove.

--- a/docs/migrating-from-v4.md
+++ b/docs/migrating-from-v4.md
@@ -11,13 +11,13 @@ If neither applies, you can stop reading here. Run `keyshelf ls --env <env>` aga
 
 ## What changed at runtime
 
-| v4                                                     | v5                                                                                    |
-| ------------------------------------------------------ | ------------------------------------------------------------------------------------- |
-| `keyshelf.yaml` + `.keyshelf/<env>.yaml`               | Same files still work, **or** a single `keyshelf.config.ts`                           |
-| `default-provider:` block per env file                 | YAML form unchanged; TS form binds providers per `secret(...)` record                 |
-| `!secret`, `!age`, `!gcp`, `!sops` YAML tags           | Still valid in YAML; TS uses `secret(...)`, `age(...)`, `gcp(...)`, `sops(...)` calls |
-| Plaintext values in env files override schema defaults | YAML form unchanged; TS form expresses the same thing as `values: { <env>: ... }`     |
-| `name:` introduced in v4.6 to namespace GCP secrets    | `name:` is required (`/^[A-Za-z0-9_-]+$/`) — same rule the v4 loader applied          |
+| v4                                                     | v5                                                                                                |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------- |
+| `keyshelf.yaml` + `.keyshelf/<env>.yaml`               | Same files still work, **or** a single `keyshelf.config.ts`                                       |
+| `default-provider:` block per env file                 | YAML form unchanged; TS form binds providers per `secret(...)` record                             |
+| `!secret`, `!age`, `!aws`, `!gcp`, `!sops` YAML tags   | Still valid in YAML; TS uses `secret(...)`, `age(...)`, `aws(...)`, `gcp(...)`, `sops(...)` calls |
+| Plaintext values in env files override schema defaults | YAML form unchanged; TS form expresses the same thing as `values: { <env>: ... }`                 |
+| `name:` introduced in v4.6 to namespace GCP secrets    | `name:` is required (`/^[A-Za-z0-9_-]+$/`) — same rule the v4 loader applied                      |
 
 ### `keyshelf set`
 

--- a/docs/migrating-without-v4-name.md
+++ b/docs/migrating-without-v4-name.md
@@ -24,9 +24,9 @@ keys:
 
 Don't change anything else yet.
 
-## 2a. No GCP bindings — you're done
+## 2a. No remote-store bindings — you're done
 
-If none of your secrets use `!gcp`, adding `name:` is the entire migration. The v5 CLI accepts your existing YAML as-is. Verify:
+If none of your secrets use `!gcp` or `!aws`, adding `name:` is the entire migration. The v5 CLI accepts your existing YAML as-is. Verify:
 
 ```sh
 keyshelf ls --env <env>

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -213,6 +213,35 @@ the active `envName`, and the key path:
 `/` is not a valid character in GCP secret ids, so path separators are
 mangled to `__`.
 
+### `aws(options)`
+
+```ts
+aws({
+  region?: string;        // optional; falls back to the AWS SDK region chain
+                          // (AWS_REGION → AWS_DEFAULT_REGION → ~/.aws/config
+                          // profile). Set explicitly to override that chain.
+  kmsKeyId?: string;      // optional; passed to CreateSecret as KmsKeyId for
+                          // customer-managed KMS encryption. Inherited from
+                          // the secret on subsequent updates.
+})
+```
+
+The AWS Secrets Manager secret name is derived from the keyshelf config
+`name`, the active `envName`, and the key path, separated by `/` (the
+conventional hierarchy character in Secrets Manager):
+
+- env-scoped: `keyshelf/<name>/<env>/<keyPath>`
+- envless: `keyshelf/<name>/<keyPath>`
+
+The bare form `aws()` is valid and works whenever the SDK can resolve a
+region from the environment or active profile. Credentials follow the AWS
+SDK default credential chain (env vars → shared credentials file → SSO →
+IAM role).
+
+Reconcile (`keyshelf up`) force-deletes secrets without the 30-day
+recovery window so that orphan removal is genuinely terminal — re-applying
+will not see the deleted entry on its next `list` call.
+
 ### `sops(options)`
 
 ```ts

--- a/examples/07-full.config.ts
+++ b/examples/07-full.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, config, secret, age, gcp, sops } from "keyshelf/config";
+import { defineConfig, config, secret, age, aws, gcp, sops } from "keyshelf/config";
 
 export default defineConfig({
   name: "example-07-full",
@@ -45,6 +45,7 @@ export default defineConfig({
         group: "app",
         optional: true,
         values: {
+          staging: aws({ region: "eu-west-1" }),
           production: gcp({ project: "myproj" })
         }
       })

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,668 @@
         "node": ">=20"
       }
     },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager": {
+      "version": "3.1043.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1043.0.tgz",
+      "integrity": "sha512-xjxE4CSid16j9yBFuykNinW7z+RwqJGxqCDD+hh99jL6YRmVa6FZOkv96gur5jHfrolbb0e19aS3ztD7UWmcLQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/credential-provider-node": "^3.972.39",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.24",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.7",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.974.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.8.tgz",
+      "integrity": "sha512-njR2qoG6ZuB0kvAS2FyICsFZJ6gmCcf2X/7JcD14sUvGDm26wiZ5BrA6LOiUxKFEF+IVe7kdroxyE00YlkiYsw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/xml-builder": "^3.972.22",
+        "@smithy/core": "^3.23.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.34.tgz",
+      "integrity": "sha512-XT0jtf8Fw9JE6ppsQeoNnZRiG+jqRixMT1v1ZR17G60UvVdsQmTG8nbEyHuEPfMxDXEhfdARaM/XiEhca4lGHQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.36.tgz",
+      "integrity": "sha512-DPoGWfy7J7RKxvbf5kOKIGQkD2ek3dbKgzKIGrnLuvZBz5myU+Im/H6pmc14QcnFbqHMqxvtWSgRDSJW3qXLQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-stream": "^4.5.25",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.38.tgz",
+      "integrity": "sha512-oDzUBu2MGJFgoar05sPMCwSrhw44ASyccrHzj66vO69OZqi7I6hZZxXfuPLC8OCzW7C+sU+bI73XHij41yekgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/credential-provider-env": "^3.972.34",
+        "@aws-sdk/credential-provider-http": "^3.972.36",
+        "@aws-sdk/credential-provider-login": "^3.972.38",
+        "@aws-sdk/credential-provider-process": "^3.972.34",
+        "@aws-sdk/credential-provider-sso": "^3.972.38",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.38",
+        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.38.tgz",
+      "integrity": "sha512-g1NosS8qe4OF++G2UFCM5ovSkgipC7YYor5KCWatG0UoMSO5YFj9C8muePlyVmOBV/WTI16Jo3/s1NUo/o1Bww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.39.tgz",
+      "integrity": "sha512-HEswDQyxUtadoZ/bJsPPENHg7R0Lzym5LuMksJeHvqhCOpP+rtkDLKI4/ZChH4w3cf5kG8n6bZuI8PzajoiqMg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.34",
+        "@aws-sdk/credential-provider-http": "^3.972.36",
+        "@aws-sdk/credential-provider-ini": "^3.972.38",
+        "@aws-sdk/credential-provider-process": "^3.972.34",
+        "@aws-sdk/credential-provider-sso": "^3.972.38",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.38",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.34.tgz",
+      "integrity": "sha512-T3IFs4EVmVi1dVN5RciFnklCANSzvrQd/VuHY9ThHSQmYkTogjcGkoJEr+oNUPQZnso52183088NqysMPji1/Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.38.tgz",
+      "integrity": "sha512-5ZxG+t0+3Q3QPh8KEjX6syskhgNf7I0MN7oGioTf6Lm1NTjfP7sIcYGNsthXC2qR8vcD3edNZwCr2ovfSSWuRA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/token-providers": "3.1041.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.38.tgz",
+      "integrity": "sha512-lYHFF30DGI20jZcYX8cm6Ns0V7f1dDN6g/MBDLTyD/5iw+bXs3yBr2iAiHDkx4RFU5JgsnZvCHYKiRVPRdmOgw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
+      "integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
+      "integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
+      "integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.37.tgz",
+      "integrity": "sha512-Km7M+i8DrLArVzrid1gfxeGhYHBd3uxvE77g0s5a52zPSVosxzQBnJ0gwWb6NIp/DOk8gsBMhi7V+cpJG0ndTA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-arn-parser": "^3.972.3",
+        "@smithy/core": "^3.23.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-stream": "^4.5.25",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.38.tgz",
+      "integrity": "sha512-iz+B29TXcAZsJpwB+AwG/TTGA5l/VnmMZ2UxtiySOZjI6gCdmviXPwdgzcmuazMy16rXoPY4mYCGe7zdNKfx5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@smithy/core": "^3.23.17",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-retry": "^4.3.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.6.tgz",
+      "integrity": "sha512-WBDnqatJl+kGObpfmfSxqnXeYTu3Me8wx8WCtvoxX3pfWrrTv8I4WTMSSs7PZqcRcVh8WeUKMgGFjMG+52SR1w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.25",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.24",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.7",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
+      "integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.25.tgz",
+      "integrity": "sha512-+CMIt3e1VzlklAECmG+DtP1sV8iKq25FuA0OKpnJ4KA0kxUtd7CgClY7/RU6VzJBQwbN4EJ9Ue6plvqx1qGadw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "^3.972.37",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1041.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1041.0.tgz",
+      "integrity": "sha512-Th7kPI6YPtvJUcdznooXJMy+9rQWjmEF81LxaJssngBzuysK4a/x+l8kjm1zb7nYsUPbndnBdUnwng/3PLvtGw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-arn-parser": {
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.3.tgz",
+      "integrity": "sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.996.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
+      "integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-endpoints": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
+      "integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.973.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.24.tgz",
+      "integrity": "sha512-ZWwlkjcIp7cEL8ZfTpTAPNkwx25p7xol0xlKoWVVf22+nsjwmLcHYtTPjIV1cSpmB/b6DaK4cb1fSkvCXHgRdw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.22.tgz",
+      "integrity": "sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@nodable/entities": "2.1.0",
+        "@smithy/types": "^4.14.1",
+        "fast-xml-parser": "5.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
@@ -909,6 +1571,18 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.127.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
@@ -1673,6 +2347,574 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@smithy/config-resolver": {
+      "version": "4.4.17",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.17.tgz",
+      "integrity": "sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.23.17",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.17.tgz",
+      "integrity": "sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-stream": "^4.5.25",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/uuid": "^1.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.14.tgz",
+      "integrity": "sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.3.17",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.17.tgz",
+      "integrity": "sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-base64": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.14.tgz",
+      "integrity": "sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.14.tgz",
+      "integrity": "sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.14.tgz",
+      "integrity": "sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "4.4.32",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.32.tgz",
+      "integrity": "sha512-ZZkgyjnJppiZbIm6Qbx92pbXYi1uzenIvGhBSCDlc7NwuAkiqSgS75j1czAD25ZLs2FjMjYy1q7gyRVWG6JA0Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.17",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-middleware": "^4.2.14",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.7.tgz",
+      "integrity": "sha512-bRt6ZImqVSeTk39Nm81K20ObIiAZ3WefY7G6+iz/0tZjs4dgRRjvRX2sgsH+zi6iDCRR/aQvQofLKxxz4rPBZg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/service-error-classification": "^4.3.1",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
+        "@smithy/uuid": "^1.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "4.2.20",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.20.tgz",
+      "integrity": "sha512-Lx9JMO9vArPtiChE3wbEZ5akMIDQpWQtlu90lhACQmNOXcGXRbaDywMHDzuDZ2OkZzP+9wQfZi3YJT9F67zTQQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.17",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.14.tgz",
+      "integrity": "sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "4.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.14.tgz",
+      "integrity": "sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.6.1.tgz",
+      "integrity": "sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.14.tgz",
+      "integrity": "sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.14.tgz",
+      "integrity": "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.14.tgz",
+      "integrity": "sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.14.tgz",
+      "integrity": "sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.3.1.tgz",
+      "integrity": "sha512-aUQuDGh760ts/8MU+APjIZhlLPKhIIfqyzZaJikLEIMrdxFvxuLYD0WxWzaYWpmLbQlXDe9p7EWM3HsBe0K6Gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.9.tgz",
+      "integrity": "sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.14.tgz",
+      "integrity": "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "4.12.13",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.13.tgz",
+      "integrity": "sha512-y/Pcj1V9+qG98gyu1gvftHB7rDpdh+7kIBIggs55yGm3JdtBV8GT8IFF3a1qxZ79QnaJHX9GXzvBG6tAd+czJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.17",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-stream": "^4.5.25",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
+      "integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.14.tgz",
+      "integrity": "sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
+      "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
+      "integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
+      "integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
+      "integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "4.3.49",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.49.tgz",
+      "integrity": "sha512-a5bNrdiONYB/qE2BuKegvUMd/+ZDwdg4vsNuuSzYE8qs2EYAdK9CynL+Rzn29PbPiUqoz/cbpRbcLzD5lEevHw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "4.2.54",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.54.tgz",
+      "integrity": "sha512-g1cvrJvOnzeJgEdf7AE4luI7gp6L8weE0y9a9wQUSGtjb8QRHDbCJYuE4Sy0SD9N8RrnNPFsPltAz/OSoBR9Zw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.4.2.tgz",
+      "integrity": "sha512-a55Tr+3OKld4TTtnT+RhKOQHyPxm3j/xL4OR83WBUhLJaKDS9dnJ7arRMOp3t31dcLhApwG9bgvrRXBHlLdIkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+      "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.14.tgz",
+      "integrity": "sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.8.tgz",
+      "integrity": "sha512-LUIxbTBi+OpvXpg91poGA6BdyoleMDLnfXjVDqyi2RvZmTveY5loE/FgYUBCR5LU2BThW2SoZRh8dTIIy38IPw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/service-error-classification": "^4.3.1",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "4.5.25",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.25.tgz",
+      "integrity": "sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+      "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/uuid": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
+      "integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -2246,6 +3488,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "5.0.5",
@@ -2840,6 +4088,42 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.8.tgz",
+      "integrity": "sha512-sDVBc2gg8pSKvcbE8rBmOyjSGQf0AdsbqvHeIOv3D/uYNoV4eCReQXyDF8Pdv8+m1FHazACypSz2hR7O2S1LLw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
+      "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -3950,6 +5234,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -4559,6 +5858,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/strnum": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/stubs": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
@@ -4711,9 +6022,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/tsup": {
       "version": "8.5.1",
@@ -5313,6 +6622,7 @@
       "version": "5.0.0",
       "license": "MIT",
       "dependencies": {
+        "@aws-sdk/client-secrets-manager": "^3.1043.0",
         "@google-cloud/secret-manager": "^6.1.1",
         "age-encryption": "^0.3.0",
         "commander": "^14.0.3",

--- a/packages/action/dist/emit-env.mjs
+++ b/packages/action/dist/emit-env.mjs
@@ -52,6 +52,14 @@ var ageProviderSchema = z.object({
     secretsDir: z.string().min(1)
   }).strict()
 }).strict();
+var awsProviderSchema = z.object({
+  __kind: z.literal("provider:aws"),
+  name: z.literal("aws"),
+  options: z.object({
+    region: z.string().min(1).optional(),
+    kmsKeyId: z.string().min(1).optional()
+  }).strict()
+}).strict();
 var gcpProviderSchema = z.object({
   __kind: z.literal("provider:gcp"),
   name: z.literal("gcp"),
@@ -69,6 +77,7 @@ var sopsProviderSchema = z.object({
 }).strict();
 var providerRefSchema = z.discriminatedUnion("__kind", [
   ageProviderSchema,
+  awsProviderSchema,
   gcpProviderSchema,
   sopsProviderSchema
 ]);
@@ -2332,6 +2341,9 @@ function secret(input) {
 function age(options) {
   return { __kind: "provider:age", name: "age", options };
 }
+function aws(options = {}) {
+  return { __kind: "provider:aws", name: "aws", options };
+}
 function gcp(options) {
   return { __kind: "provider:gcp", name: "gcp", options };
 }
@@ -2341,7 +2353,7 @@ function sops(options) {
 
 // ../cli/dist/src/config/yaml-loader.js
 var ENV_DIR = ".keyshelf";
-var PROVIDER_TAGS = ["age", "gcp", "sops"];
+var PROVIDER_TAGS = ["age", "aws", "gcp", "sops"];
 var ALL_TAGS = ["secret", ...PROVIDER_TAGS];
 function makeMappingTag(name) {
   return new Type(`!${name}`, {
@@ -2569,6 +2581,8 @@ function providerRef(name, options, label) {
       return age(
         requireOptions(options, ["identityFile", "secretsDir"], label, "age")
       );
+    case "aws":
+      return aws(requireOptions(options, [], label, "aws"));
     case "gcp":
       return gcp(requireOptions(options, ["project"], label, "gcp"));
     case "sops":

--- a/packages/action/dist/keyshelf-config.mjs
+++ b/packages/action/dist/keyshelf-config.mjs
@@ -11,6 +11,9 @@ function secret(input) {
 function age(options) {
   return { __kind: "provider:age", name: "age", options };
 }
+function aws(options = {}) {
+  return { __kind: "provider:aws", name: "aws", options };
+}
 function gcp(options) {
   return { __kind: "provider:gcp", name: "gcp", options };
 }
@@ -18,4 +21,4 @@ function sops(options) {
   return { __kind: "provider:sops", name: "sops", options };
 }
 
-export { age, config, defineConfig, gcp, secret, sops };
+export { age, aws, config, defineConfig, gcp, secret, sops };

--- a/packages/action/dist/write-identity.mjs
+++ b/packages/action/dist/write-identity.mjs
@@ -51,6 +51,14 @@ var ageProviderSchema = z.object({
     secretsDir: z.string().min(1)
   }).strict()
 }).strict();
+var awsProviderSchema = z.object({
+  __kind: z.literal("provider:aws"),
+  name: z.literal("aws"),
+  options: z.object({
+    region: z.string().min(1).optional(),
+    kmsKeyId: z.string().min(1).optional()
+  }).strict()
+}).strict();
 var gcpProviderSchema = z.object({
   __kind: z.literal("provider:gcp"),
   name: z.literal("gcp"),
@@ -68,6 +76,7 @@ var sopsProviderSchema = z.object({
 }).strict();
 var providerRefSchema = z.discriminatedUnion("__kind", [
   ageProviderSchema,
+  awsProviderSchema,
   gcpProviderSchema,
   sopsProviderSchema
 ]);
@@ -2331,6 +2340,9 @@ function secret(input) {
 function age(options) {
   return { __kind: "provider:age", name: "age", options };
 }
+function aws(options = {}) {
+  return { __kind: "provider:aws", name: "aws", options };
+}
 function gcp(options) {
   return { __kind: "provider:gcp", name: "gcp", options };
 }
@@ -2340,7 +2352,7 @@ function sops(options) {
 
 // ../cli/dist/src/config/yaml-loader.js
 var ENV_DIR = ".keyshelf";
-var PROVIDER_TAGS = ["age", "gcp", "sops"];
+var PROVIDER_TAGS = ["age", "aws", "gcp", "sops"];
 var ALL_TAGS = ["secret", ...PROVIDER_TAGS];
 function makeMappingTag(name) {
   return new Type(`!${name}`, {
@@ -2568,6 +2580,8 @@ function providerRef(name, options, label) {
       return age(
         requireOptions(options, ["identityFile", "secretsDir"], label, "age")
       );
+    case "aws":
+      return aws(requireOptions(options, [], label, "aws"));
     case "gcp":
       return gcp(requireOptions(options, ["project"], label, "gcp"));
     case "sops":

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -43,6 +43,7 @@
     "node": ">=20"
   },
   "dependencies": {
+    "@aws-sdk/client-secrets-manager": "^3.1043.0",
     "@google-cloud/secret-manager": "^6.1.1",
     "age-encryption": "^0.3.0",
     "commander": "^14.0.3",

--- a/packages/cli/src/config/factories.ts
+++ b/packages/cli/src/config/factories.ts
@@ -1,5 +1,6 @@
 import type {
   AgeProviderOptions,
+  AwsProviderOptions,
   BuiltinProviderRef,
   ConfigRecordInput,
   DefineConfigInput,
@@ -41,6 +42,12 @@ export function age<const Options extends AgeProviderOptions>(
   options: Options
 ): ProviderRef<"age", Options> {
   return { __kind: "provider:age", name: "age", options };
+}
+
+export function aws<const Options extends AwsProviderOptions = AwsProviderOptions>(
+  options: Options = {} as Options
+): ProviderRef<"aws", Options> {
+  return { __kind: "provider:aws", name: "aws", options };
 }
 
 export function gcp<const Options extends GcpProviderOptions>(

--- a/packages/cli/src/config/index.ts
+++ b/packages/cli/src/config/index.ts
@@ -1,4 +1,4 @@
-export { defineConfig, config, secret, age, gcp, sops } from "./factories.js";
+export { defineConfig, config, secret, age, aws, gcp, sops } from "./factories.js";
 export { findRootDir, loadConfig, type LoadedConfig, type LoadConfigOptions } from "./loader.js";
 export {
   isProviderRef,
@@ -9,6 +9,7 @@ export {
 } from "./schema.js";
 export type {
   AgeProviderOptions,
+  AwsProviderOptions,
   BuiltinProviderRef,
   ConfigBinding,
   ConfigRecord,

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -30,6 +30,19 @@ const ageProviderSchema = z
   })
   .strict();
 
+const awsProviderSchema = z
+  .object({
+    __kind: z.literal("provider:aws"),
+    name: z.literal("aws"),
+    options: z
+      .object({
+        region: z.string().min(1).optional(),
+        kmsKeyId: z.string().min(1).optional()
+      })
+      .strict()
+  })
+  .strict();
+
 const gcpProviderSchema = z
   .object({
     __kind: z.literal("provider:gcp"),
@@ -57,6 +70,7 @@ const sopsProviderSchema = z
 
 const providerRefSchema = z.discriminatedUnion("__kind", [
   ageProviderSchema,
+  awsProviderSchema,
   gcpProviderSchema,
   sopsProviderSchema
 ]);

--- a/packages/cli/src/config/types.ts
+++ b/packages/cli/src/config/types.ts
@@ -12,6 +12,11 @@ export interface AgeProviderOptions {
   secretsDir: string;
 }
 
+export interface AwsProviderOptions {
+  region?: string;
+  kmsKeyId?: string;
+}
+
 export interface GcpProviderOptions {
   project: string;
 }
@@ -23,6 +28,7 @@ export interface SopsProviderOptions {
 
 export type BuiltinProviderRef =
   | ProviderRef<"age", AgeProviderOptions>
+  | ProviderRef<"aws", AwsProviderOptions>
   | ProviderRef<"gcp", GcpProviderOptions>
   | ProviderRef<"sops", SopsProviderOptions>;
 

--- a/packages/cli/src/config/yaml-loader.ts
+++ b/packages/cli/src/config/yaml-loader.ts
@@ -2,9 +2,10 @@ import { existsSync } from "node:fs";
 import { readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { DEFAULT_SCHEMA, load as loadYaml, Type as YamlType } from "js-yaml";
-import { age, config as configRecord, gcp, secret, sops } from "./factories.js";
+import { age, aws, config as configRecord, gcp, secret, sops } from "./factories.js";
 import type {
   AgeProviderOptions,
+  AwsProviderOptions,
   BuiltinProviderRef,
   ConfigBinding,
   ConfigRecord,
@@ -48,7 +49,7 @@ interface EnvFile {
   overrides: Record<string, ConfigBinding | TaggedValue>;
 }
 
-const PROVIDER_TAGS = ["age", "gcp", "sops"] as const;
+const PROVIDER_TAGS = ["age", "aws", "gcp", "sops"] as const;
 const ALL_TAGS = ["secret", ...PROVIDER_TAGS] as const;
 
 function makeMappingTag(name: string): YamlType {
@@ -353,6 +354,8 @@ function providerRef(
       return age(
         requireOptions<AgeProviderOptions>(options, ["identityFile", "secretsDir"], label, "age")
       );
+    case "aws":
+      return aws(requireOptions<AwsProviderOptions>(options, [], label, "aws"));
     case "gcp":
       return gcp(requireOptions<GcpProviderOptions>(options, ["project"], label, "gcp"));
     case "sops":

--- a/packages/cli/src/providers/_paths.ts
+++ b/packages/cli/src/providers/_paths.ts
@@ -2,7 +2,7 @@ import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { isAbsolute, join, resolve } from "node:path";
 import { identityToRecipient } from "age-encryption";
-import type { ProviderContext, ProviderListContext } from "./types.js";
+import type { ProviderContext, ProviderListContext, StoredKey } from "./types.js";
 
 export function resolvePath(filePath: string, rootDir: string): string {
   if (filePath.startsWith("~/") || filePath === "~") {
@@ -25,6 +25,19 @@ export async function readIdentityWithRecipient(
   const identity = await readIdentity(identityFile);
   const recipient = await identityToRecipient(identity);
   return { identity, recipient };
+}
+
+// Shared by `gcp` and `aws` listers: both encode env-or-not into the secret
+// id by joining segments with a per-provider delimiter. After stripping the
+// keyshelf prefix and splitting, this turns the remaining segments back into
+// a `{ keyPath, envName }` pair — using the known env set to disambiguate
+// whether the leading segment is an env or part of the path.
+export function parseStoredSecretSegments(segments: string[], envs: Set<string>): StoredKey | null {
+  if (segments.length === 0 || segments[0] === "") return null;
+  const envName = envs.has(segments[0]) ? segments[0] : undefined;
+  const pathSegs = envName === undefined ? segments : segments.slice(1);
+  if (pathSegs.length === 0) return null;
+  return { keyPath: pathSegs.join("/"), envName };
 }
 
 export function requireStringConfig(

--- a/packages/cli/src/providers/aws-sm.ts
+++ b/packages/cli/src/providers/aws-sm.ts
@@ -106,11 +106,7 @@ export class AwsSmProvider implements Provider {
     return client;
   }
 
-  private async send<T>(
-    opts: AwsSmProviderOptions,
-    keyPath: string,
-    op: () => Promise<T>
-  ): Promise<T> {
+  private async send<T>(keyPath: string, op: () => Promise<T>): Promise<T> {
     try {
       return await op();
     } catch (err) {
@@ -125,7 +121,7 @@ export class AwsSmProvider implements Provider {
     const client = this.getClient(opts);
     const secretId = toSecretId(ctx.keyshelfName, ctx.envName, ctx.keyPath);
 
-    const result = await this.send(opts, ctx.keyPath, () =>
+    const result = await this.send(ctx.keyPath, () =>
       client.send(new GetSecretValueCommand({ SecretId: secretId }))
     );
 
@@ -167,7 +163,7 @@ export class AwsSmProvider implements Provider {
     const fromId = toSecretId(from.keyshelfName, from.envName, from.keyPath);
     const toId = toSecretId(to.keyshelfName, to.envName, to.keyPath);
 
-    const result = await this.send(opts, from.keyPath, () =>
+    const result = await this.send(from.keyPath, () =>
       client.send(new GetSecretValueCommand({ SecretId: fromId }))
     );
 
@@ -209,7 +205,7 @@ export class AwsSmProvider implements Provider {
     const stored: StoredKey[] = [];
     let nextToken: string | undefined;
     do {
-      const result = await this.send(opts, "<list>", () =>
+      const result = await this.send("<list>", () =>
         client.send(
           new ListSecretsCommand({
             Filters: [{ Key: "name", Values: [prefix] }],
@@ -249,7 +245,7 @@ export class AwsSmProvider implements Provider {
       if (!(err instanceof ResourceExistsException)) throw err;
     }
 
-    await this.send(opts, keyPath, () =>
+    await this.send(keyPath, () =>
       client.send(new PutSecretValueCommand({ SecretId: secretId, SecretString: value }))
     );
   }

--- a/packages/cli/src/providers/aws-sm.ts
+++ b/packages/cli/src/providers/aws-sm.ts
@@ -1,0 +1,273 @@
+import {
+  CreateSecretCommand,
+  DeleteSecretCommand,
+  DescribeSecretCommand,
+  GetSecretValueCommand,
+  ListSecretsCommand,
+  PutSecretValueCommand,
+  ResourceExistsException,
+  ResourceNotFoundException,
+  SecretsManagerClient
+} from "@aws-sdk/client-secrets-manager";
+import type {
+  Provider,
+  ProviderContext,
+  ProviderListContext,
+  StorageScope,
+  StoredKey
+} from "./types.js";
+
+export interface AwsSmProviderOptions {
+  region?: string;
+  kmsKeyId?: string;
+}
+
+export class AwsAuthError extends Error {
+  constructor(cause?: Error) {
+    super(
+      "AWS authentication failed. Run 'aws sso login' or check your AWS credentials (AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY env vars or ~/.aws/credentials)."
+    );
+    this.name = "AwsAuthError";
+    this.cause = cause;
+  }
+}
+
+export class AwsRegionError extends Error {
+  constructor(keyPath: string, cause?: Error) {
+    super(
+      `aws provider could not resolve a region for "${keyPath}". Set AWS_REGION, configure a default in your AWS profile, or pass region: '...' in the binding.`
+    );
+    this.name = "AwsRegionError";
+    this.cause = cause;
+  }
+}
+
+const AUTH_ERROR_NAMES = new Set([
+  "CredentialsProviderError",
+  "ExpiredTokenException",
+  "ExpiredToken",
+  "UnrecognizedClientException",
+  "InvalidSignatureException",
+  "InvalidClientTokenId",
+  "SignatureDoesNotMatch"
+]);
+
+function isAuthError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  if (AUTH_ERROR_NAMES.has(err.name)) return true;
+  const status = (err as { $metadata?: { httpStatusCode?: number } }).$metadata?.httpStatusCode;
+  return status === 401 || status === 403;
+}
+
+function isRegionMissingError(err: unknown): boolean {
+  return err instanceof Error && err.message.includes("Region is missing");
+}
+
+const DEFAULT_REGION_KEY = "__default__";
+
+export function toSecretId(
+  keyshelfName: string | undefined,
+  envName: string | undefined,
+  keyPath: string
+): string {
+  const segments = ["keyshelf"];
+  if (keyshelfName !== undefined) segments.push(keyshelfName);
+  if (envName !== undefined && envName !== "") segments.push(envName);
+  segments.push(keyPath);
+  return segments.join("/");
+}
+
+export class AwsSmProvider implements Provider {
+  name = "aws";
+  storageScope: StorageScope = "perEnv";
+
+  private clients = new Map<string, SecretsManagerClient>();
+  private injectedClient: SecretsManagerClient | undefined;
+
+  constructor(client?: SecretsManagerClient) {
+    this.injectedClient = client;
+  }
+
+  private resolveOptions(ctx: ProviderContext | ProviderListContext): AwsSmProviderOptions {
+    const opts: AwsSmProviderOptions = {};
+    if (typeof ctx.config.region === "string") opts.region = ctx.config.region;
+    if (typeof ctx.config.kmsKeyId === "string") opts.kmsKeyId = ctx.config.kmsKeyId;
+    return opts;
+  }
+
+  private getClient(opts: AwsSmProviderOptions): SecretsManagerClient {
+    if (this.injectedClient) return this.injectedClient;
+    const key = opts.region ?? DEFAULT_REGION_KEY;
+    const existing = this.clients.get(key);
+    if (existing) return existing;
+    const client = new SecretsManagerClient(opts.region ? { region: opts.region } : {});
+    this.clients.set(key, client);
+    return client;
+  }
+
+  private async send<T>(
+    opts: AwsSmProviderOptions,
+    keyPath: string,
+    op: () => Promise<T>
+  ): Promise<T> {
+    try {
+      return await op();
+    } catch (err) {
+      if (isAuthError(err)) throw new AwsAuthError(err as Error);
+      if (isRegionMissingError(err)) throw new AwsRegionError(keyPath, err as Error);
+      throw err;
+    }
+  }
+
+  async resolve(ctx: ProviderContext): Promise<string> {
+    const opts = this.resolveOptions(ctx);
+    const client = this.getClient(opts);
+    const secretId = toSecretId(ctx.keyshelfName, ctx.envName, ctx.keyPath);
+
+    const result = await this.send(opts, ctx.keyPath, () =>
+      client.send(new GetSecretValueCommand({ SecretId: secretId }))
+    );
+
+    if (typeof result.SecretString === "string" && result.SecretString.length > 0) {
+      return result.SecretString;
+    }
+    if (result.SecretBinary && result.SecretBinary.byteLength > 0) {
+      return Buffer.from(result.SecretBinary).toString("utf-8");
+    }
+    throw new Error(`Secret "${secretId}" has no payload`);
+  }
+
+  async validate(ctx: ProviderContext): Promise<boolean> {
+    const opts = this.resolveOptions(ctx);
+    const client = this.getClient(opts);
+    const secretId = toSecretId(ctx.keyshelfName, ctx.envName, ctx.keyPath);
+
+    try {
+      await client.send(new DescribeSecretCommand({ SecretId: secretId }));
+      return true;
+    } catch (err) {
+      if (isAuthError(err)) throw new AwsAuthError(err as Error);
+      if (isRegionMissingError(err)) throw new AwsRegionError(ctx.keyPath, err as Error);
+      if (err instanceof ResourceNotFoundException) return false;
+      return false;
+    }
+  }
+
+  async set(ctx: ProviderContext, value: string): Promise<void> {
+    const opts = this.resolveOptions(ctx);
+    const client = this.getClient(opts);
+    const secretId = toSecretId(ctx.keyshelfName, ctx.envName, ctx.keyPath);
+    await this.writeSecret(client, opts, ctx.keyPath, secretId, value);
+  }
+
+  async copy(from: ProviderContext, to: ProviderContext): Promise<void> {
+    const opts = this.resolveOptions(from);
+    const client = this.getClient(opts);
+    const fromId = toSecretId(from.keyshelfName, from.envName, from.keyPath);
+    const toId = toSecretId(to.keyshelfName, to.envName, to.keyPath);
+
+    const result = await this.send(opts, from.keyPath, () =>
+      client.send(new GetSecretValueCommand({ SecretId: fromId }))
+    );
+
+    let payload: string;
+    if (typeof result.SecretString === "string" && result.SecretString.length > 0) {
+      payload = result.SecretString;
+    } else if (result.SecretBinary && result.SecretBinary.byteLength > 0) {
+      payload = Buffer.from(result.SecretBinary).toString("utf-8");
+    } else {
+      throw new Error(`aws: source secret "${fromId}" has no payload`);
+    }
+
+    await this.writeSecret(client, opts, to.keyPath, toId, payload);
+  }
+
+  async delete(ctx: ProviderContext): Promise<void> {
+    const opts = this.resolveOptions(ctx);
+    const client = this.getClient(opts);
+    const secretId = toSecretId(ctx.keyshelfName, ctx.envName, ctx.keyPath);
+
+    try {
+      await client.send(
+        new DeleteSecretCommand({ SecretId: secretId, ForceDeleteWithoutRecovery: true })
+      );
+    } catch (err) {
+      if (isAuthError(err)) throw new AwsAuthError(err as Error);
+      if (isRegionMissingError(err)) throw new AwsRegionError(ctx.keyPath, err as Error);
+      if (err instanceof ResourceNotFoundException) return;
+      throw err;
+    }
+  }
+
+  async list(ctx: ProviderListContext): Promise<StoredKey[]> {
+    const opts = this.resolveOptions(ctx);
+    const client = this.getClient(opts);
+    const prefix = ctx.keyshelfName ? `keyshelf/${ctx.keyshelfName}/` : "keyshelf/";
+    const envs = new Set(ctx.envs ?? []);
+
+    const stored: StoredKey[] = [];
+    let nextToken: string | undefined;
+    do {
+      const result = await this.send(opts, "<list>", () =>
+        client.send(
+          new ListSecretsCommand({
+            Filters: [{ Key: "name", Values: [prefix] }],
+            NextToken: nextToken
+          })
+        )
+      );
+      for (const secret of result.SecretList ?? []) {
+        const parsed = parseSecretId(secret.Name, prefix, envs);
+        if (parsed) stored.push(parsed);
+      }
+      nextToken = result.NextToken;
+    } while (nextToken);
+
+    return stored;
+  }
+
+  private async writeSecret(
+    client: SecretsManagerClient,
+    opts: AwsSmProviderOptions,
+    keyPath: string,
+    secretId: string,
+    value: string
+  ): Promise<void> {
+    try {
+      await client.send(
+        new CreateSecretCommand({
+          Name: secretId,
+          SecretString: value,
+          ...(opts.kmsKeyId ? { KmsKeyId: opts.kmsKeyId } : {})
+        })
+      );
+      return;
+    } catch (err) {
+      if (isAuthError(err)) throw new AwsAuthError(err as Error);
+      if (isRegionMissingError(err)) throw new AwsRegionError(keyPath, err as Error);
+      if (!(err instanceof ResourceExistsException)) throw err;
+    }
+
+    await this.send(opts, keyPath, () =>
+      client.send(new PutSecretValueCommand({ SecretId: secretId, SecretString: value }))
+    );
+  }
+}
+
+function parseSecretId(
+  secretName: string | null | undefined,
+  prefix: string,
+  envs: Set<string>
+): StoredKey | null {
+  if (!secretName?.startsWith(prefix)) return null;
+
+  const remainder = secretName.slice(prefix.length);
+  if (remainder.length === 0) return null;
+
+  const segs = remainder.split("/");
+  const envName = envs.has(segs[0]) ? segs[0] : undefined;
+  const pathSegs = envName === undefined ? segs : segs.slice(1);
+  if (pathSegs.length === 0) return null;
+
+  return { keyPath: pathSegs.join("/"), envName };
+}

--- a/packages/cli/src/providers/aws-sm.ts
+++ b/packages/cli/src/providers/aws-sm.ts
@@ -9,6 +9,7 @@ import {
   ResourceNotFoundException,
   SecretsManagerClient
 } from "@aws-sdk/client-secrets-manager";
+import { parseStoredSecretSegments } from "./_paths.js";
 import type {
   Provider,
   ProviderContext,
@@ -260,14 +261,7 @@ function parseSecretId(
   envs: Set<string>
 ): StoredKey | null {
   if (!secretName?.startsWith(prefix)) return null;
-
   const remainder = secretName.slice(prefix.length);
   if (remainder.length === 0) return null;
-
-  const segs = remainder.split("/");
-  const envName = envs.has(segs[0]) ? segs[0] : undefined;
-  const pathSegs = envName === undefined ? segs : segs.slice(1);
-  if (pathSegs.length === 0) return null;
-
-  return { keyPath: pathSegs.join("/"), envName };
+  return parseStoredSecretSegments(remainder.split("/"), envs);
 }

--- a/packages/cli/src/providers/gcp-sm.ts
+++ b/packages/cli/src/providers/gcp-sm.ts
@@ -1,4 +1,5 @@
 import { SecretManagerServiceClient } from "@google-cloud/secret-manager";
+import { parseStoredSecretSegments } from "./_paths.js";
 import type {
   Provider,
   ProviderContext,
@@ -221,14 +222,7 @@ function parseSecretId(
 ): StoredKey | null {
   const id = secretName?.split("/").pop();
   if (!id?.startsWith(prefix)) return null;
-
   const remainder = id.slice(prefix.length);
   if (remainder.length === 0) return null;
-
-  const segs = remainder.split("__");
-  const envName = envs.has(segs[0]) ? segs[0] : undefined;
-  const pathSegs = envName === undefined ? segs : segs.slice(1);
-  if (pathSegs.length === 0) return null;
-
-  return { keyPath: pathSegs.join("/"), envName };
+  return parseStoredSecretSegments(remainder.split("__"), envs);
 }

--- a/packages/cli/src/providers/setup.ts
+++ b/packages/cli/src/providers/setup.ts
@@ -1,6 +1,7 @@
 import { ProviderRegistry } from "./registry.js";
 import { PlaintextProvider } from "./plaintext.js";
 import { AgeProvider } from "./age.js";
+import { AwsSmProvider } from "./aws-sm.js";
 import { GcpSmProvider } from "./gcp-sm.js";
 import { SopsProvider } from "./sops.js";
 
@@ -8,6 +9,7 @@ export function createDefaultRegistry(): ProviderRegistry {
   const registry = new ProviderRegistry();
   registry.register(new PlaintextProvider());
   registry.register(new AgeProvider());
+  registry.register(new AwsSmProvider());
   registry.register(new GcpSmProvider());
   registry.register(new SopsProvider());
   return registry;

--- a/packages/cli/test/unit/config.test.ts
+++ b/packages/cli/test/unit/config.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
   age,
+  aws,
   config,
   defineConfig,
   gcp,
   normalizeConfig,
+  providerRefSchema,
   secret,
   validateAppMappingReferences
 } from "../../src/config/index.js";
@@ -365,5 +367,69 @@ describe("config factories and validation", () => {
         normalized.keys
       )
     ).toThrow('DB_PASSWORD: references unknown key "db/password"');
+  });
+});
+
+describe("aws() factory", () => {
+  it("returns a provider ref with empty options when called bare", () => {
+    expect(aws()).toEqual({ __kind: "provider:aws", name: "aws", options: {} });
+  });
+
+  it("preserves region and kmsKeyId when provided", () => {
+    const ref = aws({ region: "eu-west-1", kmsKeyId: "alias/keyshelf" });
+    expect(ref.options).toEqual({ region: "eu-west-1", kmsKeyId: "alias/keyshelf" });
+  });
+
+  it("normalizes through the full config pipeline", () => {
+    const normalized = normalizeConfig(
+      defineConfig({
+        name: "test",
+        envs: ["prod"],
+        keys: {
+          token: secret({ value: aws({ region: "us-east-1" }) })
+        }
+      })
+    );
+    const token = normalized.keys.find((k) => k.path === "token");
+    expect(token).toMatchObject({
+      kind: "secret",
+      value: { __kind: "provider:aws", name: "aws", options: { region: "us-east-1" } }
+    });
+  });
+});
+
+describe("aws provider schema", () => {
+  it("accepts a ref with no options (relies on SDK region chain)", () => {
+    expect(() => providerRefSchema.parse(aws())).not.toThrow();
+  });
+
+  it("accepts a ref with explicit region", () => {
+    expect(() => providerRefSchema.parse(aws({ region: "eu-west-2" }))).not.toThrow();
+  });
+
+  it("accepts a ref with kmsKeyId", () => {
+    expect(() =>
+      providerRefSchema.parse(aws({ region: "eu-west-2", kmsKeyId: "alias/x" }))
+    ).not.toThrow();
+  });
+
+  it("rejects unknown option keys (strict mode)", () => {
+    expect(() =>
+      providerRefSchema.parse({
+        __kind: "provider:aws",
+        name: "aws",
+        options: { region: "eu-west-1", bogus: true }
+      })
+    ).toThrow();
+  });
+
+  it("rejects empty-string region", () => {
+    expect(() =>
+      providerRefSchema.parse({
+        __kind: "provider:aws",
+        name: "aws",
+        options: { region: "" }
+      })
+    ).toThrow();
   });
 });

--- a/packages/cli/test/unit/providers/aws-sm.test.ts
+++ b/packages/cli/test/unit/providers/aws-sm.test.ts
@@ -1,0 +1,461 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  CreateSecretCommand,
+  DeleteSecretCommand,
+  DescribeSecretCommand,
+  GetSecretValueCommand,
+  ListSecretsCommand,
+  PutSecretValueCommand,
+  ResourceExistsException,
+  ResourceNotFoundException,
+  type SecretsManagerClient
+} from "@aws-sdk/client-secrets-manager";
+import { AwsAuthError, AwsRegionError, AwsSmProvider } from "../../../src/providers/aws-sm.js";
+
+interface MockClient {
+  send: ReturnType<typeof vi.fn>;
+}
+
+function mockClient(): MockClient {
+  return { send: vi.fn() };
+}
+
+function commandKind(command: unknown): string {
+  return (command as { constructor: { name: string } }).constructor.name;
+}
+
+function notFoundError(): ResourceNotFoundException {
+  return new ResourceNotFoundException({
+    $metadata: {},
+    message: "Secrets Manager can't find the specified secret."
+  });
+}
+
+function alreadyExistsError(): ResourceExistsException {
+  return new ResourceExistsException({
+    $metadata: {},
+    message: "The operation failed because the secret already exists."
+  });
+}
+
+function authError(name = "CredentialsProviderError"): Error {
+  const err = new Error("Could not load credentials from any providers");
+  err.name = name;
+  return err;
+}
+
+function http403Error(): Error {
+  const err = Object.assign(new Error("AccessDenied"), {
+    name: "AccessDenied",
+    $metadata: { httpStatusCode: 403 }
+  });
+  return err;
+}
+
+function regionMissingError(): Error {
+  return new Error("Region is missing");
+}
+
+describe("AwsSmProvider", () => {
+  let client: MockClient;
+  let provider: AwsSmProvider;
+
+  beforeEach(() => {
+    client = mockClient();
+    provider = new AwsSmProvider(client as unknown as SecretsManagerClient);
+  });
+
+  function ctx(keyPath: string, envName: string | undefined = "prod") {
+    return { keyPath, envName, rootDir: "/tmp", config: { region: "eu-west-1" } };
+  }
+
+  describe("secret ID derivation", () => {
+    it("generates keyshelf/{env}/{path} when keyshelfName is absent", async () => {
+      client.send.mockResolvedValue({ SecretString: "val" });
+
+      await provider.resolve(ctx("db/password", "staging"));
+
+      const call = client.send.mock.calls[0][0];
+      expect(commandKind(call)).toBe("GetSecretValueCommand");
+      expect(call.input).toEqual({ SecretId: "keyshelf/staging/db/password" });
+    });
+
+    it("preserves nested path segments with /", async () => {
+      client.send.mockResolvedValue({ SecretString: "val" });
+      await provider.resolve(ctx("services/api/db/password", "dev"));
+      expect(client.send.mock.calls[0][0].input.SecretId).toBe(
+        "keyshelf/dev/services/api/db/password"
+      );
+    });
+
+    it("includes keyshelfName segment when provided", async () => {
+      client.send.mockResolvedValue({ SecretString: "val" });
+      await provider.resolve({
+        keyPath: "db/password",
+        envName: "staging",
+        rootDir: "/tmp",
+        config: { region: "eu-west-1" },
+        keyshelfName: "myapp"
+      });
+      expect(client.send.mock.calls[0][0].input.SecretId).toBe(
+        "keyshelf/myapp/staging/db/password"
+      );
+    });
+
+    it("omits env segment when envName is undefined (envless)", async () => {
+      client.send.mockResolvedValue({ SecretString: "val" });
+      await provider.resolve({
+        keyPath: "github/token",
+        envName: undefined,
+        rootDir: "/tmp",
+        config: { region: "eu-west-1" },
+        keyshelfName: "myapp"
+      });
+      expect(client.send.mock.calls[0][0].input.SecretId).toBe("keyshelf/myapp/github/token");
+    });
+
+    it("omits env segment when envName is empty string", async () => {
+      client.send.mockResolvedValue({ SecretString: "val" });
+      await provider.resolve({
+        keyPath: "github/token",
+        envName: "",
+        rootDir: "/tmp",
+        config: { region: "eu-west-1" },
+        keyshelfName: "myapp"
+      });
+      expect(client.send.mock.calls[0][0].input.SecretId).toBe("keyshelf/myapp/github/token");
+    });
+  });
+
+  describe("resolve", () => {
+    it("returns SecretString payload", async () => {
+      client.send.mockResolvedValue({ SecretString: "supersecret" });
+      const result = await provider.resolve(ctx("db/password"));
+      expect(result).toBe("supersecret");
+    });
+
+    it("decodes SecretBinary as UTF-8 when SecretString is empty", async () => {
+      client.send.mockResolvedValue({
+        SecretString: "",
+        SecretBinary: new Uint8Array(Buffer.from("binary-payload", "utf-8"))
+      });
+      const result = await provider.resolve(ctx("db/password"));
+      expect(result).toBe("binary-payload");
+    });
+
+    it("throws when payload is empty", async () => {
+      client.send.mockResolvedValue({});
+      await expect(provider.resolve(ctx("db/password"))).rejects.toThrow("has no payload");
+    });
+
+    it("uses GetSecretValueCommand", async () => {
+      client.send.mockResolvedValue({ SecretString: "v" });
+      await provider.resolve(ctx("db/password"));
+      expect(client.send.mock.calls[0][0]).toBeInstanceOf(GetSecretValueCommand);
+    });
+  });
+
+  describe("validate", () => {
+    it("returns true when DescribeSecret succeeds", async () => {
+      client.send.mockResolvedValue({});
+      const result = await provider.validate(ctx("db/password"));
+      expect(result).toBe(true);
+      expect(client.send.mock.calls[0][0]).toBeInstanceOf(DescribeSecretCommand);
+    });
+
+    it("returns false on ResourceNotFoundException", async () => {
+      client.send.mockRejectedValue(notFoundError());
+      expect(await provider.validate(ctx("db/password"))).toBe(false);
+    });
+
+    it("returns false on other errors", async () => {
+      client.send.mockRejectedValue(new Error("InternalServiceError"));
+      expect(await provider.validate(ctx("db/password"))).toBe(false);
+    });
+
+    it("throws AwsAuthError on auth failure", async () => {
+      client.send.mockRejectedValue(authError());
+      await expect(provider.validate(ctx("db/password"))).rejects.toThrow(AwsAuthError);
+    });
+  });
+
+  describe("set", () => {
+    it("uses CreateSecretCommand on first set", async () => {
+      client.send.mockResolvedValue({});
+      await provider.set(ctx("db/password"), "newval");
+
+      expect(client.send.mock.calls).toHaveLength(1);
+      const call = client.send.mock.calls[0][0];
+      expect(call).toBeInstanceOf(CreateSecretCommand);
+      expect(call.input).toEqual({
+        Name: "keyshelf/prod/db/password",
+        SecretString: "newval"
+      });
+    });
+
+    it("forwards kmsKeyId on CreateSecret when configured", async () => {
+      client.send.mockResolvedValue({});
+      await provider.set(
+        {
+          keyPath: "db/password",
+          envName: "prod",
+          rootDir: "/tmp",
+          config: { region: "eu-west-1", kmsKeyId: "arn:aws:kms:eu-west-1:111:key/abc" }
+        },
+        "v"
+      );
+      expect(client.send.mock.calls[0][0].input.KmsKeyId).toBe("arn:aws:kms:eu-west-1:111:key/abc");
+    });
+
+    it("falls back to PutSecretValueCommand on ResourceExistsException", async () => {
+      client.send.mockRejectedValueOnce(alreadyExistsError()).mockResolvedValueOnce({});
+
+      await provider.set(ctx("db/password"), "updated");
+
+      expect(client.send.mock.calls).toHaveLength(2);
+      expect(client.send.mock.calls[0][0]).toBeInstanceOf(CreateSecretCommand);
+      const put = client.send.mock.calls[1][0];
+      expect(put).toBeInstanceOf(PutSecretValueCommand);
+      expect(put.input).toEqual({
+        SecretId: "keyshelf/prod/db/password",
+        SecretString: "updated"
+      });
+    });
+
+    it("does not forward kmsKeyId on PutSecretValue (inherited from existing secret)", async () => {
+      client.send.mockRejectedValueOnce(alreadyExistsError()).mockResolvedValueOnce({});
+      await provider.set(
+        {
+          keyPath: "db/password",
+          envName: "prod",
+          rootDir: "/tmp",
+          config: { region: "eu-west-1", kmsKeyId: "arn:aws:kms:eu-west-1:111:key/abc" }
+        },
+        "v"
+      );
+      expect(client.send.mock.calls[1][0].input.KmsKeyId).toBeUndefined();
+    });
+
+    it("rethrows non-recoverable errors from CreateSecret", async () => {
+      const err = Object.assign(new Error("InvalidRequestException"), {
+        name: "InvalidRequestException"
+      });
+      client.send.mockRejectedValue(err);
+      await expect(provider.set(ctx("db/password"), "v")).rejects.toThrow(
+        "InvalidRequestException"
+      );
+    });
+
+    it("wraps auth errors on CreateSecret", async () => {
+      client.send.mockRejectedValue(authError("ExpiredTokenException"));
+      await expect(provider.set(ctx("db/password"), "v")).rejects.toThrow(AwsAuthError);
+    });
+
+    it("wraps auth errors on PutSecretValue fallback", async () => {
+      client.send.mockRejectedValueOnce(alreadyExistsError()).mockRejectedValueOnce(authError());
+      await expect(provider.set(ctx("db/password"), "v")).rejects.toThrow(AwsAuthError);
+    });
+  });
+
+  describe("copy", () => {
+    function copyCtx(keyPath: string, envName: string | undefined = "prod") {
+      return { keyPath, envName, rootDir: "/tmp", config: { region: "eu-west-1" } };
+    }
+
+    it("reads source then creates target with the same payload", async () => {
+      client.send.mockResolvedValueOnce({ SecretString: "payload" }).mockResolvedValueOnce({});
+
+      await provider.copy(copyCtx("old/key"), copyCtx("new/key"));
+
+      expect(client.send.mock.calls[0][0]).toBeInstanceOf(GetSecretValueCommand);
+      expect(client.send.mock.calls[0][0].input.SecretId).toBe("keyshelf/prod/old/key");
+      expect(client.send.mock.calls[1][0]).toBeInstanceOf(CreateSecretCommand);
+      expect(client.send.mock.calls[1][0].input).toEqual({
+        Name: "keyshelf/prod/new/key",
+        SecretString: "payload"
+      });
+    });
+
+    it("does not delete the source", async () => {
+      client.send.mockResolvedValueOnce({ SecretString: "v" }).mockResolvedValueOnce({});
+      await provider.copy(copyCtx("a"), copyCtx("b"));
+      const kinds = client.send.mock.calls.map((c) => commandKind(c[0]));
+      expect(kinds).not.toContain("DeleteSecretCommand");
+    });
+
+    it("falls back to PutSecretValue when target already exists", async () => {
+      client.send
+        .mockResolvedValueOnce({ SecretString: "v" })
+        .mockRejectedValueOnce(alreadyExistsError())
+        .mockResolvedValueOnce({});
+
+      await provider.copy(copyCtx("a"), copyCtx("b"));
+
+      expect(client.send.mock.calls[2][0]).toBeInstanceOf(PutSecretValueCommand);
+    });
+
+    it("decodes SecretBinary source payload", async () => {
+      client.send
+        .mockResolvedValueOnce({
+          SecretString: "",
+          SecretBinary: new Uint8Array(Buffer.from("bin", "utf-8"))
+        })
+        .mockResolvedValueOnce({});
+      await provider.copy(copyCtx("a"), copyCtx("b"));
+      expect(client.send.mock.calls[1][0].input.SecretString).toBe("bin");
+    });
+
+    it("throws when source has no payload", async () => {
+      client.send.mockResolvedValue({});
+      await expect(provider.copy(copyCtx("a"), copyCtx("b"))).rejects.toThrow("has no payload");
+    });
+
+    it("wraps auth errors during source read", async () => {
+      client.send.mockRejectedValue(authError());
+      await expect(provider.copy(copyCtx("a"), copyCtx("b"))).rejects.toThrow(AwsAuthError);
+    });
+  });
+
+  describe("delete", () => {
+    it("force-deletes without recovery window", async () => {
+      client.send.mockResolvedValue({});
+      await provider.delete(ctx("legacy/key"));
+      const call = client.send.mock.calls[0][0];
+      expect(call).toBeInstanceOf(DeleteSecretCommand);
+      expect(call.input).toEqual({
+        SecretId: "keyshelf/prod/legacy/key",
+        ForceDeleteWithoutRecovery: true
+      });
+    });
+
+    it("is idempotent on ResourceNotFoundException", async () => {
+      client.send.mockRejectedValue(notFoundError());
+      await expect(provider.delete(ctx("legacy/key"))).resolves.toBeUndefined();
+    });
+
+    it("rethrows other errors", async () => {
+      client.send.mockRejectedValue(new Error("InternalServiceError"));
+      await expect(provider.delete(ctx("legacy/key"))).rejects.toThrow("InternalServiceError");
+    });
+
+    it("wraps auth errors", async () => {
+      client.send.mockRejectedValue(authError());
+      await expect(provider.delete(ctx("legacy/key"))).rejects.toThrow(AwsAuthError);
+    });
+  });
+
+  describe("list", () => {
+    function listCtx(overrides: Record<string, unknown> = {}) {
+      return {
+        rootDir: "/tmp",
+        config: { region: "eu-west-1" },
+        keyshelfName: "myapp",
+        envs: ["dev", "staging", "prod"],
+        ...overrides
+      };
+    }
+
+    function mockListSecrets(pages: Array<{ ids: string[]; next?: string }>) {
+      for (const page of pages) {
+        client.send.mockResolvedValueOnce({
+          SecretList: page.ids.map((id) => ({ Name: id })),
+          NextToken: page.next
+        });
+      }
+    }
+
+    it("uses ListSecretsCommand with a name-prefix filter scoped to keyshelfName", async () => {
+      mockListSecrets([{ ids: [] }]);
+      await provider.list(listCtx());
+      const call = client.send.mock.calls[0][0];
+      expect(call).toBeInstanceOf(ListSecretsCommand);
+      expect(call.input.Filters).toEqual([{ Key: "name", Values: ["keyshelf/myapp/"] }]);
+    });
+
+    it("uses keyshelf/ prefix when keyshelfName is absent", async () => {
+      mockListSecrets([{ ids: [] }]);
+      await provider.list(listCtx({ keyshelfName: undefined }));
+      expect(client.send.mock.calls[0][0].input.Filters[0].Values[0]).toBe("keyshelf/");
+    });
+
+    it("returns empty array when no secrets match", async () => {
+      mockListSecrets([{ ids: ["unrelated", "other/thing"] }]);
+      expect(await provider.list(listCtx())).toEqual([]);
+    });
+
+    it("filters by prefix and parses env-scoped ids", async () => {
+      mockListSecrets([
+        {
+          ids: [
+            "keyshelf/myapp/staging/db/password",
+            "keyshelf/myapp/prod/api/token",
+            "keyshelf/otherapp/staging/db/password"
+          ]
+        }
+      ]);
+      const result = await provider.list(listCtx());
+      expect(result).toEqual(
+        expect.arrayContaining([
+          { keyPath: "db/password", envName: "staging" },
+          { keyPath: "api/token", envName: "prod" }
+        ])
+      );
+      expect(result).toHaveLength(2);
+    });
+
+    it("treats segments not in envs as part of key path (envless secrets)", async () => {
+      mockListSecrets([{ ids: ["keyshelf/myapp/github/token"] }]);
+      const result = await provider.list(listCtx());
+      expect(result).toEqual([{ keyPath: "github/token", envName: undefined }]);
+    });
+
+    it("paginates via NextToken", async () => {
+      mockListSecrets([
+        { ids: ["keyshelf/myapp/dev/a"], next: "tok-1" },
+        { ids: ["keyshelf/myapp/dev/b"] }
+      ]);
+      const result = await provider.list(listCtx());
+      expect(result).toHaveLength(2);
+      expect(client.send.mock.calls).toHaveLength(2);
+      expect(client.send.mock.calls[1][0].input.NextToken).toBe("tok-1");
+    });
+
+    it("wraps auth errors as AwsAuthError", async () => {
+      client.send.mockRejectedValue(authError());
+      await expect(provider.list(listCtx())).rejects.toThrow(AwsAuthError);
+    });
+  });
+
+  describe("auth error detection", () => {
+    it("recognises HTTP 403 as auth failure", async () => {
+      client.send.mockRejectedValue(http403Error());
+      await expect(provider.resolve(ctx("k"))).rejects.toThrow(AwsAuthError);
+    });
+
+    it("does not wrap non-auth errors", async () => {
+      const err = Object.assign(new Error("InvalidParameter"), { name: "InvalidParameter" });
+      client.send.mockRejectedValue(err);
+      await expect(provider.resolve(ctx("k"))).rejects.toThrow("InvalidParameter");
+      await expect(provider.resolve(ctx("k"))).rejects.not.toThrow(AwsAuthError);
+    });
+  });
+
+  describe("region resolution", () => {
+    it("throws AwsRegionError when SDK reports Region is missing", async () => {
+      client.send.mockRejectedValue(regionMissingError());
+      await expect(provider.resolve(ctx("k"))).rejects.toThrow(AwsRegionError);
+      await expect(provider.resolve(ctx("k"))).rejects.toThrow("AWS_REGION");
+    });
+
+    it("works without an explicit region in config (lets SDK resolve)", async () => {
+      client.send.mockResolvedValue({ SecretString: "v" });
+      await provider.resolve({
+        keyPath: "k",
+        envName: "prod",
+        rootDir: "/tmp",
+        config: {}
+      });
+      expect(client.send).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/cli/test/unit/yaml-loader.test.ts
+++ b/packages/cli/test/unit/yaml-loader.test.ts
@@ -100,6 +100,45 @@ describe("yaml-loader", () => {
     );
   });
 
+  it("parses bare !aws (relies on SDK region chain)", async () => {
+    const root = await writeProject({
+      "keyshelf.yaml": ["name: app", "keys:", "  api:", "    token: !secret"].join("\n"),
+      ".keyshelf/prod.yaml": ["keys:", "  api:", "    token: !aws"].join("\n")
+    });
+
+    const config = normalizeConfig(await loadYamlConfig(join(root, "keyshelf.yaml")));
+    const token = config.keys.find((k) => k.path === "api/token");
+    expect(token).toMatchObject({
+      kind: "secret",
+      values: { prod: { __kind: "provider:aws", name: "aws", options: {} } }
+    });
+  });
+
+  it("parses !aws with region and kmsKeyId mappings", async () => {
+    const root = await writeProject({
+      "keyshelf.yaml": ["name: app", "keys:", "  api:", "    token: !secret"].join("\n"),
+      ".keyshelf/prod.yaml": [
+        "keys:",
+        "  api:",
+        "    token: !aws",
+        "      region: eu-west-1",
+        "      kmsKeyId: alias/keyshelf"
+      ].join("\n")
+    });
+
+    const config = normalizeConfig(await loadYamlConfig(join(root, "keyshelf.yaml")));
+    const token = config.keys.find((k) => k.path === "api/token");
+    expect(token).toMatchObject({
+      kind: "secret",
+      values: {
+        prod: {
+          __kind: "provider:aws",
+          options: { region: "eu-west-1", kmsKeyId: "alias/keyshelf" }
+        }
+      }
+    });
+  });
+
   it("requires a top-level name", async () => {
     const root = await writeProject({
       "keyshelf.yaml": "keys: { foo: bar }\n",


### PR DESCRIPTION
## Summary

- Adds a fourth secret provider, `aws`, backed by AWS Secrets Manager. Mirrors the existing `gcp` provider's storage model (`perEnv` scope, ids derived from `name`/`env`/`keyPath`, idempotent ensure/version/delete, listing via prefix filter).
- `aws()` factory and `!aws` YAML tag accept both options optional. With nothing configured, the AWS SDK's default region chain (`AWS_REGION` → `AWS_DEFAULT_REGION` → active profile) and credential chain are used. Explicit `region` overrides the chain; `kmsKeyId` is forwarded to `CreateSecret` for customer-managed KMS encryption.
- Auth failures are wrapped in a typed `AwsAuthError`; "Region is missing" failures (when neither config nor SDK chain can resolve a region) become a typed `AwsRegionError` with a remediation hint.
- Reconcile (`keyshelf up`) integrates without planner changes — `storageScope: "perEnv"` is enough.

## Why

Users in AWS-hosted monorepos asked for parity with the GCP backend. Implementation plan lives at `.claude/plans/aws-provider.md`.

## Notable design choices

- Secret names use `/` as separator (e.g. `keyshelf/myapp/prod/db/password`). AWS Secrets Manager allows `/` natively and the console renders it as folders; no `__` mangling needed (unlike GCP).
- Region defaults to the SDK chain rather than being a required field — most users already have `AWS_REGION` or a profile default.
- `delete` uses `ForceDeleteWithoutRecovery: true` so reconcile orphan removal is genuinely terminal (the default 30-day recovery window would leave entries visible to subsequent `list` calls).

## Test plan

- [x] Unit tests for `AwsSmProvider` (41 cases) — secret-id derivation, resolve/validate/set/copy/delete/list, pagination, KMS forwarding, auth-error wrapping, region-missing handling
- [x] Config-side tests for `aws()` factory and zod schema (strict-mode rejection, optional-options acceptance)
- [x] YAML-loader tests for bare `!aws` and `!aws { region, kmsKeyId }`
- [x] Full CLI test suite — 270/270 passing
- [x] `tsc --noEmit` clean across all workspaces
- [x] `eslint .` clean
- [x] `examples/` typecheck clean against built dist
- [ ] Manual end-to-end against a real AWS account (not run; CI will exercise the mock path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)