### PR TITLE
feat(cli): add `keyshelf cp` to copy secrets to the clipboard

### DIFF
--- a/packages/cli/src/cli/cp.ts
+++ b/packages/cli/src/cli/cp.ts
@@ -1,0 +1,120 @@
+import { createHash } from "node:crypto";
+import spawn from "cross-spawn";
+import { Command } from "commander";
+import { loadConfig } from "../config/index.js";
+import { resolveWithStatus } from "../resolver/index.js";
+import { createDefaultRegistry } from "../providers/setup.js";
+import { assertValidationPasses } from "./validation.js";
+import { readClipboard, writeClipboard } from "../utils/clipboard.js";
+import type { KeyResolutionStatus } from "../resolver/types.js";
+
+interface CpOptions {
+  env?: string;
+  quiet?: boolean;
+  clear?: string;
+}
+
+const DEFAULT_CLEAR_SECONDS = 60;
+
+export const cpCommand = new Command("cp")
+  .description("Resolve a key and copy its value to the system clipboard")
+  .option("--env <env>", "Environment name (required if the key has per-env bindings)")
+  .option("-q, --quiet", "Suppress confirmation output")
+  .option(
+    "--clear <seconds>",
+    `Seconds before the clipboard is cleared; 0 disables (default ${DEFAULT_CLEAR_SECONDS})`
+  )
+  .argument("<key>", "Key path (e.g. db/password)")
+  .action(async (keyPath: string, opts: CpOptions) => {
+    const clearSeconds = parseClearSeconds(opts);
+
+    const loaded = await loadConfig(process.cwd());
+    const record = loaded.config.keys.find((entry) => entry.path === keyPath);
+    if (record === undefined) {
+      console.error(`error: key "${keyPath}" is not defined in keyshelf.config.ts`);
+      process.exit(1);
+    }
+
+    const resolveOpts = {
+      config: loaded.config,
+      envName: opts.env,
+      rootDir: loaded.rootDir,
+      registry: createDefaultRegistry(),
+      filters: [keyPath]
+    };
+
+    await assertValidationPasses(resolveOpts);
+    const resolution = await resolveWithStatus(resolveOpts);
+    const status = resolution.statusByPath.get(keyPath);
+
+    if (status === undefined || status.status !== "resolved") {
+      console.error(`error: cannot copy "${keyPath}" — ${describeUnresolved(status)}`);
+      process.exit(1);
+    }
+
+    await writeClipboard(status.value);
+
+    if (clearSeconds !== undefined) {
+      scheduleClear(status.value, clearSeconds);
+    }
+
+    if (!opts.quiet) {
+      const envLabel = opts.env ?? "(envless)";
+      const tail = clearSeconds !== undefined ? ` (clears in ${clearSeconds}s)` : "";
+      console.error(`copied "${keyPath}" from ${envLabel}${tail}`);
+    }
+  });
+
+export const cpClearCommand = new Command("__cp-clear")
+  .description("internal: clears the clipboard if it still holds the given hash")
+  .argument("<hash>", "sha256 hex of the value to clear")
+  .argument("<seconds>", "delay in seconds before clearing")
+  .action(async (hashHex: string, secondsRaw: string) => {
+    const seconds = Number(secondsRaw);
+    if (!Number.isFinite(seconds) || seconds < 0) return;
+
+    await wait(seconds * 1000);
+
+    try {
+      const current = await readClipboard();
+      if (sha256(current) === hashHex) {
+        await writeClipboard("");
+      }
+    } catch {
+      // clipboard tool gone or unreadable — nothing to do
+    }
+  });
+
+function parseClearSeconds(opts: CpOptions): number | undefined {
+  if (opts.clear === undefined) return DEFAULT_CLEAR_SECONDS;
+  const n = Number(opts.clear);
+  if (!Number.isFinite(n) || n < 0) {
+    console.error(`error: --clear must be a non-negative number of seconds`);
+    process.exit(1);
+  }
+  return n === 0 ? undefined : n;
+}
+
+function scheduleClear(value: string, seconds: number): void {
+  const hashHex = sha256(value);
+  const child = spawn(process.execPath, [process.argv[1], "__cp-clear", hashHex, String(seconds)], {
+    detached: true,
+    stdio: "ignore"
+  });
+  child.unref();
+}
+
+function sha256(input: string): string {
+  return createHash("sha256").update(input, "utf-8").digest("hex");
+}
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function describeUnresolved(status: KeyResolutionStatus | undefined): string {
+  if (status === undefined) return "no resolution status";
+  if (status.status === "error") return status.message;
+  if (status.status === "filtered") return "value is filtered out";
+  return "value is unavailable";
+}

--- a/packages/cli/src/cli/cp.ts
+++ b/packages/cli/src/cli/cp.ts
@@ -5,6 +5,7 @@ import { loadConfig } from "../config/index.js";
 import { resolveWithStatus } from "../resolver/index.js";
 import { createDefaultRegistry } from "../providers/setup.js";
 import { assertValidationPasses } from "./validation.js";
+import { findRecordOrExit } from "./options.js";
 import { readClipboard, writeClipboard } from "../utils/clipboard.js";
 import type { KeyResolutionStatus } from "../resolver/types.js";
 
@@ -29,11 +30,7 @@ export const cpCommand = new Command("cp")
     const clearSeconds = parseClearSeconds(opts);
 
     const loaded = await loadConfig(process.cwd());
-    const record = loaded.config.keys.find((entry) => entry.path === keyPath);
-    if (record === undefined) {
-      console.error(`error: key "${keyPath}" is not defined in keyshelf.config.ts`);
-      process.exit(1);
-    }
+    findRecordOrExit(loaded.config, keyPath);
 
     const resolveOpts = {
       config: loaded.config,

--- a/packages/cli/src/cli/index.ts
+++ b/packages/cli/src/cli/index.ts
@@ -4,6 +4,7 @@ import { lsCommand } from "./ls.js";
 import { setCommand } from "./set.js";
 import { importCommand } from "./import.js";
 import { upCommand } from "./up.js";
+import { cpCommand, cpClearCommand } from "./cp.js";
 
 const CLI_VERSION = "5.0.0";
 
@@ -17,6 +18,8 @@ export function createProgram(): Command {
   program.addCommand(setCommand);
   program.addCommand(importCommand);
   program.addCommand(upCommand);
+  program.addCommand(cpCommand);
+  program.addCommand(cpClearCommand, { hidden: true });
 
   return program;
 }

--- a/packages/cli/src/cli/options.ts
+++ b/packages/cli/src/cli/options.ts
@@ -1,3 +1,5 @@
+import type { NormalizedConfig, NormalizedRecord } from "../config/types.js";
+
 export function splitList(value: string | undefined): string[] | undefined {
   if (value === undefined) return undefined;
   const parts = value
@@ -5,4 +7,13 @@ export function splitList(value: string | undefined): string[] | undefined {
     .map((part) => part.trim())
     .filter((part) => part.length > 0);
   return parts.length === 0 ? undefined : parts;
+}
+
+export function findRecordOrExit(config: NormalizedConfig, keyPath: string): NormalizedRecord {
+  const record = config.keys.find((entry) => entry.path === keyPath);
+  if (record === undefined) {
+    console.error(`error: key "${keyPath}" is not defined in keyshelf.config.ts`);
+    process.exit(1);
+  }
+  return record;
 }

--- a/packages/cli/src/cli/set.ts
+++ b/packages/cli/src/cli/set.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 import { loadConfig } from "../config/index.js";
 import { createDefaultRegistry } from "../providers/setup.js";
 import { findStaleRenameSource, pickProviderRef, writeSecret } from "./secret-binding.js";
+import { findRecordOrExit } from "./options.js";
 
 interface SetOptions {
   env?: string;
@@ -21,12 +22,7 @@ export const setCommand = new Command("set")
   .action(async (keyPath: string, opts: SetOptions) => {
     const appDir = process.cwd();
     const loaded = await loadConfig(appDir);
-    const record = loaded.config.keys.find((entry) => entry.path === keyPath);
-
-    if (record === undefined) {
-      console.error(`error: key "${keyPath}" is not defined in keyshelf.config.ts`);
-      process.exit(1);
-    }
+    const record = findRecordOrExit(loaded.config, keyPath);
 
     if (record.kind === "config") {
       console.error(

--- a/packages/cli/src/utils/clipboard.ts
+++ b/packages/cli/src/utils/clipboard.ts
@@ -66,37 +66,35 @@ export async function readClipboard(): Promise<string> {
 }
 
 function runWithStdin(tool: ClipboardTool, input: string): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const child = spawn(tool.command, tool.args, { stdio: ["pipe", "ignore", "pipe"] });
-    let stderr = "";
-    child.stderr?.on("data", (chunk) => (stderr += chunk.toString()));
-    child.on("error", reject);
-    child.on("close", (code) => {
-      if (code === 0) {
-        resolve();
-        return;
-      }
-      reject(new Error(`${tool.command} exited with code ${code}${stderr ? `: ${stderr}` : ""}`));
-    });
-    child.stdin?.end(input);
-  });
+  return runTool(tool, "ignore", (child) => child.stdin?.end(input)).then(() => undefined);
 }
 
 function runCaptureStdout(tool: ClipboardTool): Promise<string> {
+  return runTool(tool, "pipe");
+}
+
+function runTool(
+  tool: ClipboardTool,
+  stdout: "pipe" | "ignore",
+  onSpawn?: (child: ReturnType<typeof spawn>) => void
+): Promise<string> {
   return new Promise((resolve, reject) => {
-    const child = spawn(tool.command, tool.args, { stdio: ["ignore", "pipe", "pipe"] });
-    let stdout = "";
-    let stderr = "";
-    child.stdout?.on("data", (chunk) => (stdout += chunk.toString()));
-    child.stderr?.on("data", (chunk) => (stderr += chunk.toString()));
+    const child = spawn(tool.command, tool.args, {
+      stdio: [stdout === "pipe" ? "ignore" : "pipe", stdout, "pipe"]
+    });
+    let out = "";
+    let err = "";
+    child.stdout?.on("data", (chunk) => (out += chunk.toString()));
+    child.stderr?.on("data", (chunk) => (err += chunk.toString()));
     child.on("error", reject);
     child.on("close", (code) => {
       if (code === 0) {
-        resolve(stdout);
+        resolve(out);
         return;
       }
-      reject(new Error(`${tool.command} exited with code ${code}${stderr ? `: ${stderr}` : ""}`));
+      reject(new Error(`${tool.command} exited with code ${code}${err ? `: ${err}` : ""}`));
     });
+    onSpawn?.(child);
   });
 }
 

--- a/packages/cli/src/utils/clipboard.ts
+++ b/packages/cli/src/utils/clipboard.ts
@@ -1,0 +1,109 @@
+import spawn from "cross-spawn";
+
+interface ClipboardTool {
+  command: string;
+  args: string[];
+}
+
+interface ClipboardSupport {
+  write: ClipboardTool;
+  read: ClipboardTool;
+}
+
+export async function detectClipboard(): Promise<ClipboardSupport> {
+  if (process.platform === "darwin") {
+    return {
+      write: { command: "pbcopy", args: [] },
+      read: { command: "pbpaste", args: [] }
+    };
+  }
+
+  if (process.platform === "win32") {
+    return {
+      write: { command: "clip", args: [] },
+      read: {
+        command: "powershell.exe",
+        args: ["-NoProfile", "-Command", "Get-Clipboard"]
+      }
+    };
+  }
+
+  if (process.platform === "linux") {
+    if (await hasCommand("wl-copy")) {
+      return {
+        write: { command: "wl-copy", args: [] },
+        read: { command: "wl-paste", args: ["--no-newline"] }
+      };
+    }
+    if (await hasCommand("xclip")) {
+      return {
+        write: { command: "xclip", args: ["-selection", "clipboard"] },
+        read: { command: "xclip", args: ["-selection", "clipboard", "-o"] }
+      };
+    }
+    if (await hasCommand("xsel")) {
+      return {
+        write: { command: "xsel", args: ["--clipboard", "--input"] },
+        read: { command: "xsel", args: ["--clipboard", "--output"] }
+      };
+    }
+    throw new Error(
+      "no clipboard tool found. Install one of: wl-clipboard (Wayland), xclip, or xsel."
+    );
+  }
+
+  throw new Error(`clipboard not supported on platform ${process.platform}`);
+}
+
+export async function writeClipboard(text: string): Promise<void> {
+  const support = await detectClipboard();
+  await runWithStdin(support.write, text);
+}
+
+export async function readClipboard(): Promise<string> {
+  const support = await detectClipboard();
+  return runCaptureStdout(support.read);
+}
+
+function runWithStdin(tool: ClipboardTool, input: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(tool.command, tool.args, { stdio: ["pipe", "ignore", "pipe"] });
+    let stderr = "";
+    child.stderr?.on("data", (chunk) => (stderr += chunk.toString()));
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(new Error(`${tool.command} exited with code ${code}${stderr ? `: ${stderr}` : ""}`));
+    });
+    child.stdin?.end(input);
+  });
+}
+
+function runCaptureStdout(tool: ClipboardTool): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(tool.command, tool.args, { stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    child.stdout?.on("data", (chunk) => (stdout += chunk.toString()));
+    child.stderr?.on("data", (chunk) => (stderr += chunk.toString()));
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve(stdout);
+        return;
+      }
+      reject(new Error(`${tool.command} exited with code ${code}${stderr ? `: ${stderr}` : ""}`));
+    });
+  });
+}
+
+function hasCommand(command: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const child = spawn("sh", ["-c", `command -v ${command}`], { stdio: "ignore" });
+    child.on("error", () => resolve(false));
+    child.on("close", (code) => resolve(code === 0));
+  });
+}

--- a/packages/cli/test/e2e/cp.test.ts
+++ b/packages/cli/test/e2e/cp.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync, spawnSync } from "node:child_process";
+import { CLI, TSX } from "./helpers/cli.js";
+import { setupAgeFixtureDir, writeEnvKeyshelf, writeKeyshelfConfig } from "./helpers/fixture.js";
+import { setupClipboardStub, type ClipboardStub } from "./helpers/clipboard-stub.js";
+
+async function writeFixture(root: string) {
+  const { identityFile, secretsDir } = await setupAgeFixtureDir(root);
+  await writeKeyshelfConfig(root, [
+    `name: "demo",`,
+    `envs: ["dev"],`,
+    `keys: {`,
+    `  db: {`,
+    `    host: config({ default: "localhost" }),`,
+    `    password: secret({ value: age({ identityFile: ${JSON.stringify(identityFile)}, secretsDir: ${JSON.stringify(secretsDir)} }) }),`,
+    `  },`,
+    `},`
+  ]);
+  await writeEnvKeyshelf(root, ["DB_HOST=db/host", "DB_PASSWORD=db/password"]);
+}
+
+function runCp(root: string, env: NodeJS.ProcessEnv, args: string[]) {
+  return spawnSync(TSX, [CLI, "cp", ...args], { cwd: root, env, encoding: "utf-8" });
+}
+
+const supported = process.platform === "darwin" || process.platform === "linux";
+
+describe.skipIf(!supported)("keyshelf cp", () => {
+  let root: string;
+  let clip: ClipboardStub;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "keyshelf-cp-"));
+    await writeFixture(root);
+    clip = await setupClipboardStub(root);
+  });
+
+  it("copies a resolved secret value to the clipboard", async () => {
+    execFileSync(TSX, [CLI, "set", "--env", "dev", "--value", "stored-pw", "db/password"], {
+      cwd: root,
+      env: clip.env,
+      encoding: "utf-8"
+    });
+
+    const r = runCp(root, clip.env, ["--env", "dev", "--clear", "0", "db/password"]);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toBe("");
+    expect(await clip.read()).toBe("stored-pw");
+  });
+
+  it("copies a resolved config value", async () => {
+    const r = runCp(root, clip.env, ["--clear", "0", "db/host"]);
+    expect(r.status).toBe(0);
+    expect(await clip.read()).toBe("localhost");
+  });
+
+  it("emits confirmation to stderr by default and never the value", async () => {
+    const r = runCp(root, clip.env, ["--clear", "0", "db/host"]);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toBe("");
+    expect(r.stderr).toContain('copied "db/host"');
+    expect(r.stderr).not.toContain("localhost");
+  });
+
+  it("--quiet suppresses confirmation", () => {
+    const r = runCp(root, clip.env, ["--clear", "0", "--quiet", "db/host"]);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toBe("");
+    expect(r.stderr).toBe("");
+  });
+
+  it("rejects unknown key", () => {
+    const r = runCp(root, clip.env, ["--clear", "0", "does/not/exist"]);
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toContain('"does/not/exist" is not defined');
+  });
+
+  it("rejects negative --clear values", () => {
+    const r = runCp(root, clip.env, ["--clear", "-1", "db/host"]);
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toContain("--clear must be a non-negative");
+  });
+});

--- a/packages/cli/test/e2e/helpers/clipboard-stub.ts
+++ b/packages/cli/test/e2e/helpers/clipboard-stub.ts
@@ -1,0 +1,43 @@
+import { chmod, mkdir, writeFile, readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+export interface ClipboardStub {
+  binDir: string;
+  clipboardFile: string;
+  env: NodeJS.ProcessEnv;
+  read(): Promise<string>;
+}
+
+export async function setupClipboardStub(root: string): Promise<ClipboardStub> {
+  const binDir = join(root, "clip-stubs");
+  const clipboardFile = join(root, "clipboard.txt");
+  await mkdir(binDir, { recursive: true });
+
+  const tools =
+    process.platform === "darwin"
+      ? { write: "pbcopy", read: "pbpaste" }
+      : { write: "wl-copy", read: "wl-paste" };
+
+  await writeStub(join(binDir, tools.write), `cat > "$CLIPBOARD_FILE"`);
+  await writeStub(join(binDir, tools.read), `cat "$CLIPBOARD_FILE" 2>/dev/null || true`);
+
+  return {
+    binDir,
+    clipboardFile,
+    env: {
+      ...process.env,
+      PATH: `${binDir}:${process.env.PATH ?? ""}`,
+      CLIPBOARD_FILE: clipboardFile
+    },
+    async read() {
+      if (!existsSync(clipboardFile)) return "";
+      return await readFile(clipboardFile, "utf-8");
+    }
+  };
+}
+
+async function writeStub(path: string, body: string): Promise<void> {
+  await writeFile(path, `#!/bin/sh\n${body}\n`);
+  await chmod(path, 0o755);
+}

--- a/packages/cli/test/unit/cli.test.ts
+++ b/packages/cli/test/unit/cli.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it } from "vitest";
 import { createProgram } from "../../src/index.js";
 
 describe("createProgram", () => {
-  it("registers run, ls, set, import, and up commands", () => {
+  it("registers run, ls, set, import, up, cp, and __cp-clear commands", () => {
     const program = createProgram();
     expect(program.name()).toBe("keyshelf");
     expect(program.commands.map((command) => command.name()).sort()).toEqual([
+      "__cp-clear",
+      "cp",
       "import",
       "ls",
       "run",


### PR DESCRIPTION
## Summary
- New `keyshelf cp <key>` command that resolves a config or secret value through the existing pipeline and copies it to the system clipboard.
- Auto-clears after `--clear <seconds>` (default 60; `0` disables). Clearing is performed by a detached child that re-checks the clipboard via sha256 before wiping, so a value the user has since replaced is left alone. The value is never passed via argv.
- Cross-platform: `pbcopy` (darwin), `wl-copy` / `xclip` / `xsel` (linux, hard-fail with install hint if none found), `clip.exe` (win32). Value is piped via stdin.
- Confirmation goes to stderr (`copied "<key>" from <env> (clears in 60s)`); `--quiet` suppresses it. The value is never echoed.

## Test plan
- [x] `npm test` — 276/276 pass, including new e2e suite (`test/e2e/cp.test.ts`) covering secret copy, config copy, stderr-only confirmation, `--quiet`, unknown key, and `--clear` validation.
- [x] `npm run typecheck` clean.
- [x] Manual: `keyshelf cp --help` and `keyshelf --help` render correctly; hidden `__cp-clear` is registered but not surfaced in help.

🤖 Generated with [Claude Code](https://claude.com/claude-code)