### PR TITLE
feat(config): add plain() / !plain inline provider for secrets

### DIFF
--- a/docs/migrating-from-v4.md
+++ b/docs/migrating-from-v4.md
@@ -11,13 +11,13 @@ If neither applies, you can stop reading here. Run `keyshelf ls --env <env>` aga
 
 ## What changed at runtime
 
-| v4                                                     | v5                                                                                                |
-| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------- |
-| `keyshelf.yaml` + `.keyshelf/<env>.yaml`               | Same files still work, **or** a single `keyshelf.config.ts`                                       |
-| `default-provider:` block per env file                 | YAML form unchanged; TS form binds providers per `secret(...)` record                             |
-| `!secret`, `!age`, `!aws`, `!gcp`, `!sops` YAML tags   | Still valid in YAML; TS uses `secret(...)`, `age(...)`, `aws(...)`, `gcp(...)`, `sops(...)` calls |
-| Plaintext values in env files override schema defaults | YAML form unchanged; TS form expresses the same thing as `values: { <env>: ... }`                 |
-| `name:` introduced in v4.6 to namespace GCP secrets    | `name:` is required (`/^[A-Za-z0-9_-]+$/`) — same rule the v4 loader applied                      |
+| v4                                                     | v5                                                                                                                                                  |
+| ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `keyshelf.yaml` + `.keyshelf/<env>.yaml`               | Same files still work, **or** a single `keyshelf.config.ts`                                                                                         |
+| `default-provider:` block per env file                 | YAML form unchanged; TS form binds providers per `secret(...)` record                                                                               |
+| `!secret`, `!age`, `!aws`, `!gcp`, `!sops` YAML tags   | Still valid in YAML; TS uses `secret(...)`, `age(...)`, `aws(...)`, `gcp(...)`, `sops(...)` calls                                                   |
+| Plaintext values in env files override schema defaults | Plain strings still work for `config` keys; secret keys now require an explicit `!plain "..."` / `plain("...")` tag for inline literals (see below) |
+| `name:` introduced in v4.6 to namespace GCP secrets    | `name:` is required (`/^[A-Za-z0-9_-]+$/`) — same rule the v4 loader applied                                                                        |
 
 ### `keyshelf set`
 
@@ -34,6 +34,35 @@ keyshelf set --env production db/password --value "s3cret"
 ```
 
 If you used `set` to update plaintext config values in v4, edit the YAML file (or `keyshelf.config.ts`) directly in v5.
+
+### Plain-string overrides on `!secret` keys
+
+v4 silently accepted plain-string overrides on secret keys:
+
+```yaml
+# .keyshelf/mirror.yaml — v4-style
+keys:
+  web:
+    client-secret: "" # secretly overrode the !secret with empty plaintext
+```
+
+v5 rejects this at config-load time (`secret keys require a provider tag, got a plain value`) because it erases the type signal. The fix is to tag it explicitly:
+
+```yaml
+keys:
+  web:
+    client-secret: !plain "" # explicit inline literal — visible in review
+```
+
+Or in TypeScript:
+
+```ts
+secret({ values: { mirror: plain("") } });
+```
+
+`plain(...)` is an inline provider — the value lives in the config, not in remote storage. `keyshelf up` ignores it, and `keyshelf set` refuses to write through it (edit the config directly).
+
+The `@keyshelf/migrate` package handles this automatically: plain-string overrides on `!secret` keys are converted to `plain("...")` calls in the emitted v5 config, with a summary line counting the conversions for review.
 
 ### `--env` is optional
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -165,8 +165,8 @@ Same `value` / `default` / `values` semantics as `config`, with the
 following differences:
 
 - All bindings (`value`, `default`, each entry in `values`) **must** be a
-  `ProviderRef` — the result of a provider factory call. Plaintext secrets are
-  not supported.
+  `ProviderRef` — the result of a provider factory call. Use `plain("...")`
+  for inline literal values; plain untagged strings are not accepted.
 - A `secret` must have _some_ binding that can resolve in the active env.
   Concretely: at least one of `value`/`default`, or a matching entry in
   `values`. The validator enforces that `secret(...)` declarations are not
@@ -250,6 +250,29 @@ sops({
   secretsFile: string;    // path to the encrypted JSON document
 })
 ```
+
+### `plain(value)`
+
+```ts
+plain("literal-value"); // TS — value is stored inline in the config
+```
+
+```yaml
+api:
+  token: !plain "literal-value" # YAML — same shape as a provider tag
+```
+
+`plain` is an inline provider — the value lives in the config (TS file or env
+YAML), not in remote storage. Intended for dev stubs, CI envs where a secret
+doesn't apply, or optional secrets that are deliberately blank.
+
+Implications:
+
+- The value is checked into your repo as-is. Don't use `plain(...)` for real
+  secrets — that's what the other providers exist for.
+- `keyshelf set` will not write to a `plain`-bound key; edit the config (or env
+  YAML override) directly.
+- `keyshelf up` ignores `plain` bindings — they have no storage to reconcile.
 
 Phase 4 ports these providers to the new `ProviderContext`; option shapes
 above are pinned.
@@ -481,6 +504,7 @@ skip the var."
 - TS-format `.env.keyshelf`. Stay with the v4 format.
 - Variation axes beyond env (region, tenant, …). The `values` naming was
   chosen to leave the door open, but no implementation work happens in v5.
-- Plaintext secrets. `secret(...)` always requires a `ProviderRef`. If you
-  truly want a plaintext "secret-shaped" value, use `config(...)` and accept
-  that it will be treated as non-sensitive by the tooling.
+- Untagged plaintext for secrets. `secret(...)` always requires a `ProviderRef`.
+  Inline literal values are supported via `plain("...")` / `!plain "..."` —
+  the value lives in the config and is treated as non-sensitive by the tooling
+  (no remote storage, no `keyshelf set` write path).

--- a/packages/action/dist/emit-env.mjs
+++ b/packages/action/dist/emit-env.mjs
@@ -75,11 +75,19 @@ var sopsProviderSchema = z.object({
     secretsFile: z.string().min(1)
   }).strict()
 }).strict();
+var plainProviderSchema = z.object({
+  __kind: z.literal("provider:plain"),
+  name: z.literal("plain"),
+  options: z.object({
+    value: z.string()
+  }).strict()
+}).strict();
 var providerRefSchema = z.discriminatedUnion("__kind", [
   ageProviderSchema,
   awsProviderSchema,
   gcpProviderSchema,
-  sopsProviderSchema
+  sopsProviderSchema,
+  plainProviderSchema
 ]);
 var movedFromSchema = z.union([z.string().min(1), z.array(z.string().min(1)).nonempty()]).optional();
 var baseRecordSchema = {
@@ -2350,10 +2358,15 @@ function gcp(options) {
 function sops(options) {
   return { __kind: "provider:sops", name: "sops", options };
 }
+function plain(value) {
+  return { __kind: "provider:plain", name: "plain", options: { value } };
+}
 
 // ../cli/dist/src/config/yaml-loader.js
 var ENV_DIR = ".keyshelf";
-var PROVIDER_TAGS = ["age", "aws", "gcp", "sops"];
+var PROVIDER_TAGS = ["age", "aws", "gcp", "sops", "plain"];
+var BARE_EMPTY_TAGS = ["secret", "age", "aws", "gcp", "sops"];
+var SCALAR_PAYLOAD_TAGS = ["plain"];
 var ALL_TAGS = ["secret", ...PROVIDER_TAGS];
 function makeMappingTag(name) {
   return new Type(`!${name}`, {
@@ -2371,8 +2384,17 @@ function makeBareTag(name) {
     }
   });
 }
+function makeScalarPayloadTag(name) {
+  return new Type(`!${name}`, {
+    kind: "scalar",
+    construct(data) {
+      return { tag: name, options: { value: data ?? "" } };
+    }
+  });
+}
 var KEYSHELF_SCHEMA = DEFAULT_SCHEMA.extend([
-  ...ALL_TAGS.map(makeBareTag),
+  ...BARE_EMPTY_TAGS.map(makeBareTag),
+  ...SCALAR_PAYLOAD_TAGS.map(makeScalarPayloadTag),
   ...ALL_TAGS.map(makeMappingTag)
 ]);
 function safeYamlLoad(content) {
@@ -2589,6 +2611,8 @@ function providerRef(name, options, label) {
       return sops(
         requireOptions(options, ["identityFile", "secretsFile"], label, "sops")
       );
+    case "plain":
+      return plain(requirePlainValue(options, label));
     default:
       throw new Error(`${label}: unknown provider "${name}"`);
   }
@@ -2600,6 +2624,13 @@ function requireOptions(options, required, label, providerName) {
     }
   }
   return options;
+}
+function requirePlainValue(options, label) {
+  const { value } = options;
+  if (typeof value !== "string") {
+    throw new Error(`${label}: !plain requires a string value (use \`!plain "..."\`)`);
+  }
+  return value;
 }
 
 // ../cli/dist/src/config/loader.js
@@ -3020,7 +3051,7 @@ var ProviderRegistry = class {
 
 // ../cli/dist/src/providers/plaintext.js
 var PlaintextProvider = class {
-  name = "plaintext";
+  name = "plain";
   // Plaintext values live inline in the config tree, not in storage. No
   // listing exists; scope is moot but envless matches the empty-list shape.
   storageScope = "envless";
@@ -11739,8 +11770,8 @@ async function decryptDataKey(encrypted, identity) {
   const decrypter = new Decrypter();
   decrypter.addIdentity(identity);
   const ciphertext = Buffer.from(encrypted, "base64");
-  const plain = await decrypter.decrypt(ciphertext, "uint8array");
-  return Buffer.from(plain);
+  const plain2 = await decrypter.decrypt(ciphertext, "uint8array");
+  return Buffer.from(plain2);
 }
 function encryptValue(dataKey, plaintext) {
   const iv = randomBytes$1(12);

--- a/packages/action/dist/emit-env.mjs
+++ b/packages/action/dist/emit-env.mjs
@@ -2626,7 +2626,7 @@ function requireOptions(options, required, label, providerName) {
   return options;
 }
 function requirePlainValue(options, label) {
-  const { value } = options;
+  const value = options.value;
   if (typeof value !== "string") {
     throw new Error(`${label}: !plain requires a string value (use \`!plain "..."\`)`);
   }

--- a/packages/action/dist/keyshelf-config.mjs
+++ b/packages/action/dist/keyshelf-config.mjs
@@ -20,5 +20,8 @@ function gcp(options) {
 function sops(options) {
   return { __kind: "provider:sops", name: "sops", options };
 }
+function plain(value) {
+  return { __kind: "provider:plain", name: "plain", options: { value } };
+}
 
-export { age, aws, config, defineConfig, gcp, secret, sops };
+export { age, aws, config, defineConfig, gcp, plain, secret, sops };

--- a/packages/action/dist/write-identity.mjs
+++ b/packages/action/dist/write-identity.mjs
@@ -74,11 +74,19 @@ var sopsProviderSchema = z.object({
     secretsFile: z.string().min(1)
   }).strict()
 }).strict();
+var plainProviderSchema = z.object({
+  __kind: z.literal("provider:plain"),
+  name: z.literal("plain"),
+  options: z.object({
+    value: z.string()
+  }).strict()
+}).strict();
 var providerRefSchema = z.discriminatedUnion("__kind", [
   ageProviderSchema,
   awsProviderSchema,
   gcpProviderSchema,
-  sopsProviderSchema
+  sopsProviderSchema,
+  plainProviderSchema
 ]);
 var movedFromSchema = z.union([z.string().min(1), z.array(z.string().min(1)).nonempty()]).optional();
 var baseRecordSchema = {
@@ -2349,10 +2357,15 @@ function gcp(options) {
 function sops(options) {
   return { __kind: "provider:sops", name: "sops", options };
 }
+function plain(value) {
+  return { __kind: "provider:plain", name: "plain", options: { value } };
+}
 
 // ../cli/dist/src/config/yaml-loader.js
 var ENV_DIR = ".keyshelf";
-var PROVIDER_TAGS = ["age", "aws", "gcp", "sops"];
+var PROVIDER_TAGS = ["age", "aws", "gcp", "sops", "plain"];
+var BARE_EMPTY_TAGS = ["secret", "age", "aws", "gcp", "sops"];
+var SCALAR_PAYLOAD_TAGS = ["plain"];
 var ALL_TAGS = ["secret", ...PROVIDER_TAGS];
 function makeMappingTag(name) {
   return new Type(`!${name}`, {
@@ -2370,8 +2383,17 @@ function makeBareTag(name) {
     }
   });
 }
+function makeScalarPayloadTag(name) {
+  return new Type(`!${name}`, {
+    kind: "scalar",
+    construct(data) {
+      return { tag: name, options: { value: data ?? "" } };
+    }
+  });
+}
 var KEYSHELF_SCHEMA = DEFAULT_SCHEMA.extend([
-  ...ALL_TAGS.map(makeBareTag),
+  ...BARE_EMPTY_TAGS.map(makeBareTag),
+  ...SCALAR_PAYLOAD_TAGS.map(makeScalarPayloadTag),
   ...ALL_TAGS.map(makeMappingTag)
 ]);
 function safeYamlLoad(content) {
@@ -2588,6 +2610,8 @@ function providerRef(name, options, label) {
       return sops(
         requireOptions(options, ["identityFile", "secretsFile"], label, "sops")
       );
+    case "plain":
+      return plain(requirePlainValue(options, label));
     default:
       throw new Error(`${label}: unknown provider "${name}"`);
   }
@@ -2599,6 +2623,13 @@ function requireOptions(options, required, label, providerName) {
     }
   }
   return options;
+}
+function requirePlainValue(options, label) {
+  const { value } = options;
+  if (typeof value !== "string") {
+    throw new Error(`${label}: !plain requires a string value (use \`!plain "..."\`)`);
+  }
+  return value;
 }
 
 // ../cli/dist/src/config/loader.js

--- a/packages/action/dist/write-identity.mjs
+++ b/packages/action/dist/write-identity.mjs
@@ -2625,7 +2625,7 @@ function requireOptions(options, required, label, providerName) {
   return options;
 }
 function requirePlainValue(options, label) {
-  const { value } = options;
+  const value = options.value;
   if (typeof value !== "string") {
     throw new Error(`${label}: !plain requires a string value (use \`!plain "..."\`)`);
   }

--- a/packages/cli/src/cli/set.ts
+++ b/packages/cli/src/cli/set.ts
@@ -40,6 +40,13 @@ export const setCommand = new Command("set")
       process.exit(1);
     }
 
+    if (providerRef.name === "plain") {
+      console.error(
+        `error: "${keyPath}" is bound to plain(...) — its value lives inline in the config. Edit ${loaded.configPath} (or the env override) directly instead of using keyshelf set.`
+      );
+      process.exit(1);
+    }
+
     const value = await readValue(keyPath, opts.value);
     const registry = createDefaultRegistry();
 

--- a/packages/cli/src/config/factories.ts
+++ b/packages/cli/src/config/factories.ts
@@ -8,6 +8,7 @@ import type {
   KeyPaths,
   KeyshelfConfig,
   KeyTree,
+  PlainProviderOptions,
   ProviderRef,
   SecretRecordInput,
   SopsProviderOptions
@@ -60,6 +61,12 @@ export function sops<const Options extends SopsProviderOptions>(
   options: Options
 ): ProviderRef<"sops", Options> {
   return { __kind: "provider:sops", name: "sops", options };
+}
+
+export function plain<const V extends string>(
+  value: V
+): ProviderRef<"plain", PlainProviderOptions & { value: V }> {
+  return { __kind: "provider:plain", name: "plain", options: { value } };
 }
 
 export type { BuiltinProviderRef };

--- a/packages/cli/src/config/index.ts
+++ b/packages/cli/src/config/index.ts
@@ -1,4 +1,4 @@
-export { defineConfig, config, secret, age, aws, gcp, sops } from "./factories.js";
+export { defineConfig, config, secret, age, aws, gcp, sops, plain } from "./factories.js";
 export { findRootDir, loadConfig, type LoadedConfig, type LoadConfigOptions } from "./loader.js";
 export {
   isProviderRef,
@@ -22,6 +22,7 @@ export type {
   KeyTree,
   NormalizedConfig,
   NormalizedRecord,
+  PlainProviderOptions,
   ProviderRef,
   SecretRecord,
   SecretRecordInput,

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -68,11 +68,24 @@ const sopsProviderSchema = z
   })
   .strict();
 
+const plainProviderSchema = z
+  .object({
+    __kind: z.literal("provider:plain"),
+    name: z.literal("plain"),
+    options: z
+      .object({
+        value: z.string()
+      })
+      .strict()
+  })
+  .strict();
+
 const providerRefSchema = z.discriminatedUnion("__kind", [
   ageProviderSchema,
   awsProviderSchema,
   gcpProviderSchema,
-  sopsProviderSchema
+  sopsProviderSchema,
+  plainProviderSchema
 ]);
 
 const movedFromSchema = z

--- a/packages/cli/src/config/types.ts
+++ b/packages/cli/src/config/types.ts
@@ -26,11 +26,16 @@ export interface SopsProviderOptions {
   secretsFile: string;
 }
 
+export interface PlainProviderOptions {
+  value: string;
+}
+
 export type BuiltinProviderRef =
   | ProviderRef<"age", AgeProviderOptions>
   | ProviderRef<"aws", AwsProviderOptions>
   | ProviderRef<"gcp", GcpProviderOptions>
-  | ProviderRef<"sops", SopsProviderOptions>;
+  | ProviderRef<"sops", SopsProviderOptions>
+  | ProviderRef<"plain", PlainProviderOptions>;
 
 export interface BaseRecord<GroupName extends string = string> {
   group?: GroupName;

--- a/packages/cli/src/config/yaml-loader.ts
+++ b/packages/cli/src/config/yaml-loader.ts
@@ -2,7 +2,7 @@ import { existsSync } from "node:fs";
 import { readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { DEFAULT_SCHEMA, load as loadYaml, Type as YamlType } from "js-yaml";
-import { age, aws, config as configRecord, gcp, secret, sops } from "./factories.js";
+import { age, aws, config as configRecord, gcp, plain, secret, sops } from "./factories.js";
 import type {
   AgeProviderOptions,
   AwsProviderOptions,
@@ -12,6 +12,7 @@ import type {
   GcpProviderOptions,
   KeyshelfConfig,
   KeyTree,
+  PlainProviderOptions,
   SecretRecord,
   SopsProviderOptions
 } from "./types.js";
@@ -49,7 +50,9 @@ interface EnvFile {
   overrides: Record<string, ConfigBinding | TaggedValue>;
 }
 
-const PROVIDER_TAGS = ["age", "aws", "gcp", "sops"] as const;
+const PROVIDER_TAGS = ["age", "aws", "gcp", "sops", "plain"] as const;
+const BARE_EMPTY_TAGS = ["secret", "age", "aws", "gcp", "sops"] as const;
+const SCALAR_PAYLOAD_TAGS = ["plain"] as const;
 const ALL_TAGS = ["secret", ...PROVIDER_TAGS] as const;
 
 function makeMappingTag(name: string): YamlType {
@@ -70,11 +73,21 @@ function makeBareTag(name: string): YamlType {
   });
 }
 
+function makeScalarPayloadTag(name: string): YamlType {
+  return new YamlType(`!${name}`, {
+    kind: "scalar",
+    construct(data: string | null): TaggedValue {
+      return { tag: name, options: { value: data ?? "" } };
+    }
+  });
+}
+
 // js-yaml v4 has no unsafe loader — `load` always uses the schema we pass.
 // We extend DEFAULT_SCHEMA only with our own keyshelf tags, so no `!!js/*`
 // constructors are reachable from user content.
 const KEYSHELF_SCHEMA = DEFAULT_SCHEMA.extend([
-  ...ALL_TAGS.map(makeBareTag),
+  ...BARE_EMPTY_TAGS.map(makeBareTag),
+  ...SCALAR_PAYLOAD_TAGS.map(makeScalarPayloadTag),
   ...ALL_TAGS.map(makeMappingTag)
 ]);
 
@@ -362,6 +375,8 @@ function providerRef(
       return sops(
         requireOptions<SopsProviderOptions>(options, ["identityFile", "secretsFile"], label, "sops")
       );
+    case "plain":
+      return plain(requirePlainValue(options, label));
     default:
       throw new Error(`${label}: unknown provider "${name}"`);
   }
@@ -379,4 +394,12 @@ function requireOptions<T>(
     }
   }
   return options as T;
+}
+
+function requirePlainValue(options: Record<string, unknown>, label: string): string {
+  const { value } = options as PlainProviderOptions;
+  if (typeof value !== "string") {
+    throw new Error(`${label}: !plain requires a string value (use \`!plain "..."\`)`);
+  }
+  return value;
 }

--- a/packages/cli/src/config/yaml-loader.ts
+++ b/packages/cli/src/config/yaml-loader.ts
@@ -12,7 +12,6 @@ import type {
   GcpProviderOptions,
   KeyshelfConfig,
   KeyTree,
-  PlainProviderOptions,
   SecretRecord,
   SopsProviderOptions
 } from "./types.js";
@@ -397,7 +396,7 @@ function requireOptions<T>(
 }
 
 function requirePlainValue(options: Record<string, unknown>, label: string): string {
-  const { value } = options as PlainProviderOptions;
+  const value = options.value;
   if (typeof value !== "string") {
     throw new Error(`${label}: !plain requires a string value (use \`!plain "..."\`)`);
   }

--- a/packages/cli/src/providers/plaintext.ts
+++ b/packages/cli/src/providers/plaintext.ts
@@ -1,7 +1,7 @@
 import type { Provider, ProviderContext, StorageScope, StoredKey } from "./types.js";
 
 export class PlaintextProvider implements Provider {
-  name = "plaintext";
+  name = "plain";
   // Plaintext values live inline in the config tree, not in storage. No
   // listing exists; scope is moot but envless matches the empty-list shape.
   storageScope: StorageScope = "envless";

--- a/packages/cli/src/reconcile/internal/desired-bindings.ts
+++ b/packages/cli/src/reconcile/internal/desired-bindings.ts
@@ -15,6 +15,13 @@ export function collectDesiredBindings(config: NormalizedConfig): DesiredBinding
   return collector.bindings;
 }
 
+// `plain` is an inline provider — its value lives in the config, not in remote
+// storage. Reconcile has nothing to plan or apply for it, so it's excluded from
+// both desired-binding collection and provider listings.
+export function isReconcilableProvider(name: string): boolean {
+  return name !== "plain";
+}
+
 export function collectProviderRefs(record: NormalizedRecord): BuiltinProviderRef[] {
   if (record.kind !== "secret") return [];
   const refs: BuiltinProviderRef[] = [];
@@ -47,6 +54,7 @@ class BindingsCollector {
     envless: BuiltinProviderRef,
     perEnv: Record<string, BuiltinProviderRef>
   ): void {
+    if (!isReconcilableProvider(envless.name)) return;
     const overridden = new Map<string, true>();
     for (const env of Object.keys(perEnv)) overridden.set(env, true);
     for (const env of this.envs) {
@@ -62,6 +70,7 @@ class BindingsCollector {
 
   private absorbPerEnv(keyPath: string, perEnv: Record<string, BuiltinProviderRef>): void {
     for (const [envName, ref] of Object.entries(perEnv)) {
+      if (!isReconcilableProvider(ref.name)) continue;
       this.bindings.push({
         keyPath,
         envName,

--- a/packages/cli/src/reconcile/listings.ts
+++ b/packages/cli/src/reconcile/listings.ts
@@ -1,6 +1,6 @@
 import type { BuiltinProviderRef, NormalizedConfig } from "../config/types.js";
 import type { ProviderRegistry } from "../providers/registry.js";
-import { collectProviderRefs } from "./internal/desired-bindings.js";
+import { collectProviderRefs, isReconcilableProvider } from "./internal/desired-bindings.js";
 import { instanceKey } from "./internal/instance-key.js";
 import type { ProviderListing } from "./planner.js";
 
@@ -88,6 +88,7 @@ function collectProviderInstances(config: NormalizedConfig): Map<string, Builtin
   const out = new Map<string, BuiltinProviderRef>();
   for (const record of config.keys) {
     for (const ref of collectProviderRefs(record)) {
+      if (!isReconcilableProvider(ref.name)) continue;
       out.set(instanceKey(ref.name, ref.options), ref);
     }
   }

--- a/packages/cli/test/e2e/helpers/fixture.ts
+++ b/packages/cli/test/e2e/helpers/fixture.ts
@@ -19,7 +19,7 @@ export async function writeKeyshelfConfig(root: string, body: string[]): Promise
   await writeFile(
     join(root, "keyshelf.config.ts"),
     [
-      `import { defineConfig, config, secret, age } from "keyshelf/config";`,
+      `import { defineConfig, config, secret, age, plain } from "keyshelf/config";`,
       ``,
       `export default defineConfig({`,
       ...body.map((line) => `  ${line}`),

--- a/packages/cli/test/e2e/set.test.ts
+++ b/packages/cli/test/e2e/set.test.ts
@@ -130,4 +130,29 @@ describe("keyshelf-next set", () => {
     );
     expect(out).not.toContain("hint:");
   });
+
+  it("refuses to set a plain()-bound key (value is inline in the config)", async () => {
+    await writeKeyshelfConfig(root, [
+      `name: "demo",`,
+      `envs: ["dev"],`,
+      `keys: {`,
+      `  web: {`,
+      `    "client-secret": secret({ value: plain("stub") }),`,
+      `  },`,
+      `},`
+    ]);
+    await writeEnvKeyshelf(root, ["WEB_CLIENT_SECRET=web/client-secret"]);
+    try {
+      execFileSync(TSX, [CLI, "set", "--env", "dev", "--value", "x", "web/client-secret"], {
+        cwd: root,
+        encoding: "utf-8",
+        stdio: "pipe"
+      });
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect((err as { stderr: string }).stderr).toContain(
+        "bound to plain(...) — its value lives inline in the config"
+      );
+    }
+  });
 });

--- a/packages/cli/test/integration/providers.test.ts
+++ b/packages/cli/test/integration/providers.test.ts
@@ -1,14 +1,16 @@
 import { describe, expect, it, vi } from "vitest";
-import { mkdtemp, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { SecretManagerServiceClient } from "@google-cloud/secret-manager";
-import { age, config, defineConfig, secret, gcp } from "../../src/config/index.js";
+import { age, config, defineConfig, plain, secret, gcp } from "../../src/config/index.js";
 import { normalizeConfig } from "../../src/config/index.js";
+import { loadYamlConfig } from "../../src/config/yaml-loader.js";
 import { resolve as resolveResult } from "../../src/resolver/index.js";
 import { ProviderRegistry } from "../../src/providers/registry.js";
 import { AgeProvider, generateIdentity } from "../../src/providers/age.js";
 import { GcpSmProvider } from "../../src/providers/gcp-sm.js";
+import { PlaintextProvider } from "../../src/providers/plaintext.js";
 
 async function ageFixture() {
   const dir = await mkdtemp(join(tmpdir(), "keyshelf-age-"));
@@ -140,5 +142,69 @@ describe("resolver → providers", () => {
     expect(accessSecretVersion).toHaveBeenCalledWith({
       name: "projects/my-gcp-proj/secrets/keyshelf__myapp__github__token/versions/latest"
     });
+  });
+
+  it("resolves a TS plain() secret through the registered plain provider", async () => {
+    const registry = new ProviderRegistry();
+    registry.register(new PlaintextProvider());
+
+    const normalized = normalizeConfig(
+      defineConfig({
+        name: "myapp",
+        envs: ["dev", "mirror"],
+        keys: {
+          web: {
+            "client-secret": secret({
+              values: {
+                dev: plain("dev-stub"),
+                mirror: plain("")
+              }
+            })
+          }
+        }
+      })
+    );
+
+    const dev = await resolveResult({
+      config: normalized,
+      rootDir: "/repo",
+      envName: "dev",
+      registry
+    });
+    const mirror = await resolveResult({
+      config: normalized,
+      rootDir: "/repo",
+      envName: "mirror",
+      registry
+    });
+
+    expect(dev).toEqual([{ path: "web/client-secret", value: "dev-stub" }]);
+    expect(mirror).toEqual([{ path: "web/client-secret", value: "" }]);
+  });
+
+  it("resolves a YAML !plain secret through the registered plain provider", async () => {
+    const root = await mkdtemp(join(tmpdir(), "keyshelf-plain-yaml-"));
+    await mkdir(join(root, ".keyshelf"));
+    await writeFile(
+      join(root, "keyshelf.yaml"),
+      ["name: app", "keys:", "  web:", "    client-secret: !secret"].join("\n")
+    );
+    await writeFile(
+      join(root, ".keyshelf/dev.yaml"),
+      ["keys:", "  web:", '    client-secret: !plain "yaml-stub"'].join("\n")
+    );
+
+    const registry = new ProviderRegistry();
+    registry.register(new PlaintextProvider());
+
+    const normalized = normalizeConfig(await loadYamlConfig(join(root, "keyshelf.yaml")));
+    const resolved = await resolveResult({
+      config: normalized,
+      rootDir: root,
+      envName: "dev",
+      registry
+    });
+
+    expect(resolved).toEqual([{ path: "web/client-secret", value: "yaml-stub" }]);
   });
 });

--- a/packages/cli/test/unit/reconcile/planner.test.ts
+++ b/packages/cli/test/unit/reconcile/planner.test.ts
@@ -5,6 +5,7 @@ import {
   defineConfig,
   gcp,
   normalizeConfig,
+  plain,
   secret
 } from "../../../src/config/index.js";
 import { planReconciliation } from "../../../src/reconcile/planner.js";
@@ -350,5 +351,30 @@ describe("planReconciliation", () => {
     );
 
     expect(planReconciliation(cfg, [])).toEqual([]);
+  });
+
+  it("ignores plain() bindings — they have no remote storage to reconcile", () => {
+    const cfg = normalizeConfig(
+      defineConfig({
+        name: "test",
+        envs: ["dev", "mirror"],
+        keys: {
+          token: secret({
+            values: {
+              dev: age(ageOpts),
+              mirror: plain("")
+            }
+          })
+        }
+      })
+    );
+
+    const plan = planReconciliation(cfg, [ageListing([{ keyPath: "token" }])]);
+
+    // Only the age binding shows up; the plain mirror binding is invisible to the planner.
+    // age's storageScope is envless, so envName collapses to undefined.
+    expect(plan).toEqual([
+      { kind: "noop", keyPath: "token", envName: undefined, providerName: "age" }
+    ]);
   });
 });

--- a/packages/cli/test/unit/yaml-loader.test.ts
+++ b/packages/cli/test/unit/yaml-loader.test.ts
@@ -100,6 +100,55 @@ describe("yaml-loader", () => {
     );
   });
 
+  it("accepts a !plain override on a !secret key", async () => {
+    const root = await writeProject({
+      "keyshelf.yaml": ["name: app", "keys:", "  api:", "    token: !secret"].join("\n"),
+      ".keyshelf/dev.yaml": ["keys:", "  api:", '    token: !plain "stub"'].join("\n")
+    });
+
+    const config = normalizeConfig(await loadYamlConfig(join(root, "keyshelf.yaml")));
+    const token = config.keys.find((k) => k.path === "api/token");
+    expect(token).toMatchObject({
+      kind: "secret",
+      values: {
+        dev: { __kind: "provider:plain", name: "plain", options: { value: "stub" } }
+      }
+    });
+  });
+
+  it("accepts an empty !plain override (the v4 empty-string case)", async () => {
+    const root = await writeProject({
+      "keyshelf.yaml": ["name: app", "keys:", "  api:", "    token: !secret"].join("\n"),
+      ".keyshelf/mirror.yaml": ["keys:", "  api:", '    token: !plain ""'].join("\n")
+    });
+
+    const config = normalizeConfig(await loadYamlConfig(join(root, "keyshelf.yaml")));
+    const token = config.keys.find((k) => k.path === "api/token");
+    expect(token).toMatchObject({
+      values: { mirror: { __kind: "provider:plain", options: { value: "" } } }
+    });
+  });
+
+  it("accepts the mapping form of !plain", async () => {
+    const root = await writeProject({
+      "keyshelf.yaml": ["name: app", "keys:", "  api:", "    token: !secret"].join("\n"),
+      ".keyshelf/dev.yaml": [
+        "keys:",
+        "  api:",
+        "    token: !plain",
+        '      value: "from-mapping"'
+      ].join("\n")
+    });
+
+    const config = normalizeConfig(await loadYamlConfig(join(root, "keyshelf.yaml")));
+    const token = config.keys.find((k) => k.path === "api/token");
+    expect(token).toMatchObject({
+      values: {
+        dev: { __kind: "provider:plain", options: { value: "from-mapping" } }
+      }
+    });
+  });
+
   it("parses bare !aws (relies on SDK region chain)", async () => {
     const root = await writeProject({
       "keyshelf.yaml": ["name: app", "keys:", "  api:", "    token: !secret"].join("\n"),

--- a/packages/migrate/src/cli.ts
+++ b/packages/migrate/src/cli.ts
@@ -104,22 +104,18 @@ async function migrateProvider(
   migration: NormalizedMigration,
   options: ProjectNameOptions
 ): Promise<void> {
-  switch (provider) {
-    case "age":
-    case "sops":
-    case "plain":
-      process.stderr.write(
-        `${provider}: no-op (secrets stay co-located with the project; no remote namespacing required).\n`
-      );
-      return;
-    case "gcp":
-      await runGcpMigration(migration, options);
-      return;
-    default: {
-      const exhaustive: never = provider;
-      throw new Error(`Unsupported provider for project-name migration: ${String(exhaustive)}`);
-    }
+  if (provider === "gcp") {
+    await runGcpMigration(migration, options);
+    return;
   }
+  // Local-storage providers — project-name namespacing only matters for
+  // remote stores. The annotation keeps this exhaustive: TS errors if a
+  // new provider name lands in the union without being routed above.
+  const _localStorageProvider: "age" | "sops" | "plain" = provider;
+  void _localStorageProvider;
+  process.stderr.write(
+    `${provider}: no-op (secrets stay co-located with the project; no remote namespacing required).\n`
+  );
 }
 
 async function runGcpMigration(

--- a/packages/migrate/src/cli.ts
+++ b/packages/migrate/src/cli.ts
@@ -107,6 +107,7 @@ async function migrateProvider(
   switch (provider) {
     case "age":
     case "sops":
+    case "plain":
       process.stderr.write(
         `${provider}: no-op (secrets stay co-located with the project; no remote namespacing required).\n`
       );

--- a/packages/migrate/src/emit.ts
+++ b/packages/migrate/src/emit.ts
@@ -100,6 +100,9 @@ function objectLiteral(value: Record<string, unknown>, indent: number): string {
 
 function valueLiteral(value: unknown, indent: number): string {
   if (isProviderRef(value)) {
+    if (value.name === "plain") {
+      return `plain(${literal(String(value.options.value ?? ""))})`;
+    }
     return `${value.name}(${objectLiteral(value.options, indent)})`;
   }
   if (Array.isArray(value)) {

--- a/packages/migrate/src/normalize.ts
+++ b/packages/migrate/src/normalize.ts
@@ -11,7 +11,7 @@ import {
 export type ConfigScalar = string | number | boolean;
 
 export interface ProviderRef {
-  name: "age" | "gcp" | "sops";
+  name: "age" | "gcp" | "sops" | "plain";
   options: Record<string, unknown>;
 }
 
@@ -40,7 +40,7 @@ export interface NormalizedMigration {
 }
 
 const V5_PATH_SEGMENT_RE = /^[A-Za-z_][A-Za-z0-9_-]*$/;
-const SUPPORTED_PROVIDERS = new Set(["age", "gcp", "sops"]);
+const SUPPORTED_PROVIDERS = new Set(["age", "gcp", "sops", "plain"]);
 
 export function normalizeProject(project: V4Project): NormalizedMigration {
   if (project.name === undefined) {
@@ -94,9 +94,7 @@ function normalizeConfig(key: KeyDefinition, envs: V4Environment[]): NormalizedR
 function pickSecretProvider(env: V4Environment, keyPath: string): ProviderRef | undefined {
   const override = env.env.overrides[keyPath];
   if (override !== undefined && !isTaggedValue(override)) {
-    throw new Error(
-      `${env.name}:${keyPath} has a plaintext secret override. v5 secret records require provider bindings; move the value into a provider with keyshelf set before migrating.`
-    );
+    return { name: "plain", options: { value: String(override) } };
   }
   if (override !== undefined) {
     return providerFromTag(override, env);

--- a/packages/migrate/src/report.ts
+++ b/packages/migrate/src/report.ts
@@ -20,6 +20,12 @@ export function buildReport(migration: NormalizedMigration): string {
   lines.push("Review:");
   lines.push("  - groups: [] is a placeholder; add v5 groups manually if you use group filters.");
   lines.push("  - Secret values are not copied by this config migration.");
+  const plainCount = countPlainConversions(migration.keys);
+  if (plainCount > 0) {
+    lines.push(
+      `  - ${plainCount} plain-string secret override(s) were converted to plain("..."). Review for sensitive material.`
+    );
+  }
   lines.push(mappingReview(migration.appMapping));
 
   return `${lines.join("\n")}\n`;
@@ -32,10 +38,23 @@ function buildRebindCommands(records: NormalizedRecord[], envs: string[]): strin
     for (const env of envs) {
       const provider = record.values?.[env] ?? record.default;
       if (provider === undefined) continue;
+      if (provider.name === "plain") continue;
       commands.push(commandFor(record.path, env, provider));
     }
   }
   return commands;
+}
+
+function countPlainConversions(records: NormalizedRecord[]): number {
+  let count = 0;
+  for (const record of records) {
+    if (record.kind !== "secret") continue;
+    if (record.default?.name === "plain") count += 1;
+    for (const value of Object.values(record.values ?? {})) {
+      if (value.name === "plain") count += 1;
+    }
+  }
+  return count;
 }
 
 function commandFor(path: string, env: string, provider: ProviderRef): string {

--- a/packages/migrate/test/fixtures/plain-overrides/.keyshelf/dev.yaml
+++ b/packages/migrate/test/fixtures/plain-overrides/.keyshelf/dev.yaml
@@ -1,0 +1,3 @@
+keys:
+  web:
+    client-secret: "dev-stub"

--- a/packages/migrate/test/fixtures/plain-overrides/.keyshelf/mirror.yaml
+++ b/packages/migrate/test/fixtures/plain-overrides/.keyshelf/mirror.yaml
@@ -1,0 +1,3 @@
+keys:
+  web:
+    client-secret: ""

--- a/packages/migrate/test/fixtures/plain-overrides/keyshelf.yaml
+++ b/packages/migrate/test/fixtures/plain-overrides/keyshelf.yaml
@@ -1,0 +1,4 @@
+name: demo-app
+keys:
+  web:
+    client-secret: !secret

--- a/packages/migrate/test/normalize.test.ts
+++ b/packages/migrate/test/normalize.test.ts
@@ -87,4 +87,17 @@ describe("normalizeProject", () => {
     const project = await loadV4Project(fixturePath("name-rename"));
     expect(normalizeProject(project)).toMatchObject({ name: "My_Project" });
   });
+
+  it("converts plain-string overrides on !secret keys into plain providers", async () => {
+    const migration = await loadFixture("plain-overrides");
+    expect(migration.keys).toContainEqual({
+      path: "web/client-secret",
+      kind: "secret",
+      optional: false,
+      values: {
+        dev: { name: "plain", options: { value: "dev-stub" } },
+        mirror: { name: "plain", options: { value: "" } }
+      }
+    });
+  });
 });

--- a/packages/migrate/test/round-trip.test.ts
+++ b/packages/migrate/test/round-trip.test.ts
@@ -18,7 +18,7 @@ describe("round-trip through the keyshelf loader", () => {
     roots.length = 0;
   });
 
-  it.each(["basic", "multi-env", "optional", "nested", "name-rename"])(
+  it.each(["basic", "multi-env", "optional", "nested", "name-rename", "plain-overrides"])(
     "loads emitted %s config",
     async (fixture) => {
       const migration = await loadFixture(fixture);


### PR DESCRIPTION
## Summary

- New `plain("value")` factory (TS) and `!plain "value"` YAML tag for binding secret keys to inline literal values — useful for dev stubs, CI envs where a secret doesn't apply, or optional secrets that are intentionally blank.
- Migrator now converts v4 plain-string overrides on `!secret` keys into `plain("...")` calls instead of failing; report counts conversions so sensitive material gets a review prompt.
- Fixes a silent-no-op in `keyshelf set` when the target key is bound to `plain()` (was reachable for the first time via this PR).

## Why

v5 rejects untagged plain-string overrides on `!secret` keys with `secret keys require a provider tag, got a plain value`. The strictness is correct — silent collapse of a `!secret` to plaintext erases the type signal — but it left no escape valve. `plain()` / `!plain` is the explicit opt-in: the literal value is *visible* in the config, greppable in review, and treated as non-sensitive by the tooling (no remote storage, no `keyshelf set` write path, ignored by `keyshelf up`).

## Scope notes

A `keyshelf set --plain` flag was originally planned but deferred: writing a literal into the config requires comment-preserving YAML or TS AST round-tripping, which is a separate capability. Instead, the silent-no-op bug (`set` on a `plain()`-bound key looked successful but wrote nothing) is now a hard error pointing the user to the right file.

The action package tests fail in this branch due to a pre-existing stale `dist/` symlink in the main worktree (unrelated to these changes); cli and migrate tests are green (283 and 32 respectively).

## Test plan

- [ ] `npm test -w packages/cli` passes (283 tests, including 3 new YAML `!plain` parse cases, 2 new TS+YAML end-to-end resolver cases, 1 new planner skip case, 1 new e2e set-rejection case)
- [ ] `npm test -w packages/migrate` passes (32 tests, including 1 new normalize case and the round-trip via the `plain-overrides` fixture)
- [ ] `npm run lint` clean
- [ ] Manual smoke: drop `!plain "stub"` into a `.keyshelf/<env>.yaml` and confirm `keyshelf run` resolves it
- [ ] Manual smoke: run the migrator against a v4 project with an empty-string secret override and confirm the emitted `keyshelf.config.ts` uses `plain("")`

🤖 Generated with [Claude Code](https://claude.com/claude-code)