### PR TITLE
fix(release): keep package-lock.json workspace versions in sync

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6604,7 +6604,7 @@
     },
     "packages/action": {
       "name": "@keyshelf/action",
-      "version": "1.0.0",
+      "version": "1.2.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.5.0",
@@ -6619,7 +6619,7 @@
     },
     "packages/cli": {
       "name": "keyshelf",
-      "version": "5.0.0",
+      "version": "5.2.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "^3.1043.0",
@@ -6649,7 +6649,7 @@
     },
     "packages/migrate": {
       "name": "@keyshelf/migrate",
-      "version": "1.0.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/secret-manager": "^6.1.1",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,7 @@
   "release-type": "node",
   "include-component-in-tag": true,
   "separate-pull-requests": true,
+  "plugins": ["node-workspace"],
   "packages": {
     "packages/cli": {
       "package-name": "keyshelf"


### PR DESCRIPTION
## Why

release-please bumps each `package.json` on release but never touches the root `package-lock.json`, so the lockfile's `packages/*` workspace entries drift behind — they were still at `5.0.0`/`1.0.0` while the packages are at `5.2.0`/`1.2.0`. Any local `npm install` then produces an uncommitted lockfile diff.

## What

- Sync the lockfile workspace entries to the current versions (`npm install --package-lock-only`).
- Enable the [`node-workspace` plugin](https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md#plugins) in `release-please-config.json` — its `postProcessCandidates` adds a root `package-lock.json` update to release PRs (added in release-please 16.1.0, googleapis/release-please#2088), which the action at `@v4` already includes.

## Behavior change to be aware of

With `separate-pull-requests: true` the plugin keeps PRs separate (`merge` defaults to `!separatePullRequests`), but it also pulls **dependents** of a released package into the release: a `keyshelf` (cli) release will now also create patch-bump release PRs for `@keyshelf/action` and `@keyshelf/migrate`, since both depend on it via `file:../cli`. Given the action bundles the cli into its committed `dist`, that cascade is arguably what we want — but drop the plugin if not.

The `file:` dependency specs themselves are never rewritten (the updater skips `protocol:` specs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)