### PR TITLE
fix(run): single resolution pass — stop resolving every secret twice

### DIFF
--- a/packages/action/dist/emit-env.mjs
+++ b/packages/action/dist/emit-env.mjs
@@ -2731,28 +2731,37 @@ function formatSkipCause(cause) {
 var TEMPLATE_RE3 = /(?<!\$)\$\{([^}]+)\}/g;
 var ESCAPED_TEMPLATE_RE = /\$\$\{/g;
 async function validate(options) {
+  const { topLevelErrors, keyErrors } = await resolveValidated(options);
+  return { topLevelErrors, keyErrors };
+}
+async function resolveValidated(options) {
+  const topLevelErrors = checkTopLevel(options);
+  if (topLevelErrors.length > 0) {
+    return { topLevelErrors, keyErrors: [] };
+  }
+  const resolution = await resolveWithStatus(options);
+  return { topLevelErrors: [], keyErrors: validateResolution(resolution), resolution };
+}
+function checkTopLevel(options) {
   const topLevelErrors = [];
   const envError = checkValidEnv(options);
   if (envError !== void 0) topLevelErrors.push(envError);
   const groupCheck = checkGroupFilter(options.config, options.groups);
   topLevelErrors.push(...groupCheck.errors);
-  if (topLevelErrors.length > 0) {
-    return { topLevelErrors, keyErrors: [] };
-  }
+  if (topLevelErrors.length > 0) return topLevelErrors;
   const selected = selectRecords(options.config, options.groups, options.filters);
   const envRequiredError = checkEnvProvidedWhenRequired(selected, options.envName);
-  if (envRequiredError !== void 0) {
-    return { topLevelErrors: [envRequiredError], keyErrors: [] };
-  }
-  const resolution = await resolveWithStatus(options);
-  const keyErrors = resolution.statuses.filter((status) => {
+  if (envRequiredError !== void 0) return [envRequiredError];
+  return [];
+}
+function validateResolution(resolution) {
+  return resolution.statuses.filter((status) => {
     return status.status === "error";
   }).map((status) => ({
     path: status.path,
     message: status.message,
     error: status.error
   }));
-  return { topLevelErrors: [], keyErrors };
 }
 async function resolveWithStatus(options) {
   assertValidEnv(options);

--- a/packages/cli/src/cli/cp.ts
+++ b/packages/cli/src/cli/cp.ts
@@ -2,7 +2,6 @@ import { createHash } from "node:crypto";
 import spawn from "cross-spawn";
 import { Command } from "commander";
 import { loadConfig } from "../config/index.js";
-import { resolveWithStatus } from "../resolver/index.js";
 import { createDefaultRegistry } from "../providers/setup.js";
 import { assertValidationPasses } from "./validation.js";
 import { findRecordOrExit } from "./options.js";
@@ -40,8 +39,7 @@ export const cpCommand = new Command("cp")
       filters: [keyPath]
     };
 
-    await assertValidationPasses(resolveOpts);
-    const resolution = await resolveWithStatus(resolveOpts);
+    const resolution = await assertValidationPasses(resolveOpts);
     const status = resolution.statusByPath.get(keyPath);
 
     if (status === undefined || status.status !== "resolved") {

--- a/packages/cli/src/cli/ls.ts
+++ b/packages/cli/src/cli/ls.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
 import { loadConfig } from "../config/index.js";
-import { formatSkipCause, renderAppMapping, resolveWithStatus } from "../resolver/index.js";
+import { formatSkipCause, renderAppMapping } from "../resolver/index.js";
 import { createDefaultRegistry } from "../providers/setup.js";
 import { splitList } from "./options.js";
 import { assertValidationPasses } from "./validation.js";
@@ -95,8 +95,7 @@ async function runReveal({ loaded, env, groups, filters, format }: RevealArgs): 
     filters
   };
 
-  await assertValidationPasses(resolveOpts);
-  const resolution = await resolveWithStatus(resolveOpts);
+  const resolution = await assertValidationPasses(resolveOpts);
 
   if (format === "json") {
     const vars = buildJsonVars(loaded.appMapping, loaded.config.keys, resolution);

--- a/packages/cli/src/cli/run.ts
+++ b/packages/cli/src/cli/run.ts
@@ -1,7 +1,7 @@
 import { Command } from "commander";
 import spawn from "cross-spawn";
 import { loadConfig } from "../config/index.js";
-import { formatSkipCause, renderAppMapping, resolveWithStatus } from "../resolver/index.js";
+import { formatSkipCause, renderAppMapping } from "../resolver/index.js";
 import { createDefaultRegistry } from "../providers/setup.js";
 import { splitList } from "./options.js";
 import { assertValidationPasses } from "./validation.js";
@@ -43,9 +43,7 @@ export const runCommand = new Command("run")
       filters: splitList(opts.filter)
     };
 
-    await assertValidationPasses(resolveOpts);
-
-    const resolution = await resolveWithStatus(resolveOpts);
+    const resolution = await assertValidationPasses(resolveOpts);
     const rendered = renderAppMapping(loaded.appMapping, resolution);
 
     const envVars: Record<string, string> = {};

--- a/packages/cli/src/cli/validation.ts
+++ b/packages/cli/src/cli/validation.ts
@@ -1,16 +1,29 @@
-import { validate } from "../resolver/index.js";
+import { resolveValidated } from "../resolver/index.js";
+import type { Resolution } from "../resolver/types.js";
 
+// Resolves every selected key exactly once, exits the process on any
+// validation error, and returns the single Resolution for callers to render
+// from — avoiding a second resolution pass.
 export async function assertValidationPasses(
-  resolveOpts: Parameters<typeof validate>[0]
-): Promise<void> {
-  const validation = await validate(resolveOpts);
-  if (validation.topLevelErrors.length > 0) {
-    for (const err of validation.topLevelErrors) console.error(`error: ${err.message}`);
+  resolveOpts: Parameters<typeof resolveValidated>[0]
+): Promise<Resolution> {
+  const { topLevelErrors, keyErrors, resolution } = await resolveValidated(resolveOpts);
+
+  if (topLevelErrors.length > 0) {
+    for (const err of topLevelErrors) console.error(`error: ${err.message}`);
     process.exit(1);
   }
-  if (validation.keyErrors.length > 0) {
+  if (keyErrors.length > 0) {
     console.error("Validation errors:");
-    for (const err of validation.keyErrors) console.error(`  - ${err.path}: ${err.message}`);
+    for (const err of keyErrors) console.error(`  - ${err.path}: ${err.message}`);
     process.exit(1);
   }
+
+  // Unreachable when no top-level error short-circuits resolution.
+  if (resolution === undefined) {
+    console.error("error: resolution did not complete");
+    process.exit(1);
+  }
+
+  return resolution;
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -13,9 +13,11 @@ export {
 export {
   formatSkipCause,
   renderAppMapping,
+  resolveValidated,
   resolveWithStatus,
   validate,
-  type ResolveOptions
+  type ResolveOptions,
+  type ResolveValidatedResult
 } from "./resolver/index.js";
 
 export type {

--- a/packages/cli/src/resolver/index.ts
+++ b/packages/cli/src/resolver/index.ts
@@ -36,6 +36,30 @@ export async function resolve(options: ResolveOptions): Promise<ResolvedKey[]> {
 }
 
 export async function validate(options: ResolveOptions): Promise<ValidationResult> {
+  const { topLevelErrors, keyErrors } = await resolveValidated(options);
+  return { topLevelErrors, keyErrors };
+}
+
+export interface ResolveValidatedResult extends ValidationResult {
+  // Present only when no top-level error short-circuited resolution.
+  resolution?: Resolution;
+}
+
+// Single-pass validate + resolve. Runs the pre-resolution top-level checks,
+// then resolves every selected key exactly once and derives key-level
+// validation errors from that one Resolution. Callers reuse `resolution` for
+// rendering instead of resolving a second time.
+export async function resolveValidated(options: ResolveOptions): Promise<ResolveValidatedResult> {
+  const topLevelErrors = checkTopLevel(options);
+  if (topLevelErrors.length > 0) {
+    return { topLevelErrors, keyErrors: [] };
+  }
+
+  const resolution = await resolveWithStatus(options);
+  return { topLevelErrors: [], keyErrors: validateResolution(resolution), resolution };
+}
+
+function checkTopLevel(options: ResolveOptions): TopLevelError[] {
   const topLevelErrors: TopLevelError[] = [];
 
   const envError = checkValidEnv(options);
@@ -44,18 +68,17 @@ export async function validate(options: ResolveOptions): Promise<ValidationResul
   const groupCheck = checkGroupFilter(options.config, options.groups);
   topLevelErrors.push(...groupCheck.errors);
 
-  if (topLevelErrors.length > 0) {
-    return { topLevelErrors, keyErrors: [] };
-  }
+  if (topLevelErrors.length > 0) return topLevelErrors;
 
   const selected = selectRecords(options.config, options.groups, options.filters);
   const envRequiredError = checkEnvProvidedWhenRequired(selected, options.envName);
-  if (envRequiredError !== undefined) {
-    return { topLevelErrors: [envRequiredError], keyErrors: [] };
-  }
+  if (envRequiredError !== undefined) return [envRequiredError];
 
-  const resolution = await resolveWithStatus(options);
-  const keyErrors = resolution.statuses
+  return [];
+}
+
+function validateResolution(resolution: Resolution): ValidationResult["keyErrors"] {
+  return resolution.statuses
     .filter((status): status is Extract<KeyResolutionStatus, { status: "error" }> => {
       return status.status === "error";
     })
@@ -64,8 +87,6 @@ export async function validate(options: ResolveOptions): Promise<ValidationResul
       message: status.message,
       error: status.error
     }));
-
-  return { topLevelErrors: [], keyErrors };
 }
 
 export async function resolveWithStatus(options: ResolveOptions): Promise<Resolution> {

--- a/packages/cli/test/unit/resolver.test.ts
+++ b/packages/cli/test/unit/resolver.test.ts
@@ -5,6 +5,7 @@ import { age, config, defineConfig, normalizeConfig, secret } from "../../src/co
 import {
   renderAppMapping,
   resolve,
+  resolveValidated,
   resolveWithStatus,
   validate
 } from "../../src/resolver/index.js";
@@ -445,6 +446,84 @@ describe("resolver", () => {
       ],
       keyErrors: []
     });
+  });
+
+  it("resolveValidated resolves each key through its provider at most once", async () => {
+    const provider = mockProvider("age", "secret-value");
+    const normalized = normalizeConfig(
+      defineConfig({
+        name: "test",
+        envs: ["dev"],
+        keys: {
+          a: secret({ value: age({ identityFile: "./a.txt", secretsDir: "./secrets" }) }),
+          b: secret({ value: age({ identityFile: "./b.txt", secretsDir: "./secrets" }) })
+        }
+      })
+    );
+
+    const result = await resolveValidated({
+      config: normalized,
+      envName: "dev",
+      rootDir: "/repo",
+      registry: registry(provider)
+    });
+
+    expect(result.topLevelErrors).toEqual([]);
+    expect(result.keyErrors).toEqual([]);
+    expect(result.resolution.resolved).toEqual([
+      { path: "a", value: "secret-value" },
+      { path: "b", value: "secret-value" }
+    ]);
+    // One resolution per key per run — not two passes.
+    expect(provider.resolve).toHaveBeenCalledTimes(2);
+  });
+
+  it("resolveValidated surfaces top-level errors without resolving", async () => {
+    const provider = mockProvider("age", "secret-value");
+    const normalized = normalizeConfig(
+      defineConfig({
+        name: "test",
+        envs: ["dev"],
+        keys: {
+          token: secret({ value: age({ identityFile: "./a.txt", secretsDir: "./secrets" }) })
+        }
+      })
+    );
+
+    const result = await resolveValidated({
+      config: normalized,
+      envName: "prod",
+      rootDir: "/repo",
+      registry: registry(provider)
+    });
+
+    expect(result.topLevelErrors).toMatchObject([{ message: 'Unknown env "prod"' }]);
+    expect(provider.resolve).not.toHaveBeenCalled();
+  });
+
+  it("resolveValidated surfaces unresolvable required keys as keyErrors", async () => {
+    const provider = mockProvider("age");
+    (provider.resolve as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("auth failed"));
+    const normalized = normalizeConfig(
+      defineConfig({
+        name: "test",
+        envs: ["dev"],
+        keys: {
+          token: secret({ value: age({ identityFile: "./a.txt", secretsDir: "./secrets" }) })
+        }
+      })
+    );
+
+    const result = await resolveValidated({
+      config: normalized,
+      envName: "dev",
+      rootDir: "/repo",
+      registry: registry(provider)
+    });
+
+    expect(result.topLevelErrors).toEqual([]);
+    expect(result.keyErrors).toMatchObject([{ path: "token", message: "auth failed" }]);
+    expect(provider.resolve).toHaveBeenCalledTimes(1);
   });
 
   it("resolve still throws on top-level errors (unchanged fast-fail behavior)", async () => {


### PR DESCRIPTION
## Summary

`keyshelf run` resolved the entire config twice per invocation: once inside validation (`assertValidationPasses` → `validate` → `resolveWithStatus`) and again to render the app mapping. With no shared state and no provider caching, every secret cost two provider round-trips — 2× GCP Secret Manager calls, 2× sops/age decryptions. This halves that to a single pass.

## What changed

- Added `resolveValidated(options)` to the resolver: runs the pre-resolution top-level checks, then resolves every selected key exactly once and derives key-level validation errors from that single `Resolution`. `validate()` now composes it, so its public contract is unchanged.
- `assertValidationPasses` now calls `resolveValidated` and **returns** the single `Resolution`.
- `run`, `ls --reveal`, and `cp` consume that returned `Resolution` for rendering instead of calling `resolveWithStatus` a second time.
- Exported `resolveValidated` / `ResolveValidatedResult` from the public embedder surface; regenerated the action bundle, which picks up the same single-pass path.

## Acceptance criteria

- [x] A single `keyshelf run` invocation resolves each key through its provider at most once
- [x] Validation behavior unchanged: unresolvable required keys still fail before the child spawns, with the same error output (existing e2e + unit tests stay green)
- [x] Regression test asserts provider invocation counts via a counting fake provider — one resolve call per key per run (`resolveValidated resolves each key through its provider at most once`)
- [x] `ls --reveal` and `cp` also benefit (routed through the same single-pass helper, no behavior change)

## Testing

Local CI-equivalent run all green: `build` (cli + action), `lint`, `format:check`, `typecheck`, `typecheck:examples`, `test` (286 cli + 32 migrate).

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)