### PR TITLE
feat(resolver): scope run resolution + validation to the app mapping

### DIFF
--- a/packages/action/dist/emit-env.mjs
+++ b/packages/action/dist/emit-env.mjs
@@ -2749,7 +2749,12 @@ function checkTopLevel(options) {
   const groupCheck = checkGroupFilter(options.config, options.groups);
   topLevelErrors.push(...groupCheck.errors);
   if (topLevelErrors.length > 0) return topLevelErrors;
-  const selected = selectRecords(options.config, options.groups, options.filters);
+  const selected = selectRecords(
+    options.config,
+    options.groups,
+    options.filters,
+    computeReachable(options.config, options.roots)
+  );
   const envRequiredError = checkEnvProvidedWhenRequired(selected, options.envName);
   if (envRequiredError !== void 0) return [envRequiredError];
   return [];
@@ -2765,7 +2770,12 @@ function validateResolution(resolution) {
 }
 async function resolveWithStatus(options) {
   assertValidEnv(options);
-  const selected = selectRecords(options.config, options.groups, options.filters);
+  const selected = selectRecords(
+    options.config,
+    options.groups,
+    options.filters,
+    computeReachable(options.config, options.roots)
+  );
   assertEnvProvidedWhenRequired(selected, options.envName);
   const selectedByPath = new Map(
     selected.filter((entry) => entry.selected).map((entry) => [entry.record.path, entry.record])
@@ -2836,11 +2846,14 @@ function renderAppMapping(mappings, resolution) {
     };
   });
 }
-function selectRecords(config2, groups2, filters2) {
+function selectRecords(config2, groups2, filters2, reachable) {
   const groupSet = normalizeGroupFilter(config2, groups2);
   const activeGroups = [...groupSet];
   const pathPrefixes = normalizePathFilters(filters2);
   return config2.keys.map((record) => {
+    if (reachable !== void 0 && !reachable.has(record.path)) {
+      return { record, selected: false };
+    }
     if (isExcludedByGroup(record, groupSet)) {
       return {
         record,
@@ -2857,6 +2870,36 @@ function selectRecords(config2, groups2, filters2) {
     }
     return { record, selected: true };
   });
+}
+function computeReachable(config2, roots) {
+  if (roots === void 0) return void 0;
+  const recordByPath = new Map(config2.keys.map((record) => [record.path, record]));
+  const reachable = /* @__PURE__ */ new Set();
+  const queue = [...roots];
+  while (queue.length > 0) {
+    const path = queue.shift();
+    if (reachable.has(path)) continue;
+    reachable.add(path);
+    const record = recordByPath.get(path);
+    if (record === void 0) continue;
+    for (const reference of bindingReferences(record)) {
+      if (!reachable.has(reference)) queue.push(reference);
+    }
+  }
+  return reachable;
+}
+function bindingReferences(record) {
+  if (record.kind !== "config") return [];
+  const references = [];
+  const bindings = [record.value, ...Object.values(record.values ?? {})];
+  for (const binding of bindings) {
+    if (typeof binding !== "string") continue;
+    TEMPLATE_RE3.lastIndex = 0;
+    for (const match of binding.matchAll(TEMPLATE_RE3)) {
+      references.push(match[1].trim());
+    }
+  }
+  return references;
 }
 function normalizeGroupFilter(config2, groups2) {
   const { errors, groupSet } = checkGroupFilter(config2, groups2);

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -180,7 +180,7 @@ For each key, given an active `envName`:
 
 `value` and `default` are aliases. Setting both on the same record is a validation error. The two names exist purely for legibility — `value:` reads naturally for envless records, `default:` reads naturally when paired with `values:`.
 
-`--env` is **only required** when at least one selected key has a `values` map without a fallback. A fully envless config can run without `--env`.
+`--env` is **only required** when at least one selected key has a `values` map without a fallback. A fully envless config can run without `--env`. For `keyshelf run`, "selected" means a key that is reachable from the active `.env.keyshelf` (see [App mapping](#app-mapping-envkeyshelf)) — a `values`-only key the app never maps does not force `--env`.
 
 ## Templates
 
@@ -254,6 +254,10 @@ keyshelf run --env production --group app -- node server.js
 keyshelf run --filter db -- ./scripts/check-db.sh
 keyshelf run --map ./infra/.env.keyshelf -- terraform apply
 ```
+
+Resolution is **scoped to the app mapping**. The roots are the keys the mapping references — direct mappings and the `${...}` references inside template mappings — expanded transitively through `${...}` references in `config(...)` bindings. Only that reachable set is resolved and validated: a required key outside it is never resolved and can never fail the run, even if it is unseeded or has no binding for the active env. A _mapped_ required key that can't resolve (unseeded, or no binding for the active env) still fails loudly.
+
+`--group` / `--filter` intersect with the mapped set — excluding a mapped key keeps the [skip-with-warning](#groups-and-filters) behavior rather than failing. A mapping that points at an undeclared key path still fails fast at load.
 
 Forwards the child process exit code.
 

--- a/packages/cli/src/cli/run.ts
+++ b/packages/cli/src/cli/run.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 import spawn from "cross-spawn";
 import { loadConfig } from "../config/index.js";
+import { isTemplateMapping, type AppMapping } from "../config/app-mapping.js";
 import { formatSkipCause, renderAppMapping } from "../resolver/index.js";
 import { createDefaultRegistry } from "../providers/setup.js";
 import { splitList } from "./options.js";
@@ -40,7 +41,11 @@ export const runCommand = new Command("run")
       rootDir: loaded.rootDir,
       registry,
       groups: splitList(opts.group),
-      filters: splitList(opts.filter)
+      filters: splitList(opts.filter),
+      // Scope resolution + validation to the keys this app actually maps.
+      // Keys unreachable from .env.keyshelf are never resolved, so an
+      // unseeded secret belonging to another app can't fail this run.
+      roots: appMappingRoots(loaded.appMapping)
     };
 
     const resolution = await assertValidationPasses(resolveOpts);
@@ -72,3 +77,17 @@ export const runCommand = new Command("run")
       process.exit(1);
     });
   });
+
+// The key paths directly referenced by the app mapping — the resolution roots.
+// Transitive `${...}` expansion through config templates happens in the resolver.
+function appMappingRoots(mappings: AppMapping[]): string[] {
+  const roots = new Set<string>();
+  for (const mapping of mappings) {
+    if (isTemplateMapping(mapping)) {
+      for (const keyPath of mapping.keyPaths) roots.add(keyPath);
+    } else {
+      roots.add(mapping.keyPath);
+    }
+  }
+  return [...roots];
+}

--- a/packages/cli/src/resolver/index.ts
+++ b/packages/cli/src/resolver/index.ts
@@ -29,6 +29,12 @@ export interface ResolveOptions {
   registry: ProviderRegistry;
   groups?: string[];
   filters?: string[];
+  // When set, scope resolution + validation to the keys reachable from these
+  // root key paths (expanded transitively through `${...}` references inside
+  // config bindings). Keys outside the reachable set are never resolved and
+  // never produce validation errors. When undefined, every config key is in
+  // scope (legacy behavior).
+  roots?: string[];
 }
 
 export async function resolve(options: ResolveOptions): Promise<ResolvedKey[]> {
@@ -70,7 +76,12 @@ function checkTopLevel(options: ResolveOptions): TopLevelError[] {
 
   if (topLevelErrors.length > 0) return topLevelErrors;
 
-  const selected = selectRecords(options.config, options.groups, options.filters);
+  const selected = selectRecords(
+    options.config,
+    options.groups,
+    options.filters,
+    computeReachable(options.config, options.roots)
+  );
   const envRequiredError = checkEnvProvidedWhenRequired(selected, options.envName);
   if (envRequiredError !== undefined) return [envRequiredError];
 
@@ -91,7 +102,12 @@ function validateResolution(resolution: Resolution): ValidationResult["keyErrors
 
 export async function resolveWithStatus(options: ResolveOptions): Promise<Resolution> {
   assertValidEnv(options);
-  const selected = selectRecords(options.config, options.groups, options.filters);
+  const selected = selectRecords(
+    options.config,
+    options.groups,
+    options.filters,
+    computeReachable(options.config, options.roots)
+  );
   assertEnvProvidedWhenRequired(selected, options.envName);
 
   const selectedByPath = new Map(
@@ -184,13 +200,20 @@ export function renderAppMapping(mappings: AppMapping[], resolution: Resolution)
 function selectRecords(
   config: NormalizedConfig,
   groups: string[] | undefined,
-  filters: string[] | undefined
+  filters: string[] | undefined,
+  reachable: Set<string> | undefined
 ): SelectedRecord[] {
   const groupSet = normalizeGroupFilter(config, groups);
   const activeGroups = [...groupSet];
   const pathPrefixes = normalizePathFilters(filters);
 
   return config.keys.map((record) => {
+    // Out of scope: not reachable from the app mapping. Drop it silently —
+    // no cause means no resolution status, so it never resolves and never
+    // surfaces a validation error or skip warning.
+    if (reachable !== undefined && !reachable.has(record.path)) {
+      return { record, selected: false };
+    }
     if (isExcludedByGroup(record, groupSet)) {
       return {
         record,
@@ -207,6 +230,56 @@ function selectRecords(
     }
     return { record, selected: true };
   });
+}
+
+// Expands the given root key paths into the full set of keys reachable through
+// `${...}` references inside config bindings. Returns undefined when no roots
+// are given (every key is in scope — legacy behavior). Unknown root paths are
+// ignored here; load-time validateAppMappingReferences already rejects mappings
+// that point at undeclared keys.
+function computeReachable(
+  config: NormalizedConfig,
+  roots: string[] | undefined
+): Set<string> | undefined {
+  if (roots === undefined) return undefined;
+
+  const recordByPath = new Map(config.keys.map((record) => [record.path, record] as const));
+  const reachable = new Set<string>();
+  const queue = [...roots];
+
+  while (queue.length > 0) {
+    const path = queue.shift() as string;
+    if (reachable.has(path)) continue;
+    reachable.add(path);
+
+    const record = recordByPath.get(path);
+    if (record === undefined) continue;
+
+    for (const reference of bindingReferences(record)) {
+      if (!reachable.has(reference)) queue.push(reference);
+    }
+  }
+
+  return reachable;
+}
+
+// Every `${...}` reference across a record's bindings (value + every env in
+// values). We follow all of them rather than just the active env's binding so
+// the reachable set — and therefore the `--env` requirement check — is
+// computed before the active env is known.
+function bindingReferences(record: NormalizedRecord): string[] {
+  if (record.kind !== "config") return [];
+
+  const references: string[] = [];
+  const bindings: unknown[] = [record.value, ...Object.values(record.values ?? {})];
+  for (const binding of bindings) {
+    if (typeof binding !== "string") continue;
+    TEMPLATE_RE.lastIndex = 0;
+    for (const match of binding.matchAll(TEMPLATE_RE)) {
+      references.push(match[1].trim());
+    }
+  }
+  return references;
 }
 
 function normalizeGroupFilter(config: NormalizedConfig, groups: string[] | undefined): Set<string> {

--- a/packages/cli/test/e2e/run.test.ts
+++ b/packages/cli/test/e2e/run.test.ts
@@ -167,3 +167,46 @@ describe("keyshelf-next run (groups)", () => {
     expect(result.trim()).toBe("ci-secret-value");
   });
 });
+
+describe("keyshelf-next run (scoped to app mapping)", () => {
+  let root: string;
+  let paths: AgeFixturePaths;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "keyshelf-run-scope-"));
+    paths = await setupAgeFixtureDir(root);
+    // a: a config the app maps. b: an unrelated required secret that is never
+    // seeded — it must not be resolved or validated for an app that doesn't map it.
+    await writeKeyshelfConfig(root, [
+      `name: "demo",`,
+      `envs: ["dev", "production"],`,
+      `keys: {`,
+      `  a: config({ value: "alpha" }),`,
+      `  b: secret({ value: age({ identityFile: ${JSON.stringify(paths.identityFile)}, secretsDir: ${JSON.stringify(paths.secretsDir)} }) }),`,
+      `},`
+    ]);
+    await writeEnvKeyshelf(root, ["A=a"]);
+  });
+
+  it("succeeds when an unrelated required key is unseeded and unmapped", () => {
+    const result = spawnSync(
+      TSX,
+      [CLI, "run", "--env", "dev", "--", "node", "-e", "console.log(process.env.A)"],
+      { cwd: root, encoding: "utf-8" }
+    );
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe("alpha");
+  });
+
+  it("fails loudly when a mapped required key is unresolvable", async () => {
+    await writeEnvKeyshelf(root, ["B=b"]);
+    const result = spawnSync(
+      TSX,
+      [CLI, "run", "--env", "dev", "--", "node", "-e", "console.log('ran')"],
+      { cwd: root, encoding: "utf-8" }
+    );
+    expect(result.status).not.toBe(0);
+    expect(result.stdout).not.toContain("ran");
+    expect(result.stderr).toContain("b");
+  });
+});

--- a/packages/cli/test/unit/resolver.test.ts
+++ b/packages/cli/test/unit/resolver.test.ts
@@ -602,9 +602,7 @@ describe("scoped resolution (roots)", () => {
       roots: ["a"]
     });
 
-    expect(result.keyErrors).toEqual([
-      expect.objectContaining({ path: "a" })
-    ]);
+    expect(result.keyErrors).toEqual([expect.objectContaining({ path: "a" })]);
   });
 
   it("expands roots transitively through config template references", async () => {

--- a/packages/cli/test/unit/resolver.test.ts
+++ b/packages/cli/test/unit/resolver.test.ts
@@ -551,3 +551,168 @@ describe("resolver", () => {
     ).rejects.toThrow('Unknown group "ci"');
   });
 });
+
+describe("scoped resolution (roots)", () => {
+  it("never resolves or validates required keys outside the reachable set", async () => {
+    const providerA = mockProvider("age", "value-a");
+    const normalized = normalizeConfig(
+      defineConfig({
+        name: "test",
+        envs: ["dev", "production"],
+        keys: {
+          a: secret({ value: age({ identityFile: "./a.txt", secretsDir: "./secrets" }) }),
+          // b is required but bound only for production — would fail a dev run if resolved.
+          b: config({ values: { production: "prod-only" } })
+        }
+      })
+    );
+
+    const result = await resolveValidated({
+      config: normalized,
+      envName: "dev",
+      rootDir: "/repo",
+      registry: registry(providerA),
+      roots: ["a"]
+    });
+
+    expect(result.topLevelErrors).toEqual([]);
+    expect(result.keyErrors).toEqual([]);
+    expect(result.resolution?.resolved).toEqual([{ path: "a", value: "value-a" }]);
+    // b never appears in the resolution at all.
+    expect(result.resolution?.statusByPath.has("b")).toBe(false);
+  });
+
+  it("fails loudly when a mapped required key is unresolvable in the active env", async () => {
+    const normalized = normalizeConfig(
+      defineConfig({
+        name: "test",
+        envs: ["dev", "production"],
+        keys: {
+          a: config({ values: { production: "prod-only" } }),
+          b: config({ value: "always" })
+        }
+      })
+    );
+
+    const result = await resolveValidated({
+      config: normalized,
+      envName: "dev",
+      rootDir: "/repo",
+      registry: registry(),
+      roots: ["a"]
+    });
+
+    expect(result.keyErrors).toEqual([
+      expect.objectContaining({ path: "a" })
+    ]);
+  });
+
+  it("expands roots transitively through config template references", async () => {
+    const provider = mockProvider("age", "pw");
+    const normalized = normalizeConfig(
+      defineConfig({
+        name: "test",
+        envs: ["dev", "production"],
+        keys: {
+          db: {
+            host: config({ value: "localhost" }),
+            password: secret({ value: age({ identityFile: "./a.txt", secretsDir: "./s" }) }),
+            url: config({ default: "postgres://${db/password}@${db/host}/x" })
+          },
+          unrelated: config({ values: { production: "x" } })
+        }
+      })
+    );
+
+    const result = await resolveValidated({
+      config: normalized,
+      envName: "dev",
+      rootDir: "/repo",
+      registry: registry(provider),
+      // Root references only the url template; password + host must be pulled in.
+      roots: ["db/url"]
+    });
+
+    expect(result.topLevelErrors).toEqual([]);
+    expect(result.keyErrors).toEqual([]);
+    expect(result.resolution?.statusByPath.has("db/password")).toBe(true);
+    expect(result.resolution?.statusByPath.has("db/host")).toBe(true);
+    expect(result.resolution?.statusByPath.has("unrelated")).toBe(false);
+  });
+
+  it("only requires --env when a reachable key needs it", async () => {
+    const normalized = normalizeConfig(
+      defineConfig({
+        name: "test",
+        envs: ["dev", "production"],
+        keys: {
+          a: config({ value: "always" }),
+          // b needs --env, but is out of scope.
+          b: config({ values: { dev: "d", production: "p" } })
+        }
+      })
+    );
+
+    const result = await resolveValidated({
+      config: normalized,
+      rootDir: "/repo",
+      registry: registry(),
+      roots: ["a"]
+    });
+
+    expect(result.topLevelErrors).toEqual([]);
+    expect(result.resolution?.resolved).toEqual([{ path: "a", value: "always" }]);
+  });
+
+  it("requires --env when a reachable key needs it", async () => {
+    const normalized = normalizeConfig(
+      defineConfig({
+        name: "test",
+        envs: ["dev", "production"],
+        keys: {
+          a: config({ values: { dev: "d", production: "p" } })
+        }
+      })
+    );
+
+    const result = await resolveValidated({
+      config: normalized,
+      rootDir: "/repo",
+      registry: registry(),
+      roots: ["a"]
+    });
+
+    expect(result.topLevelErrors).toEqual([
+      expect.objectContaining({
+        message: expect.stringContaining("--env is required")
+      })
+    ]);
+  });
+
+  it("keeps skip-with-warning when a group/filter excludes a mapped key", async () => {
+    const normalized = normalizeConfig(
+      defineConfig({
+        name: "test",
+        envs: ["dev"],
+        groups: ["app", "infra"],
+        keys: {
+          a: config({ group: "app", value: "av" }),
+          b: config({ group: "infra", value: "bv" })
+        }
+      })
+    );
+
+    const resolution = await resolveWithStatus({
+      config: normalized,
+      envName: "dev",
+      rootDir: "/repo",
+      registry: registry(),
+      roots: ["a", "b"],
+      groups: ["app"]
+    });
+
+    // a resolves; b is in scope (mapped) but filtered out by --group.
+    expect(resolution.statusByPath.get("a")?.status).toBe("resolved");
+    expect(resolution.statusByPath.get("b")?.status).toBe("filtered");
+  });
+});


### PR DESCRIPTION
Closes #142

## What

`keyshelf run` now scopes resolution **and** validation to the keys the active `.env.keyshelf` actually maps, instead of resolving/validating every key in the config. An unseeded or env-unbound secret that belongs to a *different* app can no longer fail an unrelated app's run.

## How

- `ResolveOptions` gains an optional `roots?: string[]`. When set, `computeReachable` expands those roots into the transitive closure through `${...}` references inside `config(...)` bindings; `selectRecords` drops any key outside that set silently (no status → never resolved, never validated, no skip warning).
- `run` passes the keys referenced by `.env.keyshelf` (direct + template references) as roots. `ls` / `cp` are unchanged (no roots → full-config behavior, exactly as before).
- The `--env`-required check now runs against the scoped selection, so a `values`-only key the app never maps no longer forces `--env`.
- Group/filter exclusion is applied *after* the reachability check, so excluding a mapped key keeps the existing skip-with-warning behavior.
- `validateAppMappingReferences` is untouched — mappings pointing at undeclared keys still fail fast at load.
- README updated to describe the scoped behavior (the "Resolve every key referenced by the local `.env.keyshelf`" promise is now literally true).

## Acceptance criteria

- [x] `run` with a mapping referencing only key A succeeds even when unrelated required key B is unseeded/unresolvable
- [x] `run` fails loudly when a *mapped* required key is unresolvable (unseeded, or no binding for the active env)
- [x] Template chains resolve transitively: mapping → config template → secret reference all count as reachable
- [x] `--env` is only required when a reachable key needs it
- [x] `--group`/`--filter` exclusions of mapped keys keep current skip-with-warning behavior
- [x] Mappings referencing undeclared key paths still fail at load
- [x] README accurately describes the scoped behavior

## Tests

- Unit (`resolver.test.ts`): scoping drops out-of-scope keys, transitive template expansion, scoped `--env` requirement, group-filter intersection on mapped keys.
- E2E (`run.test.ts`): unrelated unseeded key doesn't fail the run; a mapped unresolvable required key fails loudly.

Built on #146 / #141 (single-pass `resolveValidated`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)