### PR TITLE
feat(ls): opt-in exhaustive validation sweep for CI

### DIFF
--- a/packages/action/dist/emit-env.mjs
+++ b/packages/action/dist/emit-env.mjs
@@ -11756,7 +11756,17 @@ var AgeProvider = class {
     const opts2 = this.resolveOptions(ctx);
     const filePath = secretFilePath(opts2.secretsDir, ctx.keyPath);
     const identity = await readIdentity(opts2.identityFile);
-    const ciphertext = await readFile(filePath);
+    let ciphertext;
+    try {
+      ciphertext = await readFile(filePath);
+    } catch (err) {
+      if (err.code === "ENOENT") {
+        throw new Error(`age: secret "${ctx.keyPath}" not found in ${opts2.secretsDir}`, {
+          cause: err
+        });
+      }
+      throw err;
+    }
     const decrypter = new Decrypter();
     decrypter.addIdentity(identity);
     return await decrypter.decrypt(ciphertext, "text");

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -274,6 +274,22 @@ keyshelf ls --env dev --reveal --map ./apps/api/.env.keyshelf --format json
 
 `--reveal` decrypts secrets — guard accordingly. `--format json` is intended for programmatic consumers (e.g. the GitHub Action) and requires `--reveal`, `--env`, and `--map`.
 
+#### `keyshelf ls --check` — exhaustive validation sweep
+
+`run` resolution is **lazy**: it only checks the keys an app mapping actually references (see [`keyshelf run`](#keyshelf-run)). That keeps unrelated runs from failing, but it also means a never-mapped required key can sit unseeded — or rot — until the day something maps it. `--check` is the deliberate counterpart: the **exhaustive sweep** that resolves _every_ declared key for an env, ignoring app mappings entirely.
+
+```sh
+keyshelf ls --check --env dev
+keyshelf ls --check --env production        # sweep each env CI cares about
+```
+
+- Resolves every declared key for `--env` and **exits non-zero** if any _required_ key is unresolvable, listing each failing key and its cause (no binding for the env vs. a provider error) — never the secret value.
+- A _required_ key that can't resolve fails the sweep; an _optional_ key that doesn't resolve is reported as `SKIP`, not a failure.
+- Exit code `0` when everything required resolves — suitable for CI gating, one invocation per env.
+- `--check` requires `--env` and can't be combined with `--reveal` or `--format json`. `--group` / `--filter` narrow the swept set when you want to gate a subset.
+
+The rule of thumb: **`run` = lazy** (only what an app needs, right now); **`ls --check` = the exhaustive sweep** (everything declared, deliberately, in CI).
+
 ### `keyshelf set`
 
 Write a secret value through its bound provider. Does **not** edit `keyshelf.config.ts` — config keys are hand-edited.

--- a/packages/cli/src/cli/ls.ts
+++ b/packages/cli/src/cli/ls.ts
@@ -183,7 +183,9 @@ async function runCheck({ loaded, env, groups, filters }: CheckArgs): Promise<vo
     process.exit(1);
   }
 
-  console.log(`OK: all required keys resolve for env "${env}"${skipped > 0 ? ` (${skipped} optional skipped)` : ""}`);
+  console.log(
+    `OK: all required keys resolve for env "${env}"${skipped > 0 ? ` (${skipped} optional skipped)` : ""}`
+  );
 }
 
 function parseFormat(raw: string | undefined): LsFormat {

--- a/packages/cli/src/cli/ls.ts
+++ b/packages/cli/src/cli/ls.ts
@@ -76,30 +76,24 @@ export const lsCommand = new Command("ls")
     printRows(buildSchemaRows(loaded.config.keys, opts.env, groups, filters));
   });
 
+function fail(message: string): never {
+  console.error(`error: ${message}`);
+  process.exit(1);
+}
+
 function assertValidOptions(opts: LsOptions, format: LsFormat): void {
-  if (opts.check) {
-    if (!opts.env) {
-      console.error("error: --check requires --env");
-      process.exit(1);
-    }
-    if (opts.reveal) {
-      console.error("error: --check cannot be combined with --reveal");
-      process.exit(1);
-    }
-    if (format === "json") {
-      console.error("error: --check does not support --format json");
-      process.exit(1);
-    }
-    return;
-  }
-  if (opts.reveal && !opts.env) {
-    console.error("error: --reveal requires --env");
-    process.exit(1);
-  }
+  if (opts.check) return assertValidCheckOptions(opts, format);
+
+  if (opts.reveal && !opts.env) fail("--reveal requires --env");
   if (format === "json" && !(opts.reveal && opts.env && opts.map)) {
-    console.error("error: --format json requires --reveal, --env, and --map");
-    process.exit(1);
+    fail("--format json requires --reveal, --env, and --map");
   }
+}
+
+function assertValidCheckOptions(opts: LsOptions, format: LsFormat): void {
+  if (!opts.env) fail("--check requires --env");
+  if (opts.reveal) fail("--check cannot be combined with --reveal");
+  if (format === "json") fail("--check does not support --format json");
 }
 
 interface RevealArgs {
@@ -160,32 +154,30 @@ async function runCheck({ loaded, env, groups, filters }: CheckArgs): Promise<vo
   }
 
   // resolution is always present once top-level checks pass.
-  const recordByPath = new Map(loaded.config.keys.map((record) => [record.path, record]));
-  let skipped = 0;
-
-  if (resolution !== undefined) {
-    for (const status of resolution.statuses) {
-      if (status.status === "skipped") {
-        const record = recordByPath.get(status.path);
-        if (record?.optional) {
-          console.log(`SKIP ${status.path}: ${formatSkipCause(status.cause)}`);
-          skipped += 1;
-        }
-      }
-    }
-  }
+  const skipped = resolution ? reportOptionalSkips(resolution, loaded.config.keys) : 0;
 
   if (keyErrors.length > 0) {
     console.error(`error: ${keyErrors.length} key(s) failed validation for env "${env}":`);
-    for (const err of keyErrors) {
-      console.error(`  FAIL ${err.path}: ${err.message}`);
-    }
+    for (const err of keyErrors) console.error(`  FAIL ${err.path}: ${err.message}`);
     process.exit(1);
   }
 
-  console.log(
-    `OK: all required keys resolve for env "${env}"${skipped > 0 ? ` (${skipped} optional skipped)` : ""}`
-  );
+  const suffix = skipped > 0 ? ` (${skipped} optional skipped)` : "";
+  console.log(`OK: all required keys resolve for env "${env}"${suffix}`);
+}
+
+// Prints a SKIP line for every optional key that didn't resolve and returns
+// how many were skipped. Required keys that fail surface as keyErrors instead.
+function reportOptionalSkips(resolution: Resolution, records: NormalizedRecord[]): number {
+  const optionalPaths = new Set(records.filter((r) => r.optional).map((r) => r.path));
+  let skipped = 0;
+  for (const status of resolution.statuses) {
+    if (status.status === "skipped" && optionalPaths.has(status.path)) {
+      console.log(`SKIP ${status.path}: ${formatSkipCause(status.cause)}`);
+      skipped += 1;
+    }
+  }
+  return skipped;
 }
 
 function parseFormat(raw: string | undefined): LsFormat {

--- a/packages/cli/src/cli/ls.ts
+++ b/packages/cli/src/cli/ls.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
 import { loadConfig } from "../config/index.js";
-import { formatSkipCause, renderAppMapping } from "../resolver/index.js";
+import { formatSkipCause, renderAppMapping, resolveValidated } from "../resolver/index.js";
 import { createDefaultRegistry } from "../providers/setup.js";
 import { splitList } from "./options.js";
 import { assertValidationPasses } from "./validation.js";
@@ -15,6 +15,7 @@ interface LsOptions {
   group?: string;
   filter?: string;
   reveal?: boolean;
+  check?: boolean;
   map?: string;
   format?: string;
 }
@@ -48,6 +49,10 @@ export const lsCommand = new Command("ls")
     "Comma-separated key-path prefix filter (e.g. db,log); non-matching keys are marked filtered"
   )
   .option("--reveal", "Resolve through bound providers and show resolved values (requires --env)")
+  .option(
+    "--check",
+    "Validate that every declared key resolves for --env, ignoring app mappings; exits non-zero on any unresolvable required key (CI sweep)"
+  )
   .option("--map <file>", "Path to app mapping file (default: .env.keyshelf)")
   .option("--format <format>", "Output format: table (default) or json", "table")
   .action(async (opts: LsOptions) => {
@@ -58,6 +63,11 @@ export const lsCommand = new Command("ls")
     const groups = splitList(opts.group);
     const filters = splitList(opts.filter);
 
+    if (opts.check) {
+      await runCheck({ loaded, env: opts.env as string, groups, filters });
+      return;
+    }
+
     if (opts.reveal && opts.env !== undefined) {
       await runReveal({ loaded, env: opts.env, groups, filters, format });
       return;
@@ -67,6 +77,21 @@ export const lsCommand = new Command("ls")
   });
 
 function assertValidOptions(opts: LsOptions, format: LsFormat): void {
+  if (opts.check) {
+    if (!opts.env) {
+      console.error("error: --check requires --env");
+      process.exit(1);
+    }
+    if (opts.reveal) {
+      console.error("error: --check cannot be combined with --reveal");
+      process.exit(1);
+    }
+    if (format === "json") {
+      console.error("error: --check does not support --format json");
+      process.exit(1);
+    }
+    return;
+  }
   if (opts.reveal && !opts.env) {
     console.error("error: --reveal requires --env");
     process.exit(1);
@@ -105,6 +130,60 @@ async function runReveal({ loaded, env, groups, filters, format }: RevealArgs): 
 
   console.error("warning: revealing secret values");
   printRows(buildRevealedRows(loaded.config.keys, resolution));
+}
+
+interface CheckArgs {
+  loaded: Awaited<ReturnType<typeof loadConfig>>;
+  env: string;
+  groups: string[] | undefined;
+  filters: string[] | undefined;
+}
+
+// Exhaustive validation sweep: resolve every declared key for the given env,
+// ignoring app mappings (roots stay undefined => legacy "all keys in scope").
+// Required keys that don't resolve fail the sweep; optional ones are reported
+// as skipped. Designed for CI gating, so it never reveals resolved values.
+async function runCheck({ loaded, env, groups, filters }: CheckArgs): Promise<void> {
+  const { topLevelErrors, keyErrors, resolution } = await resolveValidated({
+    config: loaded.config,
+    envName: env,
+    rootDir: loaded.rootDir,
+    registry: createDefaultRegistry(),
+    groups,
+    filters
+    // roots intentionally omitted: validate the full config, not the app mapping.
+  });
+
+  if (topLevelErrors.length > 0) {
+    for (const err of topLevelErrors) console.error(`error: ${err.message}`);
+    process.exit(1);
+  }
+
+  // resolution is always present once top-level checks pass.
+  const recordByPath = new Map(loaded.config.keys.map((record) => [record.path, record]));
+  let skipped = 0;
+
+  if (resolution !== undefined) {
+    for (const status of resolution.statuses) {
+      if (status.status === "skipped") {
+        const record = recordByPath.get(status.path);
+        if (record?.optional) {
+          console.log(`SKIP ${status.path}: ${formatSkipCause(status.cause)}`);
+          skipped += 1;
+        }
+      }
+    }
+  }
+
+  if (keyErrors.length > 0) {
+    console.error(`error: ${keyErrors.length} key(s) failed validation for env "${env}":`);
+    for (const err of keyErrors) {
+      console.error(`  FAIL ${err.path}: ${err.message}`);
+    }
+    process.exit(1);
+  }
+
+  console.log(`OK: all required keys resolve for env "${env}"${skipped > 0 ? ` (${skipped} optional skipped)` : ""}`);
 }
 
 function parseFormat(raw: string | undefined): LsFormat {

--- a/packages/cli/src/providers/age.ts
+++ b/packages/cli/src/providers/age.ts
@@ -45,7 +45,16 @@ export class AgeProvider implements Provider {
     const filePath = secretFilePath(opts.secretsDir, ctx.keyPath);
     const identity = await readIdentity(opts.identityFile);
 
-    const ciphertext = await readFile(filePath);
+    let ciphertext: Uint8Array;
+    try {
+      ciphertext = await readFile(filePath);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        throw new Error(`age: secret "${ctx.keyPath}" not found in ${opts.secretsDir}`);
+      }
+      throw err;
+    }
+
     const decrypter = new Decrypter();
     decrypter.addIdentity(identity);
     return await decrypter.decrypt(ciphertext, "text");

--- a/packages/cli/src/providers/age.ts
+++ b/packages/cli/src/providers/age.ts
@@ -50,7 +50,9 @@ export class AgeProvider implements Provider {
       ciphertext = await readFile(filePath);
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code === "ENOENT") {
-        throw new Error(`age: secret "${ctx.keyPath}" not found in ${opts.secretsDir}`);
+        throw new Error(`age: secret "${ctx.keyPath}" not found in ${opts.secretsDir}`, {
+          cause: err
+        });
       }
       throw err;
     }

--- a/packages/cli/test/e2e/ls-check.test.ts
+++ b/packages/cli/test/e2e/ls-check.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+import { CLI, TSX } from "./helpers/cli.js";
+import { setupAgeFixtureDir, writeEnvKeyshelf, writeKeyshelfConfig } from "./helpers/fixture.js";
+
+interface ExecResult {
+  status: number;
+  stdout: string;
+  stderr: string;
+}
+
+function runCheck(args: string[], cwd: string): ExecResult {
+  try {
+    const stdout = execFileSync(TSX, [CLI, "ls", "--check", ...args], {
+      cwd,
+      encoding: "utf-8",
+      stdio: ["inherit", "pipe", "pipe"]
+    });
+    return { status: 0, stdout, stderr: "" };
+  } catch (err) {
+    const e = err as { status: number; stdout: string; stderr: string };
+    return { status: e.status, stdout: e.stdout ?? "", stderr: e.stderr ?? "" };
+  }
+}
+
+async function writeFixture(root: string) {
+  const { identityFile, secretsDir } = await setupAgeFixtureDir(root);
+  const age = `age({ identityFile: ${JSON.stringify(identityFile)}, secretsDir: ${JSON.stringify(secretsDir)} })`;
+  await writeKeyshelfConfig(root, [
+    `name: "demo",`,
+    `envs: ["dev", "production"],`,
+    `groups: ["app", "ci"],`,
+    `keys: {`,
+    `  db: {`,
+    `    host: config({ group: "app", default: "localhost", values: { production: "prod-db" } }),`,
+    `    password: secret({ group: "app", value: ${age} }),`,
+    `  },`,
+    `  ci: {`,
+    `    token: secret({ group: "ci", value: ${age} }),`,
+    `  },`,
+    // Required config key with a dev-only binding and no fallback: resolving it
+    // for production must fail with a "no value for required key" cause.
+    `  apiUrl: config({ group: "app", values: { dev: "https://dev.example" } }),`,
+    `  optionalThing: secret({ group: "app", optional: true, value: ${age} }),`,
+    `},`
+  ]);
+  // App mapping only references db/host — the sweep must ignore this and check
+  // db/password, ci/token, optionalThing regardless.
+  await writeEnvKeyshelf(root, ["DB_HOST=db/host"]);
+  return { identityFile, secretsDir };
+}
+
+function seedAll(root: string) {
+  execFileSync(TSX, [CLI, "set", "--env", "dev", "--value", "host-pw", "db/password"], {
+    cwd: root,
+    encoding: "utf-8"
+  });
+  execFileSync(TSX, [CLI, "set", "--env", "dev", "--value", "ci-pw", "ci/token"], {
+    cwd: root,
+    encoding: "utf-8"
+  });
+}
+
+describe("keyshelf ls --check", () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "keyshelf-ls-check-"));
+    await writeFixture(root);
+  });
+
+  it("exits 0 when every required key resolves (optional unresolved is fine)", () => {
+    seedAll(root);
+    const result = runCheck(["--env", "dev"], root);
+    expect(result.status).toBe(0);
+  });
+
+  it("validates keys that no app mapping references", () => {
+    // Nothing seeded: db/password and ci/token are unmapped but required.
+    const result = runCheck(["--env", "dev"], root);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("db/password");
+    expect(result.stderr).toContain("ci/token");
+  });
+
+  it("reports failing keys with a cause and never the secret value", () => {
+    // Seed only ci/token; db/password stays unseeded.
+    execFileSync(TSX, [CLI, "set", "--env", "dev", "--value", "the-secret", "ci/token"], {
+      cwd: root,
+      encoding: "utf-8"
+    });
+    const result = runCheck(["--env", "dev"], root);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("db/password");
+    expect(result.stderr.toLowerCase()).toMatch(/not[ _-]?found|no binding|could not/);
+    expect(result.stderr).not.toContain("the-secret");
+  });
+
+  it("distinguishes no binding for env from a provider error", () => {
+    // Secrets are envless storage, so seeding for dev satisfies production too.
+    // What stays unresolvable for production is apiUrl: required, dev-only
+    // binding, no fallback => "no value for required key" (a binding gap, not a
+    // provider error).
+    seedAll(root);
+    const result = runCheck(["--env", "production"], root);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("apiUrl");
+    expect(result.stderr.toLowerCase()).toMatch(/no value|required/);
+  });
+
+  it("surfaces a provider error cause for an unseeded required secret", () => {
+    // Nothing seeded; db/password is required and its provider file is absent.
+    const result = runCheck(["--env", "dev"], root);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("db/password");
+    expect(result.stderr.toLowerCase()).toMatch(/not found/);
+  });
+
+  it("reports optional unresolved keys as skipped, not failures", () => {
+    seedAll(root);
+    const result = runCheck(["--env", "dev"], root);
+    // optionalThing is never seeded -> skipped, still exit 0
+    expect(result.status).toBe(0);
+    expect(result.stdout + result.stderr).toMatch(/optionalThing|optional/);
+  });
+
+  it("requires --env", () => {
+    const result = runCheck([], root);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("--env");
+  });
+
+  it("rejects an unknown env", () => {
+    const result = runCheck(["--env", "nope"], root);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("nope");
+  });
+});

--- a/packages/cli/test/e2e/ls-check.test.ts
+++ b/packages/cli/test/e2e/ls-check.test.ts
@@ -1,10 +1,14 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { execFileSync } from "node:child_process";
 import { CLI, TSX } from "./helpers/cli.js";
 import { setupAgeFixtureDir, writeEnvKeyshelf, writeKeyshelfConfig } from "./helpers/fixture.js";
+
+// Each test spawns at least one tsx subprocess; cold-start adds up on CI, so
+// give the whole file plenty of headroom over the 5s default.
+const SPAWN_TIMEOUT = 30_000;
 
 interface ExecResult {
   status: number;
@@ -50,92 +54,136 @@ async function writeFixture(root: string) {
   // App mapping only references db/host — the sweep must ignore this and check
   // db/password, ci/token, optionalThing regardless.
   await writeEnvKeyshelf(root, ["DB_HOST=db/host"]);
-  return { identityFile, secretsDir };
 }
 
-function seedAll(root: string) {
-  execFileSync(TSX, [CLI, "set", "--env", "dev", "--value", "host-pw", "db/password"], {
-    cwd: root,
-    encoding: "utf-8"
-  });
-  execFileSync(TSX, [CLI, "set", "--env", "dev", "--value", "ci-pw", "ci/token"], {
+function setSecret(root: string, env: string, keyPath: string, value: string) {
+  execFileSync(TSX, [CLI, "set", "--env", env, "--value", value, keyPath], {
     cwd: root,
     encoding: "utf-8"
   });
 }
 
-describe("keyshelf ls --check", () => {
+// Read-only sweeps against a fully-seeded fixture. Seeding once in beforeAll
+// keeps each test to a single spawn so the suite stays well under timeout.
+describe("keyshelf ls --check (seeded)", () => {
   let root: string;
 
-  beforeEach(async () => {
-    root = await mkdtemp(join(tmpdir(), "keyshelf-ls-check-"));
+  beforeAll(async () => {
+    root = await mkdtemp(join(tmpdir(), "keyshelf-ls-check-seeded-"));
     await writeFixture(root);
-  });
+    setSecret(root, "dev", "db/password", "host-pw");
+    setSecret(root, "dev", "ci/token", "ci-pw");
+  }, SPAWN_TIMEOUT);
 
-  it("exits 0 when every required key resolves (optional unresolved is fine)", () => {
-    seedAll(root);
-    const result = runCheck(["--env", "dev"], root);
-    expect(result.status).toBe(0);
-  });
+  it(
+    "exits 0 when every required key resolves (optional unresolved is fine)",
+    () => {
+      const result = runCheck(["--env", "dev"], root);
+      expect(result.status).toBe(0);
+    },
+    SPAWN_TIMEOUT
+  );
 
-  it("validates keys that no app mapping references", () => {
-    // Nothing seeded: db/password and ci/token are unmapped but required.
-    const result = runCheck(["--env", "dev"], root);
-    expect(result.status).not.toBe(0);
-    expect(result.stderr).toContain("db/password");
-    expect(result.stderr).toContain("ci/token");
-  });
+  it(
+    "reports optional unresolved keys as skipped, not failures",
+    () => {
+      // optionalThing is never seeded -> skipped, but the sweep still exits 0.
+      const result = runCheck(["--env", "dev"], root);
+      expect(result.status).toBe(0);
+      expect(result.stdout + result.stderr).toMatch(/optionalThing|optional/);
+    },
+    SPAWN_TIMEOUT
+  );
 
-  it("reports failing keys with a cause and never the secret value", () => {
-    // Seed only ci/token; db/password stays unseeded.
-    execFileSync(TSX, [CLI, "set", "--env", "dev", "--value", "the-secret", "ci/token"], {
-      cwd: root,
-      encoding: "utf-8"
-    });
-    const result = runCheck(["--env", "dev"], root);
-    expect(result.status).not.toBe(0);
-    expect(result.stderr).toContain("db/password");
-    expect(result.stderr.toLowerCase()).toMatch(/not[ _-]?found|no binding|could not/);
-    expect(result.stderr).not.toContain("the-secret");
-  });
+  it(
+    "distinguishes no binding for env from a provider error",
+    () => {
+      // Secrets are envless storage, so seeding for dev satisfies production
+      // too. What stays unresolvable for production is apiUrl: required,
+      // dev-only binding, no fallback => "no value for required key" (a binding
+      // gap, not a provider error).
+      const result = runCheck(["--env", "production"], root);
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("apiUrl");
+      expect(result.stderr.toLowerCase()).toMatch(/no value|required/);
+    },
+    SPAWN_TIMEOUT
+  );
+});
 
-  it("distinguishes no binding for env from a provider error", () => {
-    // Secrets are envless storage, so seeding for dev satisfies production too.
-    // What stays unresolvable for production is apiUrl: required, dev-only
-    // binding, no fallback => "no value for required key" (a binding gap, not a
-    // provider error).
-    seedAll(root);
-    const result = runCheck(["--env", "production"], root);
-    expect(result.status).not.toBe(0);
-    expect(result.stderr).toContain("apiUrl");
-    expect(result.stderr.toLowerCase()).toMatch(/no value|required/);
-  });
+describe("keyshelf ls --check (unseeded)", () => {
+  let root: string;
 
-  it("surfaces a provider error cause for an unseeded required secret", () => {
-    // Nothing seeded; db/password is required and its provider file is absent.
-    const result = runCheck(["--env", "dev"], root);
-    expect(result.status).not.toBe(0);
-    expect(result.stderr).toContain("db/password");
-    expect(result.stderr.toLowerCase()).toMatch(/not found/);
-  });
+  beforeAll(async () => {
+    root = await mkdtemp(join(tmpdir(), "keyshelf-ls-check-unseeded-"));
+    await writeFixture(root);
+  }, SPAWN_TIMEOUT);
 
-  it("reports optional unresolved keys as skipped, not failures", () => {
-    seedAll(root);
-    const result = runCheck(["--env", "dev"], root);
-    // optionalThing is never seeded -> skipped, still exit 0
-    expect(result.status).toBe(0);
-    expect(result.stdout + result.stderr).toMatch(/optionalThing|optional/);
-  });
+  it(
+    "validates keys that no app mapping references",
+    () => {
+      // db/password and ci/token are unmapped but required, and unseeded.
+      const result = runCheck(["--env", "dev"], root);
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("db/password");
+      expect(result.stderr).toContain("ci/token");
+    },
+    SPAWN_TIMEOUT
+  );
 
-  it("requires --env", () => {
-    const result = runCheck([], root);
-    expect(result.status).not.toBe(0);
-    expect(result.stderr).toContain("--env");
-  });
+  it(
+    "surfaces a provider not-found cause without leaking values",
+    () => {
+      const result = runCheck(["--env", "dev"], root);
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("db/password");
+      expect(result.stderr.toLowerCase()).toMatch(/not found/);
+    },
+    SPAWN_TIMEOUT
+  );
 
-  it("rejects an unknown env", () => {
-    const result = runCheck(["--env", "nope"], root);
-    expect(result.status).not.toBe(0);
-    expect(result.stderr).toContain("nope");
-  });
+  it(
+    "requires --env",
+    () => {
+      const result = runCheck([], root);
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("--env");
+    },
+    SPAWN_TIMEOUT
+  );
+
+  it(
+    "rejects an unknown env",
+    () => {
+      const result = runCheck(["--env", "nope"], root);
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("nope");
+    },
+    SPAWN_TIMEOUT
+  );
+});
+
+// A failing sweep must never print a seeded secret's value. Kept separate
+// because it seeds a value we then assert is absent from output.
+describe("keyshelf ls --check (no value leak)", () => {
+  let root: string;
+
+  beforeAll(async () => {
+    root = await mkdtemp(join(tmpdir(), "keyshelf-ls-check-leak-"));
+    await writeFixture(root);
+    // Seed only ci/token; db/password stays unseeded so the sweep fails.
+    setSecret(root, "dev", "ci/token", "the-secret-value");
+  }, SPAWN_TIMEOUT);
+
+  it(
+    "never prints a resolved secret value in its report",
+    () => {
+      const result = runCheck(["--env", "dev"], root);
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("db/password");
+      expect(result.stderr).not.toContain("the-secret-value");
+      expect(result.stdout).not.toContain("the-secret-value");
+    },
+    SPAWN_TIMEOUT
+  );
 });

--- a/packages/cli/test/unit/providers/age.test.ts
+++ b/packages/cli/test/unit/providers/age.test.ts
@@ -22,8 +22,10 @@ describe("AgeProvider", () => {
     identityFile: state.identityFile
   }));
 
-  it("resolve throws for missing secret", async () => {
-    await expect(state.provider.resolve(state.ctx("missing/key"))).rejects.toThrow();
+  it("resolve throws a not-found error for a missing secret", async () => {
+    // The message must be recognizable as not-found so the resolver can treat
+    // an unseeded optional secret as a skip rather than a hard error.
+    await expect(state.provider.resolve(state.ctx("missing/key"))).rejects.toThrow(/not found/i);
   });
 
   describe("list", () => {


### PR DESCRIPTION
Closes #143

## What

Adds `keyshelf ls --check --env <env>`: the deliberate exhaustive validation sweep that complements scoped/lazy `run` resolution (#141/#142).

`run` only resolves the keys an app mapping references, so a never-mapped required key can sit unseeded or rot unnoticed. `--check` resolves **every declared key** for the given env — ignoring app mappings entirely (`roots` omitted in the resolver, i.e. full-config scope) — and gates CI on the result.

## Behavior

- Required key that can't resolve -> `FAIL <key>: <cause>` on stderr, process exits non-zero. Cause distinguishes a binding gap (`No value for required key`) from a provider error (e.g. `not found`). Secret values are never printed.
- Optional key that doesn't resolve -> `SKIP <key>: <cause>` on stdout, not a failure.
- Everything required resolves -> `OK: ...` and exit `0`, suitable for CI gating, one invocation per env.
- `--check` requires `--env`; rejects `--reveal` and `--format json`. `--group` / `--filter` narrow the swept set.
- Works with no `.env.keyshelf` present (the sweep doesn't need an app mapping).

## Incidental fix

The age provider's `resolve()` threw a raw `ENOENT` for a missing secret file, which the resolver's not-found matcher didn't recognize — so an unseeded **optional** age secret hard-failed instead of skipping. Eager validation in `run` used to mask this; the sweep surfaces it. `resolve()` now throws a recognizable `age: secret "<path>" not found ...` error (with the original error attached as `cause`), restoring the resolver's optional-not-found skip contract. The action bundle (`packages/action/dist`) is regenerated because it bundles this provider.

## Tests

- `packages/cli/test/e2e/ls-check.test.ts` — happy path, unmapped-key validation, failure cause + no-value-leak, no-binding-vs-provider-error distinction, optional-skip, `--env` required, unknown env.
- `packages/cli/test/unit/providers/age.test.ts` — asserts the not-found message.

Locally green: `lint`, `format:check`, `typecheck`, `typecheck:examples`, full `test` (302 CLI + 32 migrate), and action dist verified up to date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)