### PR TITLE
fix(cli): derive --version from package.json (closes #153)

### DIFF
--- a/packages/cli/src/cli/index.ts
+++ b/packages/cli/src/cli/index.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { Command } from "commander";
 import { runCommand } from "./run.js";
 import { lsCommand } from "./ls.js";
@@ -6,12 +9,40 @@ import { importCommand } from "./import.js";
 import { upCommand } from "./up.js";
 import { cpCommand, cpClearCommand } from "./cp.js";
 
-const CLI_VERSION = "5.0.0";
+/**
+ * Read the CLI's own version from its package.json so `--version` always tracks
+ * the published package and can never drift (see #153). Walks up from this
+ * module's directory to the nearest package.json, which works identically from
+ * source (tests/dev) and from the compiled `dist/` layout.
+ */
+function readPackageVersion(): string {
+  let dir = dirname(fileURLToPath(import.meta.url));
+
+  for (;;) {
+    try {
+      const pkg = JSON.parse(readFileSync(join(dir, "package.json"), "utf8")) as {
+        name?: string;
+        version?: string;
+      };
+      if (pkg.name === "keyshelf" && pkg.version) {
+        return pkg.version;
+      }
+    } catch {
+      // No package.json at this level; keep walking up.
+    }
+
+    const parent = dirname(dir);
+    if (parent === dir) {
+      throw new Error("keyshelf: unable to locate package.json to resolve CLI version");
+    }
+    dir = parent;
+  }
+}
 
 export function createProgram(): Command {
   const program = new Command("keyshelf")
     .description("Keyshelf — config and secrets management for monorepos")
-    .version(CLI_VERSION);
+    .version(readPackageVersion());
 
   program.addCommand(runCommand);
   program.addCommand(lsCommand);

--- a/packages/cli/test/unit/version.test.ts
+++ b/packages/cli/test/unit/version.test.ts
@@ -1,0 +1,21 @@
+import { createRequire } from "node:module";
+import { describe, expect, it } from "vitest";
+import { createProgram } from "../../src/index.js";
+
+const require = createRequire(import.meta.url);
+const pkg = require("../../package.json") as { version: string };
+
+describe("CLI --version", () => {
+  it("reports the version from the package's own package.json", () => {
+    const program = createProgram();
+    expect(program.version()).toBe(pkg.version);
+  });
+
+  it("does not report a stale hardcoded version", () => {
+    const program = createProgram();
+    // Regression guard for #153: the CLI used to hardcode "5.0.0" while the
+    // package was 5.3.0. The version must always track package.json.
+    expect(program.version()).toBe(pkg.version);
+    expect(pkg.version).not.toBe("");
+  });
+});


### PR DESCRIPTION
Closes #153

## Root cause
`packages/cli/src/cli/index.ts` carried a hardcoded `const CLI_VERSION = "5.0.0"` that was passed to commander's `.version()`. The release tooling bumps `package.json` but never touched this literal, so it silently rotted: the package shipped at 5.3.0 while `keyshelf --version` still printed `5.0.0`.

## Fix
Derive the version from the package's own `package.json` instead of a literal, so it can never drift again. A small `readPackageVersion()` helper walks up from the module's directory (`import.meta.url`) to the nearest `package.json` named `keyshelf` and returns its `version`.

Why the upward-walk over a fixed relative path or a JSON import:
- tsup runs with `bundle: false`, so sources compile 1:1 into `dist/` and the compiled `dist/src/cli/index.js` sits at a different depth from package.json than the `src/cli/index.ts` used by tests/dev. A fixed relative path would resolve differently in each. Walking up to the nearest `keyshelf` package.json works identically from source, dist, and the published tarball.
- The `name === "keyshelf"` guard skips any intermediate dependency `package.json`, so it always picks up the CLI's own.

I deliberately did **not** just bump the literal to `5.3.0` — that would re-rot on the next release. Single source of truth is `package.json`.

## Regression test
`packages/cli/test/unit/version.test.ts` asserts the CLI's reported version (`program.version()`) equals the version read from its `package.json`. Written red-first (failed `5.0.0` vs `5.3.0`), now green. A future stale literal would fail this test.

## Verification
- Before: `node packages/cli/dist/bin/keyshelf.js --version` → `5.0.0`
- After (rebuilt): `--version` → `5.3.0`
- `packages/action/dist` rebuilt — unchanged (the action bundle does not embed the CLI version), so the CI "dist up to date" check passes.
- Full local suite green: `lint`, `format:check`, `typecheck`, `typecheck:examples`, `test` (336 tests across cli + migrate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)