### PR TITLE
ci: bump GitHub Actions off deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/action-smoke.yml
+++ b/.github/workflows/action-smoke.yml
@@ -10,9 +10,9 @@ jobs:
   smoke:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: npm
@@ -119,9 +119,9 @@ jobs:
   runtime-deps-benchmark:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
 
@@ -140,11 +140,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout (acts as action source at a separate path)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: action-source
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: npm
@@ -51,7 +51,7 @@ jobs:
     outputs:
       keyshelf_release_created: ${{ steps.release.outputs['packages/cli--release_created'] }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         id: release
         with:
           config-file: release-please-config.json
@@ -64,9 +64,9 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/fallow.yml
+++ b/.github/workflows/fallow.yml
@@ -13,7 +13,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary

GitHub forces Node 20 JS actions to Node 24 on 2026-06-16 and removes Node 20 from runners on 2026-09-16. Our workflows emit "Node.js 20 actions are deprecated" annotations on every run. This bumps the affected actions to Node 24 versions.

## Changes

- `actions/checkout@v4` → `@v5` (Node 24) — all occurrences in `ci.yml`, `action-smoke.yml`, `fallow.yml`
- `actions/setup-node@v4` → `@v5` (Node 24) — all occurrences in `ci.yml`, `action-smoke.yml`
- `googleapis/release-please-action@v4` → `@v5`

### release-please decision: bumped to v5

Verified `v5.0.0` (released 2026-04-22) declares `using: 'node24'` in its `action.yml` (v4 was `node20`), so it was bumped rather than left pinned.

Job structure, gating, and triggers are unchanged — only `@v4` → `@v5` version bumps. The `node-version: 20` inputs are the project's runtime Node version (what setup-node installs), unrelated to the actions runtime, and left as-is.

Closes #158