### PR TITLE
feat: env applicability derived from values (N/A exclusion)

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -365,7 +365,7 @@ the config. The other commands are helpers around it:
 config is hand-edited; `up` is what propagates structural changes (renames,
 deletions) into storage.
 
-#### `ls` visibility and env applicability
+### `ls` visibility and env applicability
 
 Plain `keyshelf ls` (no `--env`) lists the **full schema** — every declared
 key, including env-scoped ones. Once an env is active (`ls --env`,

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -283,10 +283,23 @@ above are pinned.
 
 For each declared key, given an active `envName`:
 
+0. **Applicability (N/A exclusion).** If the key is **env-scoped** — it has at
+   least one `values` entry and **no** `value`/`default` fallback — and
+   `envName` is **not** among its `values` keys, the key is **not applicable**
+   to this env. It is excluded from the env's universe entirely: not resolved,
+   not listed, never an error (no required-key failure, no `optional` skip, no
+   count). A key with a fallback applies to every env and is never excluded
+   here. This step only runs when an env is active; with no `--env` the full
+   schema is in scope. See
+   [ADR-0001](adr/0001-env-applicability-derived-from-values.md).
 1. If `values[envName]` is set → use that binding.
 2. Else if `value` or `default` is set → use that binding.
 3. Else if the key is `optional` → skip (resolver returns `undefined`).
 4. Else → resolver raises a required-key error.
+
+Step 0 is the env-driven analog of the reachability (`roots`) exclusion: an
+applicable key that fails to resolve still FAILs (rot is preserved); only a key
+the active env does **not** apply to is silently dropped.
 
 For a binding that is a `ProviderRef`, the resolver invokes the provider with
 a `ProviderContext` (Phase 4 shape) and uses the returned string.
@@ -351,6 +364,16 @@ the config. The other commands are helpers around it:
 `set` and `import` only write values — they never edit the config. The
 config is hand-edited; `up` is what propagates structural changes (renames,
 deletions) into storage.
+
+#### `ls` visibility and env applicability
+
+Plain `keyshelf ls` (no `--env`) lists the **full schema** — every declared
+key, including env-scoped ones. Once an env is active (`ls --env`,
+`ls --reveal`, `ls --check`, and likewise `run`), env-scoped keys that are
+**N/A** to that env (step 0 above) are dropped from the output entirely: no
+row, no `(missing)` marker, no SKIP line, no FAIL. They simply do not exist in
+that env's universe. See
+[ADR-0001](adr/0001-env-applicability-derived-from-values.md).
 
 ### Renaming a key
 

--- a/packages/action/dist/emit-env.mjs
+++ b/packages/action/dist/emit-env.mjs
@@ -2753,7 +2753,8 @@ function checkTopLevel(options) {
     options.config,
     options.groups,
     options.filters,
-    computeReachable(options.config, options.roots)
+    computeReachable(options.config, options.roots),
+    options.envName
   );
   const envRequiredError = checkEnvProvidedWhenRequired(selected, options.envName);
   if (envRequiredError !== void 0) return [envRequiredError];
@@ -2774,7 +2775,8 @@ async function resolveWithStatus(options) {
     options.config,
     options.groups,
     options.filters,
-    computeReachable(options.config, options.roots)
+    computeReachable(options.config, options.roots),
+    options.envName
   );
   assertEnvProvidedWhenRequired(selected, options.envName);
   const selectedByPath = new Map(
@@ -2846,12 +2848,15 @@ function renderAppMapping(mappings, resolution) {
     };
   });
 }
-function selectRecords(config2, groups2, filters2, reachable) {
+function selectRecords(config2, groups2, filters2, reachable, envName2) {
   const groupSet = normalizeGroupFilter(config2, groups2);
   const activeGroups = [...groupSet];
   const pathPrefixes = normalizePathFilters(filters2);
   return config2.keys.map((record) => {
     if (reachable !== void 0 && !reachable.has(record.path)) {
+      return { record, selected: false };
+    }
+    if (envName2 !== void 0 && isNotApplicable(record, envName2)) {
       return { record, selected: false };
     }
     if (isExcludedByGroup(record, groupSet)) {
@@ -2962,6 +2967,9 @@ function checkEnvProvidedWhenRequired(selected, envName2) {
 }
 function hasValuesWithoutFallback(record) {
   return record.value === void 0 && Object.keys(record.values ?? {}).length > 0;
+}
+function isNotApplicable(record, envName2) {
+  return hasValuesWithoutFallback(record) && !Object.hasOwn(record.values ?? {}, envName2);
 }
 async function resolveSelectedRecord(record, options, resolveRecord) {
   const binding = getActiveBinding(record, options.envName);

--- a/packages/cli/src/cli/ls.ts
+++ b/packages/cli/src/cli/ls.ts
@@ -201,36 +201,40 @@ function buildSchemaRows(
   const groupSet = groups ? new Set(groups) : undefined;
   const filterPrefixes = filters ?? [];
 
-  return records
-    // When an env is active, env-scoped keys N/A to it are excluded from the
-    // env's universe (no row) — matching the resolver's selection-phase drop.
-    // Plain `ls` (no env) lists the full schema.
-    .filter((record) => envName === undefined || !isNotApplicable(record, envName))
-    .map((record): KeyRow => {
-      const filtered = isFiltered(record, groupSet, filterPrefixes);
-      return {
-        path: record.path,
-        kind: record.kind,
-        group: record.group ?? "",
-        detail: filtered ? "(filtered)" : describeSource(record, envName)
-      };
-    });
+  return (
+    records
+      // When an env is active, env-scoped keys N/A to it are excluded from the
+      // env's universe (no row) — matching the resolver's selection-phase drop.
+      // Plain `ls` (no env) lists the full schema.
+      .filter((record) => envName === undefined || !isNotApplicable(record, envName))
+      .map((record): KeyRow => {
+        const filtered = isFiltered(record, groupSet, filterPrefixes);
+        return {
+          path: record.path,
+          kind: record.kind,
+          group: record.group ?? "",
+          detail: filtered ? "(filtered)" : describeSource(record, envName)
+        };
+      })
+  );
 }
 
 function buildRevealedRows(records: NormalizedRecord[], resolution: Resolution): KeyRow[] {
-  return records
-    // N/A env-scoped keys carry no resolution status (the resolver never
-    // selected them); drop them so they don't render as "(missing)".
-    .filter((record) => resolution.statusByPath.has(record.path))
-    .map((record): KeyRow => {
-      const status = resolution.statusByPath.get(record.path);
-      return {
-        path: record.path,
-        kind: record.kind,
-        group: record.group ?? "",
-        detail: describeStatus(record, status)
-      };
-    });
+  return (
+    records
+      // N/A env-scoped keys carry no resolution status (the resolver never
+      // selected them); drop them so they don't render as "(missing)".
+      .filter((record) => resolution.statusByPath.has(record.path))
+      .map((record): KeyRow => {
+        const status = resolution.statusByPath.get(record.path);
+        return {
+          path: record.path,
+          kind: record.kind,
+          group: record.group ?? "",
+          detail: describeStatus(record, status)
+        };
+      })
+  );
 }
 
 function describeStatus(record: NormalizedRecord, status: KeyResolutionStatus | undefined): string {

--- a/packages/cli/src/cli/ls.ts
+++ b/packages/cli/src/cli/ls.ts
@@ -1,6 +1,11 @@
 import { Command } from "commander";
 import { loadConfig } from "../config/index.js";
-import { formatSkipCause, renderAppMapping, resolveValidated } from "../resolver/index.js";
+import {
+  formatSkipCause,
+  isNotApplicable,
+  renderAppMapping,
+  resolveValidated
+} from "../resolver/index.js";
 import { createDefaultRegistry } from "../providers/setup.js";
 import { splitList } from "./options.js";
 import { assertValidationPasses } from "./validation.js";
@@ -196,27 +201,36 @@ function buildSchemaRows(
   const groupSet = groups ? new Set(groups) : undefined;
   const filterPrefixes = filters ?? [];
 
-  return records.map((record): KeyRow => {
-    const filtered = isFiltered(record, groupSet, filterPrefixes);
-    return {
-      path: record.path,
-      kind: record.kind,
-      group: record.group ?? "",
-      detail: filtered ? "(filtered)" : describeSource(record, envName)
-    };
-  });
+  return records
+    // When an env is active, env-scoped keys N/A to it are excluded from the
+    // env's universe (no row) — matching the resolver's selection-phase drop.
+    // Plain `ls` (no env) lists the full schema.
+    .filter((record) => envName === undefined || !isNotApplicable(record, envName))
+    .map((record): KeyRow => {
+      const filtered = isFiltered(record, groupSet, filterPrefixes);
+      return {
+        path: record.path,
+        kind: record.kind,
+        group: record.group ?? "",
+        detail: filtered ? "(filtered)" : describeSource(record, envName)
+      };
+    });
 }
 
 function buildRevealedRows(records: NormalizedRecord[], resolution: Resolution): KeyRow[] {
-  return records.map((record): KeyRow => {
-    const status = resolution.statusByPath.get(record.path);
-    return {
-      path: record.path,
-      kind: record.kind,
-      group: record.group ?? "",
-      detail: describeStatus(record, status)
-    };
-  });
+  return records
+    // N/A env-scoped keys carry no resolution status (the resolver never
+    // selected them); drop them so they don't render as "(missing)".
+    .filter((record) => resolution.statusByPath.has(record.path))
+    .map((record): KeyRow => {
+      const status = resolution.statusByPath.get(record.path);
+      return {
+        path: record.path,
+        kind: record.kind,
+        group: record.group ?? "",
+        detail: describeStatus(record, status)
+      };
+    });
 }
 
 function describeStatus(record: NormalizedRecord, status: KeyResolutionStatus | undefined): string {

--- a/packages/cli/src/resolver/index.ts
+++ b/packages/cli/src/resolver/index.ts
@@ -386,7 +386,9 @@ function hasValuesWithoutFallback(record: NormalizedRecord): boolean {
 
 // An env-scoped key (values, no fallback) is N/A in any active env not named in
 // its `values` map. A key with a fallback applies to every env and is never N/A.
-function isNotApplicable(record: NormalizedRecord, envName: string): boolean {
+// Exported so `ls` can drop N/A keys from its rows when an env is active,
+// matching the resolver's selection-phase exclusion.
+export function isNotApplicable(record: NormalizedRecord, envName: string): boolean {
   return hasValuesWithoutFallback(record) && !Object.hasOwn(record.values ?? {}, envName);
 }
 

--- a/packages/cli/src/resolver/index.ts
+++ b/packages/cli/src/resolver/index.ts
@@ -80,7 +80,8 @@ function checkTopLevel(options: ResolveOptions): TopLevelError[] {
     options.config,
     options.groups,
     options.filters,
-    computeReachable(options.config, options.roots)
+    computeReachable(options.config, options.roots),
+    options.envName
   );
   const envRequiredError = checkEnvProvidedWhenRequired(selected, options.envName);
   if (envRequiredError !== undefined) return [envRequiredError];
@@ -106,7 +107,8 @@ export async function resolveWithStatus(options: ResolveOptions): Promise<Resolu
     options.config,
     options.groups,
     options.filters,
-    computeReachable(options.config, options.roots)
+    computeReachable(options.config, options.roots),
+    options.envName
   );
   assertEnvProvidedWhenRequired(selected, options.envName);
 
@@ -201,7 +203,8 @@ function selectRecords(
   config: NormalizedConfig,
   groups: string[] | undefined,
   filters: string[] | undefined,
-  reachable: Set<string> | undefined
+  reachable: Set<string> | undefined,
+  envName: string | undefined
 ): SelectedRecord[] {
   const groupSet = normalizeGroupFilter(config, groups);
   const activeGroups = [...groupSet];
@@ -212,6 +215,15 @@ function selectRecords(
     // no cause means no resolution status, so it never resolves and never
     // surfaces a validation error or skip warning.
     if (reachable !== undefined && !reachable.has(record.path)) {
+      return { record, selected: false };
+    }
+    // N/A: an env-scoped key (values, no fallback) whose `values` has no entry
+    // for the active env. The binding's *absence* is the assertion "this key
+    // does not apply here," so it is excluded from the env's universe — same
+    // silent drop as out-of-scope (no cause => no status, no SKIP, no error).
+    // Only an active env can make a key N/A; with no --env the full schema is
+    // in scope (and an env-scoped key without --env is a top-level error).
+    if (envName !== undefined && isNotApplicable(record, envName)) {
       return { record, selected: false };
     }
     if (isExcludedByGroup(record, groupSet)) {
@@ -370,6 +382,12 @@ function checkEnvProvidedWhenRequired(
 
 function hasValuesWithoutFallback(record: NormalizedRecord): boolean {
   return record.value === undefined && Object.keys(record.values ?? {}).length > 0;
+}
+
+// An env-scoped key (values, no fallback) is N/A in any active env not named in
+// its `values` map. A key with a fallback applies to every env and is never N/A.
+function isNotApplicable(record: NormalizedRecord, envName: string): boolean {
+  return hasValuesWithoutFallback(record) && !Object.hasOwn(record.values ?? {}, envName);
 }
 
 async function resolveSelectedRecord(

--- a/packages/cli/test/e2e/ls-check.test.ts
+++ b/packages/cli/test/e2e/ls-check.test.ts
@@ -162,6 +162,49 @@ describe("keyshelf ls --check (unseeded)", () => {
   );
 });
 
+// Env-scoped + optional composition under the exhaustive sweep.
+describe("keyshelf ls --check (env-scoped + optional)", () => {
+  let root: string;
+
+  beforeAll(async () => {
+    const { identityFile, secretsDir } = await setupAgeFixtureDir(
+      (root = await mkdtemp(join(tmpdir(), "keyshelf-ls-check-envscope-")))
+    );
+    const age = `age({ identityFile: ${JSON.stringify(identityFile)}, secretsDir: ${JSON.stringify(secretsDir)} })`;
+    await writeKeyshelfConfig(root, [
+      `name: "demo",`,
+      `envs: ["dev", "production"],`,
+      `keys: {`,
+      `  base: config({ default: "ok" }),`,
+      // env-scoped + optional: production-only binding, no fallback.
+      `  prodOptional: secret({ optional: true, values: { production: ${age} } }),`,
+      `},`
+    ]);
+    await writeEnvKeyshelf(root, ["BASE=base"]);
+  }, SPAWN_TIMEOUT);
+
+  it(
+    "is N/A (excluded, not even a SKIP line) in a non-applicable env",
+    () => {
+      const result = runCheck(["--env", "dev"], root);
+      expect(result.status).toBe(0);
+      expect(result.stdout + result.stderr).not.toContain("prodOptional");
+    },
+    SPAWN_TIMEOUT
+  );
+
+  it(
+    "is tolerated as an optional SKIP in its applicable env when unseeded",
+    () => {
+      // production ∈ values → applicable; unseeded provider → optional skip, sweep OK.
+      const result = runCheck(["--env", "production"], root);
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain("SKIP prodOptional");
+    },
+    SPAWN_TIMEOUT
+  );
+});
+
 // A failing sweep must never print a seeded secret's value. Kept separate
 // because it seeds a value we then assert is absent from output.
 describe("keyshelf ls --check (no value leak)", () => {

--- a/packages/cli/test/e2e/ls-check.test.ts
+++ b/packages/cli/test/e2e/ls-check.test.ts
@@ -96,16 +96,15 @@ describe("keyshelf ls --check (seeded)", () => {
   );
 
   it(
-    "distinguishes no binding for env from a provider error",
+    "excludes an env-scoped key from an env outside its values (N/A)",
     () => {
-      // Secrets are envless storage, so seeding for dev satisfies production
-      // too. What stays unresolvable for production is apiUrl: required,
-      // dev-only binding, no fallback => "no value for required key" (a binding
-      // gap, not a provider error).
+      // apiUrl is env-scoped (dev-only binding, no fallback), so it is N/A in
+      // production: excluded from the sweep entirely — no FAIL, no SKIP line,
+      // never even mentioned. Secrets are envless storage seeded for dev, which
+      // satisfies production too, so the whole sweep passes.
       const result = runCheck(["--env", "production"], root);
-      expect(result.status).not.toBe(0);
-      expect(result.stderr).toContain("apiUrl");
-      expect(result.stderr.toLowerCase()).toMatch(/no value|required/);
+      expect(result.status).toBe(0);
+      expect(result.stdout + result.stderr).not.toContain("apiUrl");
     },
     SPAWN_TIMEOUT
   );

--- a/packages/cli/test/e2e/ls.test.ts
+++ b/packages/cli/test/e2e/ls.test.ts
@@ -25,6 +25,22 @@ async function writeAgeFixture(root: string) {
   await writeEnvKeyshelf(root, ["DB_HOST=db/host", "DB_PASSWORD=db/password", "CI_TOKEN=ci/token"]);
 }
 
+// Adds an env-scoped config key (production-only binding, no fallback) so we can
+// assert it vanishes from a dev `ls` but lists under plain `ls`.
+async function writeEnvScopedFixture(root: string) {
+  const { identityFile, secretsDir } = await setupAgeFixtureDir(root);
+  await writeKeyshelfConfig(root, [
+    `name: "demo",`,
+    `envs: ["dev", "production"],`,
+    `keys: {`,
+    `  always: config({ default: "localhost" }),`,
+    `  prodOnly: config({ values: { production: "prod-url" } }),`,
+    `  prodSecret: secret({ values: { production: age({ identityFile: ${JSON.stringify(identityFile)}, secretsDir: ${JSON.stringify(secretsDir)} }) } }),`,
+    `},`
+  ]);
+  await writeEnvKeyshelf(root, ["ALWAYS=always"]);
+}
+
 describe("keyshelf-next ls", () => {
   let root: string;
 
@@ -116,5 +132,51 @@ describe("keyshelf-next ls (reveal)", () => {
         { envVar: "CI_TOKEN", keyPath: "ci/token", value: "ci-pw", secret: true }
       ]
     });
+  });
+});
+
+describe("keyshelf ls (env-scoped key applicability)", () => {
+  let root: string;
+
+  beforeAll(async () => {
+    root = await mkdtemp(join(tmpdir(), "keyshelf-ls-envscope-"));
+    await writeEnvScopedFixture(root);
+  });
+
+  it("plain ls (no --env) lists every declared key, including env-scoped ones", () => {
+    const result = execFileSync(TSX, [CLI, "ls"], { cwd: root, encoding: "utf-8" });
+    expect(result).toContain("always");
+    expect(result).toContain("prodOnly");
+    expect(result).toContain("prodSecret");
+  });
+
+  it("ls --env dev drops env-scoped keys that are N/A in dev", () => {
+    const result = execFileSync(TSX, [CLI, "ls", "--env", "dev"], { cwd: root, encoding: "utf-8" });
+    expect(result).toContain("always");
+    expect(result).not.toContain("prodOnly");
+    expect(result).not.toContain("prodSecret");
+    // and never renders them as missing
+    expect(result).not.toContain("(missing)");
+  });
+
+  it("ls --env production lists env-scoped keys applicable to production", () => {
+    const result = execFileSync(TSX, [CLI, "ls", "--env", "production"], {
+      cwd: root,
+      encoding: "utf-8"
+    });
+    expect(result).toContain("prodOnly");
+    expect(result).toContain("prodSecret");
+  });
+
+  it("ls --reveal --env dev drops N/A env-scoped keys (no (missing) rows)", () => {
+    const result = execFileSync(TSX, [CLI, "ls", "--reveal", "--env", "dev"], {
+      cwd: root,
+      encoding: "utf-8",
+      stdio: ["inherit", "pipe", "pipe"]
+    });
+    expect(result).toContain("always");
+    expect(result).not.toContain("prodOnly");
+    expect(result).not.toContain("prodSecret");
+    expect(result).not.toContain("(missing)");
   });
 });

--- a/packages/cli/test/e2e/run.test.ts
+++ b/packages/cli/test/e2e/run.test.ts
@@ -210,3 +210,53 @@ describe("keyshelf-next run (scoped to app mapping)", () => {
     expect(result.stderr).toContain("b");
   });
 });
+
+describe("keyshelf-next run (env-scoped key applicability)", () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "keyshelf-run-envscope-"));
+    // prodUrl is env-scoped (production-only binding, no fallback). Mapped to an
+    // env var so we can observe whether `run` resolves it per active env.
+    await writeKeyshelfConfig(root, [
+      `name: "demo",`,
+      `envs: ["dev", "production"],`,
+      `keys: {`,
+      `  always: config({ value: "alpha" }),`,
+      `  prodUrl: config({ values: { production: "prod-url" } }),`,
+      `},`
+    ]);
+    await writeEnvKeyshelf(root, ["ALWAYS=always", "PROD_URL=prodUrl"]);
+  });
+
+  it("excludes an N/A env-scoped key in dev: succeeds, injects no value, no error", () => {
+    const result = spawnSync(
+      TSX,
+      [
+        CLI,
+        "run",
+        "--env",
+        "dev",
+        "--",
+        "node",
+        "-e",
+        "console.log(JSON.stringify({a: process.env.ALWAYS ?? null, p: process.env.PROD_URL ?? null}))"
+      ],
+      { cwd: root, encoding: "utf-8" }
+    );
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout.trim())).toEqual({ a: "alpha", p: null });
+    // N/A keys are not errors and not the loud "no value for required key" path.
+    expect(result.stderr).not.toMatch(/no value for required key/i);
+  });
+
+  it("resolves the env-scoped key in its applicable env (production)", () => {
+    const result = spawnSync(
+      TSX,
+      [CLI, "run", "--env", "production", "--", "node", "-e", "console.log(process.env.PROD_URL)"],
+      { cwd: root, encoding: "utf-8" }
+    );
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe("prod-url");
+  });
+});

--- a/packages/cli/test/unit/resolver.test.ts
+++ b/packages/cli/test/unit/resolver.test.ts
@@ -69,13 +69,21 @@ describe("resolver", () => {
   });
 
   it("reports required missing keys and skips optional keys with no active binding", async () => {
+    // A secret applicable to dev (envless storage) that the provider can't find
+    // → required FAILs, optional SKIPs. Both keys apply to dev (no env-scoping),
+    // so neither is N/A — this exercises the missing-binding paths, not exclusion.
+    const notFound = mockProvider("age", "");
+    (notFound.resolve as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("NOT_FOUND"));
     const normalized = normalizeConfig(
       defineConfig({
         name: "test",
         envs: ["dev", "production"],
         keys: {
-          required: config({ values: { production: "prod" } }),
-          optional: config({ optional: true, values: { production: "prod" } })
+          required: secret({ value: age({ identityFile: "./a.txt", secretsDir: "./s" }) }),
+          optional: secret({
+            optional: true,
+            value: age({ identityFile: "./a.txt", secretsDir: "./s" })
+          })
         }
       })
     );
@@ -84,28 +92,23 @@ describe("resolver", () => {
       config: normalized,
       envName: "dev",
       rootDir: "/repo",
-      registry: registry()
+      registry: registry(notFound)
     });
 
     expect(result).toMatchObject({
       topLevelErrors: [],
-      keyErrors: [
-        {
-          path: "required",
-          message: 'No value for required key "required"'
-        }
-      ]
+      keyErrors: [expect.objectContaining({ path: "required" })]
     });
 
     const resolution = await resolveWithStatus({
       config: normalized,
       envName: "dev",
       rootDir: "/repo",
-      registry: registry()
+      registry: registry(notFound)
     });
     expect(resolution.statusByPath.get("optional")).toMatchObject({
       status: "skipped",
-      cause: { type: "optional-no-value" }
+      cause: { type: "optional-not-found" }
     });
   });
 
@@ -583,12 +586,16 @@ describe("scoped resolution (roots)", () => {
   });
 
   it("fails loudly when a mapped required key is unresolvable in the active env", async () => {
+    // `a` is a secret bound for dev (envless storage) that the provider can't
+    // find: applicable to dev but unresolvable → FAIL, not silent exclusion.
+    const notFound = mockProvider("age", "");
+    (notFound.resolve as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("NOT_FOUND"));
     const normalized = normalizeConfig(
       defineConfig({
         name: "test",
         envs: ["dev", "production"],
         keys: {
-          a: config({ values: { production: "prod-only" } }),
+          a: secret({ values: { dev: age({ identityFile: "./a.txt", secretsDir: "./s" }) } }),
           b: config({ value: "always" })
         }
       })
@@ -598,7 +605,7 @@ describe("scoped resolution (roots)", () => {
       config: normalized,
       envName: "dev",
       rootDir: "/repo",
-      registry: registry(),
+      registry: registry(notFound),
       roots: ["a"]
     });
 
@@ -712,5 +719,174 @@ describe("scoped resolution (roots)", () => {
     // a resolves; b is in scope (mapped) but filtered out by --group.
     expect(resolution.statusByPath.get("a")?.status).toBe("resolved");
     expect(resolution.statusByPath.get("b")?.status).toBe("filtered");
+  });
+});
+
+describe("env applicability (N/A exclusion)", () => {
+  it("excludes an env-scoped key from a non-applicable active env", async () => {
+    const provider = mockProvider("age", "prod-secret");
+    const normalized = normalizeConfig(
+      defineConfig({
+        name: "test",
+        envs: ["staging", "production"],
+        keys: {
+          always: config({ value: "always" }),
+          // Env-scoped: values for production only, no fallback. N/A in staging.
+          prodOnly: secret({
+            values: { production: age({ identityFile: "./p.txt", secretsDir: "./s" }) }
+          })
+        }
+      })
+    );
+
+    const result = await resolveValidated({
+      config: normalized,
+      envName: "staging",
+      rootDir: "/repo",
+      registry: registry(provider)
+    });
+
+    expect(result.topLevelErrors).toEqual([]);
+    expect(result.keyErrors).toEqual([]);
+    // prodOnly is excluded entirely: no status, no resolution, no error.
+    expect(result.resolution?.statusByPath.has("prodOnly")).toBe(false);
+    expect(result.resolution?.resolved).toEqual([{ path: "always", value: "always" }]);
+    expect(provider.resolve).not.toHaveBeenCalled();
+  });
+
+  it("includes and resolves an env-scoped key in an applicable active env", async () => {
+    const provider = mockProvider("age", "prod-secret");
+    const normalized = normalizeConfig(
+      defineConfig({
+        name: "test",
+        envs: ["staging", "production"],
+        keys: {
+          prodOnly: secret({
+            values: { production: age({ identityFile: "./p.txt", secretsDir: "./s" }) }
+          })
+        }
+      })
+    );
+
+    const result = await resolveValidated({
+      config: normalized,
+      envName: "production",
+      rootDir: "/repo",
+      registry: registry(provider)
+    });
+
+    expect(result.keyErrors).toEqual([]);
+    expect(result.resolution?.resolved).toEqual([{ path: "prodOnly", value: "prod-secret" }]);
+  });
+
+  it("still FAILs an applicable env-scoped key that does not resolve (rot preserved)", async () => {
+    // production ∈ values → applicable. A deleted/unseeded binding for an
+    // applicable env still fails: the secret has no seeded value.
+    const provider = mockProvider("age", "");
+    (provider.resolve as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("NOT_FOUND"));
+    const normalized = normalizeConfig(
+      defineConfig({
+        name: "test",
+        envs: ["staging", "production"],
+        keys: {
+          prodOnly: secret({
+            values: { production: age({ identityFile: "./p.txt", secretsDir: "./s" }) }
+          })
+        }
+      })
+    );
+
+    const result = await resolveValidated({
+      config: normalized,
+      envName: "production",
+      rootDir: "/repo",
+      registry: registry(provider)
+    });
+
+    expect(result.keyErrors).toEqual([expect.objectContaining({ path: "prodOnly" })]);
+  });
+
+  it("never excludes a key with a fallback (applies to all envs)", async () => {
+    const normalized = normalizeConfig(
+      defineConfig({
+        name: "test",
+        envs: ["staging", "production"],
+        keys: {
+          // Has a fallback default plus a production override → applies everywhere.
+          withFallback: config({ default: "fb", values: { production: "p" } })
+        }
+      })
+    );
+
+    const result = await resolveValidated({
+      config: normalized,
+      envName: "staging",
+      rootDir: "/repo",
+      registry: registry()
+    });
+
+    expect(result.keyErrors).toEqual([]);
+    expect(result.resolution?.resolved).toEqual([{ path: "withFallback", value: "fb" }]);
+  });
+
+  it("composes with optional: N/A in non-applicable env, tolerant in applicable env", async () => {
+    const provider = mockProvider("age", "ok");
+    // N/A: env-scoped + optional, staging active, staging ∉ values → excluded.
+    const naConfig = normalizeConfig(
+      defineConfig({
+        name: "test",
+        envs: ["staging", "production"],
+        keys: {
+          optProd: secret({
+            optional: true,
+            values: { production: age({ identityFile: "./p.txt", secretsDir: "./s" }) }
+          })
+        }
+      })
+    );
+    const naResult = await resolveValidated({
+      config: naConfig,
+      envName: "staging",
+      rootDir: "/repo",
+      registry: registry(provider)
+    });
+    expect(naResult.resolution?.statusByPath.has("optProd")).toBe(false);
+
+    // Applicable: production active, not-found from provider → skipped, not failed.
+    const notFound = mockProvider("age", "");
+    (notFound.resolve as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("NOT_FOUND"));
+    const applicableResult = await resolveValidated({
+      config: naConfig,
+      envName: "production",
+      rootDir: "/repo",
+      registry: registry(notFound)
+    });
+    expect(applicableResult.keyErrors).toEqual([]);
+    expect(applicableResult.resolution?.statusByPath.get("optProd")?.status).toBe("skipped");
+  });
+
+  it("does not exclude env-scoped keys when no env is active (full schema in scope)", async () => {
+    const normalized = normalizeConfig(
+      defineConfig({
+        name: "test",
+        envs: ["staging", "production"],
+        keys: {
+          always: config({ value: "always" }),
+          prodOnly: config({ values: { production: "p" } })
+        }
+      })
+    );
+
+    // No envName: an env-scoped key without --env is a top-level error today,
+    // so the exclusion must NOT kick in here — the key stays in scope.
+    const result = await resolveValidated({
+      config: normalized,
+      rootDir: "/repo",
+      registry: registry()
+    });
+
+    expect(result.topLevelErrors).toEqual([
+      expect.objectContaining({ message: expect.stringContaining("--env is required") })
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

A key's `values` map *is* its env-applicability declaration. An **env-scoped key** (≥1 `values` entry AND no `value`/`default` fallback) is now **N/A** in any active env outside its `values` keys: when `--env X` is active and X ∉ values, the key is **excluded from X's universe** — not selected, not resolved, not listed, never an error — across `run`, `ls --env`, `ls --reveal`, and `ls --check`. Plain `ls` (no `--env`) still lists the full schema. Keys with a fallback apply to all envs (unchanged). An applicable key that fails to resolve still **FAILs** (rot preserved). `optional` stays orthogonal. No new config field.

Implements the decided design in ADR-0001.

## Changes

- **`resolver/index.ts`**: `selectRecords` now drops env-scoped keys N/A to the active env (`{ selected: false }`, no cause), mirroring the reachability (`roots`) exclusion. New exported `isNotApplicable` predicate. Only excludes when an env is active.
- **`cli/ls.ts`**: `buildSchemaRows` (when `--env` active) and `buildRevealedRows` drop N/A keys so they don't render as `(missing)`. Plain `ls` unchanged.
- **`docs/spec.md`**: resolution order gains step 0 (applicability/N/A exclusion) and an `ls` visibility note, both referencing ADR-0001.

## Tests

- Resolver unit: exclusion in N/A env, inclusion in applicable env, rot still FAILs, fallback never N/A, optional composition, full-schema when no `--env`.
- e2e: env-scoped key excluded across `run`, `ls --env`, `ls --reveal`, `ls --check`; plain `ls` lists everything; env-scoped+optional SKIP in applicable env.
- Two pre-existing tests that asserted the overturned pre-ADR behavior were updated to the new semantics.

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)