### PR TITLE
feat(run): error on --map reference to an N/A key (ADR-0002)

### DIFF
--- a/packages/action/dist/emit-env.mjs
+++ b/packages/action/dist/emit-env.mjs
@@ -3056,13 +3056,13 @@ function skippedEnvVar(envVar, mapping, keyPath, resolution) {
     envVar,
     status: "skipped",
     keyPath,
-    cause: statusToSkipCause(status),
+    cause: statusToSkipCause(status, keyPath),
     mapping
   };
 }
-function statusToSkipCause(status) {
+function statusToSkipCause(status, keyPath) {
   if (status?.status === "filtered" || status?.status === "skipped") return status.cause;
-  return { type: "optional-no-value" };
+  throw new Error(`mapped key "${keyPath}" was not resolved and has no skip reason`);
 }
 var FilteredTemplateReferenceError = class extends Error {
   constructor(keyPath, reference, referenceCause) {

--- a/packages/cli/src/cli/run.ts
+++ b/packages/cli/src/cli/run.ts
@@ -2,7 +2,11 @@ import { Command } from "commander";
 import spawn from "cross-spawn";
 import { loadConfig } from "../config/index.js";
 import { isTemplateMapping, type AppMapping } from "../config/app-mapping.js";
-import { formatSkipCause, renderAppMapping } from "../resolver/index.js";
+import {
+  findNotApplicableMapReferences,
+  formatSkipCause,
+  renderAppMapping
+} from "../resolver/index.js";
 import { createDefaultRegistry } from "../providers/setup.js";
 import { splitList } from "./options.js";
 import { assertValidationPasses } from "./validation.js";
@@ -34,6 +38,20 @@ export const runCommand = new Command("run")
     const appDir = process.cwd();
     const loaded = await loadConfig(appDir, { mappingFile: opts.map });
     const registry = createDefaultRegistry();
+
+    // ADR-0002: a --map entry that names a key N/A in the active env is an
+    // error (the env does not have that key), not a silent drop or skip warning
+    // — the same posture as referencing a key that does not exist. Fail before
+    // resolving or spawning the subprocess.
+    const naReferences = findNotApplicableMapReferences(loaded.config, loaded.appMapping, opts.env);
+    if (naReferences.length > 0) {
+      for (const ref of naReferences) {
+        console.error(
+          `error: ${ref.envVar}: referenced key "${ref.keyPath}" does not exist in env "${ref.envName}"`
+        );
+      }
+      process.exit(1);
+    }
 
     const resolveOpts = {
       config: loaded.config,

--- a/packages/cli/src/resolver/index.ts
+++ b/packages/cli/src/resolver/index.ts
@@ -392,6 +392,42 @@ export function isNotApplicable(record: NormalizedRecord, envName: string): bool
   return hasValuesWithoutFallback(record) && !Object.hasOwn(record.values ?? {}, envName);
 }
 
+export interface NotApplicableMapReference {
+  envVar: string;
+  keyPath: string;
+  envName: string;
+}
+
+// An explicit `--map` entry that names a key which is N/A in the active env is
+// an error (ADR-0002): from the map's point of view the key is absent in this
+// env, exactly like a reference to a key that does not exist. This is the
+// opposite of bare-`run`'s env-driven sweep, where an unreferenced N/A key is
+// silently excluded. Returns one entry per offending (env var, key) pair so the
+// caller can fail before running the subprocess.
+export function findNotApplicableMapReferences(
+  config: NormalizedConfig,
+  mappings: AppMapping[],
+  envName: string | undefined
+): NotApplicableMapReference[] {
+  if (envName === undefined) return [];
+
+  const recordByPath = new Map(config.keys.map((record) => [record.path, record] as const));
+  const offenders: NotApplicableMapReference[] = [];
+
+  for (const mapping of mappings) {
+    const references = isTemplateMapping(mapping) ? mapping.keyPaths : [mapping.keyPath];
+    for (const keyPath of references) {
+      const record = recordByPath.get(keyPath);
+      // Unknown keys are already rejected at load time; only N/A applies here.
+      if (record !== undefined && isNotApplicable(record, envName)) {
+        offenders.push({ envVar: mapping.envVar, keyPath, envName });
+      }
+    }
+  }
+
+  return offenders;
+}
+
 async function resolveSelectedRecord(
   record: NormalizedRecord,
   options: ResolveOptions,
@@ -522,15 +558,19 @@ function skippedEnvVar(
     envVar,
     status: "skipped",
     keyPath,
-    cause: statusToSkipCause(status),
+    cause: statusToSkipCause(status, keyPath),
     mapping
   };
 }
 
-function statusToSkipCause(status: KeyResolutionStatus | undefined): SkipCause {
+function statusToSkipCause(status: KeyResolutionStatus | undefined, keyPath: string): SkipCause {
   if (status?.status === "filtered" || status?.status === "skipped") return status.cause;
-  // Defensive fallback — shouldn't be reached with a validated config.
-  return { type: "optional-no-value" };
+  // A mapped key with no skip status is unexpected: filters/optional produce a
+  // skip cause, and an N/A map reference is rejected upstream (ADR-0002) before
+  // rendering. Reaching here means the key neither resolved nor has a reason —
+  // surface it loudly rather than inventing a misleading "optional and has no
+  // value" cause (which previously masked N/A references).
+  throw new Error(`mapped key "${keyPath}" was not resolved and has no skip reason`);
 }
 
 class FilteredTemplateReferenceError extends Error {

--- a/packages/cli/test/e2e/run.test.ts
+++ b/packages/cli/test/e2e/run.test.ts
@@ -229,7 +229,39 @@ describe("keyshelf-next run (env-scoped key applicability)", () => {
     await writeEnvKeyshelf(root, ["ALWAYS=always", "PROD_URL=prodUrl"]);
   });
 
-  it("excludes an N/A env-scoped key in dev: succeeds, injects no value, no error", () => {
+  it("errors when a --map entry references a key that is N/A in the active env", () => {
+    // ADR-0002: a map entry naming an N/A key fails the run (non-zero exit, no
+    // subprocess) — the same posture as referencing a key that does not exist.
+    const result = spawnSync(
+      TSX,
+      [CLI, "run", "--env", "dev", "--", "node", "-e", "console.log('ran')"],
+      { cwd: root, encoding: "utf-8" }
+    );
+    expect(result.status).not.toBe(0);
+    expect(result.stdout).not.toContain("ran");
+    // Message names the env var, the key, and the env.
+    expect(result.stderr).toContain("PROD_URL");
+    expect(result.stderr).toContain("prodUrl");
+    expect(result.stderr).toContain("dev");
+    // It is an error, not the misleading "optional and has no value" skip line.
+    expect(result.stderr).not.toMatch(/optional/i);
+  });
+
+  it("resolves the env-scoped key in its applicable env (production)", () => {
+    const result = spawnSync(
+      TSX,
+      [CLI, "run", "--env", "production", "--", "node", "-e", "console.log(process.env.PROD_URL)"],
+      { cwd: root, encoding: "utf-8" }
+    );
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe("prod-url");
+  });
+
+  it("still silently excludes an N/A env-scoped key that the map does not reference", async () => {
+    // No env var maps prodUrl, so bare-run's env-driven sweep excludes it
+    // silently in dev — the "never an error" rule still holds for unreferenced
+    // N/A keys (ADR-0001).
+    await writeEnvKeyshelf(root, ["ALWAYS=always"]);
     const result = spawnSync(
       TSX,
       [
@@ -246,17 +278,7 @@ describe("keyshelf-next run (env-scoped key applicability)", () => {
     );
     expect(result.status).toBe(0);
     expect(JSON.parse(result.stdout.trim())).toEqual({ a: "alpha", p: null });
-    // N/A keys are not errors and not the loud "no value for required key" path.
+    expect(result.stderr).not.toMatch(/prodUrl/i);
     expect(result.stderr).not.toMatch(/no value for required key/i);
-  });
-
-  it("resolves the env-scoped key in its applicable env (production)", () => {
-    const result = spawnSync(
-      TSX,
-      [CLI, "run", "--env", "production", "--", "node", "-e", "console.log(process.env.PROD_URL)"],
-      { cwd: root, encoding: "utf-8" }
-    );
-    expect(result.status).toBe(0);
-    expect(result.stdout.trim()).toBe("prod-url");
   });
 });


### PR DESCRIPTION
Closes #163

## What changed

Per [ADR-0002](https://github.com/pantoninho/keyshelf/blob/main/docs/adr/0002-map-reference-to-na-key-is-an-error.md), a `keyshelf run --map` entry that references a key which is **N/A in the active env** (an env-scoped key whose `values` map does not name the active env, with no fallback binding) now **fails the run** with a non-zero exit and does **not** spawn the subprocess.

This is the opposite of the original #163 proposal (reword the skip warning). From the map's point of view an N/A key is effectively absent, so referencing it is an error — the same posture as referencing a key that does not exist at all. The misleading `is optional and has no value` skip line is no longer produced for this case.

The error names the env var, the key, and the env, e.g.:

```
error: PROD_URL: referenced key "prodUrl" does not exist in env "dev"
```

## What is unaffected

- **Bare `run`** (no `--map`): still silently excludes N/A keys from the env-driven sweep (ADR-0001).
- **`ls` / `ls --check` / `ls --env` / `ls --reveal`**: unchanged.
- **Genuine `optional` skips**: an `optional` key with no value in an *applicable* env still skips with its correct `is optional and has no value` message.

## Implementation

- New `findNotApplicableMapReferences` in the resolver detects map references to N/A keys for the active env (reusing `isNotApplicable`).
- `run` calls it after loading config and before resolving/spawning, mirroring the existing unknown-key reference error path.
- The now-unreachable `optional-no-value` fallback in `statusToSkipCause` (which previously mislabeled N/A references) now throws loudly instead of inventing a misleading cause.

## Tests

- `run --map` referencing an N/A key → non-zero exit, no subprocess, error names env var/key/env (TDD: red first).
- `run --map` referencing the same key in its applicable env still resolves.
- An unreferenced N/A key is still silently excluded by bare-`run`.

All workspace tests, lint, format:check, typecheck, and typecheck:examples pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)