### PR TITLE
feat(init): keyshelf init scaffolds config + AGENTS.md entry point

### DIFF
--- a/packages/cli/src/cli/index.ts
+++ b/packages/cli/src/cli/index.ts
@@ -8,6 +8,7 @@ import { setCommand } from "./set.js";
 import { importCommand } from "./import.js";
 import { upCommand } from "./up.js";
 import { cpCommand, cpClearCommand } from "./cp.js";
+import { initCommand } from "./init.js";
 
 /**
  * Read the CLI's own version from its package.json so `--version` always tracks
@@ -44,6 +45,7 @@ export function createProgram(): Command {
     .description("Keyshelf — config and secrets management for monorepos")
     .version(readPackageVersion());
 
+  program.addCommand(initCommand);
   program.addCommand(runCommand);
   program.addCommand(lsCommand);
   program.addCommand(setCommand);

--- a/packages/cli/src/cli/init.ts
+++ b/packages/cli/src/cli/init.ts
@@ -1,0 +1,52 @@
+import { Command } from "commander";
+import { existsSync } from "node:fs";
+import { readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { upsertKeyshelfSection } from "../init/agents-md.js";
+import { buildConfigTemplate } from "../init/config-template.js";
+
+const CONFIG_FILE = "keyshelf.config.ts";
+const AGENTS_FILE = "AGENTS.md";
+
+export const initCommand = new Command("init")
+  .description(
+    "Scaffold a starter keyshelf.config.ts and an AGENTS.md keyshelf section (idempotent, non-destructive)"
+  )
+  .action(async () => {
+    try {
+      await runInit(process.cwd());
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`error: ${msg}`);
+      process.exit(1);
+    }
+  });
+
+async function runInit(rootDir: string): Promise<void> {
+  await scaffoldConfig(rootDir);
+  await scaffoldAgentsMd(rootDir);
+}
+
+async function scaffoldConfig(rootDir: string): Promise<void> {
+  const configPath = join(rootDir, CONFIG_FILE);
+  if (existsSync(configPath)) {
+    console.log(`skip: ${CONFIG_FILE} already exists (left untouched)`);
+    return;
+  }
+  await writeFile(configPath, buildConfigTemplate());
+  console.log(`created: ${CONFIG_FILE}`);
+}
+
+async function scaffoldAgentsMd(rootDir: string): Promise<void> {
+  const agentsPath = join(rootDir, AGENTS_FILE);
+  const existing = existsSync(agentsPath) ? await readFile(agentsPath, "utf-8") : undefined;
+  const updated = upsertKeyshelfSection(existing);
+
+  if (existing === updated) {
+    console.log(`skip: ${AGENTS_FILE} keyshelf section already up to date`);
+    return;
+  }
+
+  await writeFile(agentsPath, updated);
+  console.log(existing === undefined ? `created: ${AGENTS_FILE}` : `updated: ${AGENTS_FILE}`);
+}

--- a/packages/cli/src/init/agents-md.ts
+++ b/packages/cli/src/init/agents-md.ts
@@ -1,0 +1,66 @@
+/**
+ * The keyshelf section scaffolded into a consuming repo's `AGENTS.md`.
+ *
+ * The section is a thin pointer at the authoritative, version-tracking sources
+ * (`keyshelf check`, `keyshelf rules`, `docs/spec.md`) rather than a copy of the
+ * ruleset, so the scaffolded text itself carries little that can rot. See
+ * ADR-0003.
+ */
+
+export const KEYSHELF_SECTION_HEADING = "## keyshelf";
+
+/** The body of the keyshelf section (heading included), with no trailing blank line. */
+export function buildKeyshelfSection(): string {
+  return [
+    KEYSHELF_SECTION_HEADING,
+    "Config and secrets are declared in keyshelf.config.ts.",
+    "After editing it, run `keyshelf check`.",
+    "Full agent rules: `keyshelf rules`. Spec: docs/spec.md."
+  ].join("\n");
+}
+
+/**
+ * Return AGENTS.md content with the keyshelf section present exactly once.
+ *
+ * - `existing === undefined` → no AGENTS.md yet; return a file containing just
+ *   the section.
+ * - existing content without a keyshelf section → append the section, leaving
+ *   the rest untouched.
+ * - existing content with a keyshelf section → replace only that section in
+ *   place, leaving every other section untouched.
+ *
+ * Idempotent: feeding the output back in returns it unchanged.
+ */
+export function upsertKeyshelfSection(existing: string | undefined): string {
+  const section = buildKeyshelfSection();
+
+  if (existing === undefined || existing.trim() === "") {
+    return `${section}\n`;
+  }
+
+  const lines = existing.split("\n");
+  const startIdx = lines.findIndex((line) => line.trim() === KEYSHELF_SECTION_HEADING);
+
+  if (startIdx === -1) {
+    // No keyshelf section yet — append one, separated by a blank line.
+    const base = existing.endsWith("\n") ? existing : `${existing}\n`;
+    return `${base}\n${section}\n`;
+  }
+
+  // Replace the existing section in place. It runs until the next heading of the
+  // same (top) level or the end of the file.
+  let endIdx = lines.length;
+  for (let i = startIdx + 1; i < lines.length; i++) {
+    if (lines[i].startsWith("## ")) {
+      endIdx = i;
+      break;
+    }
+  }
+
+  const before = lines.slice(0, startIdx);
+  const after = lines.slice(endIdx);
+  const rebuilt = [...before, ...section.split("\n"), ...after];
+  let result = rebuilt.join("\n");
+  if (!result.endsWith("\n")) result += "\n";
+  return result;
+}

--- a/packages/cli/src/init/config-template.ts
+++ b/packages/cli/src/init/config-template.ts
@@ -1,0 +1,33 @@
+/**
+ * The starter `keyshelf.config.ts` scaffolded by `keyshelf init` into a repo
+ * that does not yet have one. Minimal, valid, and commented: a `name`, an
+ * `envs` list, and one config key plus one secret key as worked examples. The
+ * secret uses `plain()` so the scaffold validates and resolves with no external
+ * provider setup — the author swaps it for a real provider (age/aws/...) when
+ * they wire up secret storage.
+ */
+export function buildConfigTemplate(): string {
+  return `import { defineConfig, config, secret, plain } from "keyshelf/config";
+
+// keyshelf declares your config and secret keys once and resolves them per
+// environment. After editing this file, run \`keyshelf check\`. Full agent
+// rules: \`keyshelf rules\`. Spec: docs/spec.md.
+export default defineConfig({
+  // Project name — used to namespace stored secrets.
+  name: "my-app",
+
+  // The environments your keys resolve for.
+  envs: ["dev", "prod"],
+
+  keys: {
+    // A config key: a plain (non-secret) value, here with an envless fallback.
+    "api-url": config({ default: "https://api.example.com" }),
+
+    // A secret key: its value comes from a provider binding. \`plain()\` keeps
+    // the value inline so the scaffold works out of the box — swap it for a
+    // real provider (e.g. age/aws/gcp/sops) and run \`keyshelf set\`.
+    "api-token": secret({ value: plain("replace-me") }),
+  },
+});
+`;
+}

--- a/packages/cli/test/e2e/init.test.ts
+++ b/packages/cli/test/e2e/init.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+import { CLI, TSX } from "./helpers/cli.js";
+
+function runInit(cwd: string): string {
+  return execFileSync(TSX, [CLI, "init"], { cwd, encoding: "utf-8" });
+}
+
+describe("keyshelf init", () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "keyshelf-init-"));
+  });
+
+  it("scaffolds a valid keyshelf.config.ts and an AGENTS.md keyshelf section in a fresh repo", async () => {
+    runInit(root);
+
+    const configPath = join(root, "keyshelf.config.ts");
+    const agentsPath = join(root, "AGENTS.md");
+    expect(existsSync(configPath)).toBe(true);
+    expect(existsSync(agentsPath)).toBe(true);
+
+    const agents = await readFile(agentsPath, "utf-8");
+    expect(agents).toContain("## keyshelf");
+    expect(agents).toContain("keyshelf check");
+    expect(agents).toContain("keyshelf rules");
+    expect(agents).toContain("docs/spec.md");
+
+    // The scaffolded config passes validation: `keyshelf ls` loads + normalizes it.
+    const ls = execFileSync(TSX, [CLI, "ls"], { cwd: root, encoding: "utf-8" });
+    expect(ls).toContain("api-url");
+    expect(ls).toContain("api-token");
+  });
+
+  it("refuses to overwrite an existing keyshelf.config.ts", async () => {
+    const configPath = join(root, "keyshelf.config.ts");
+    await writeFile(configPath, "// my hand-written config\n");
+
+    runInit(root);
+
+    // config untouched
+    expect(await readFile(configPath, "utf-8")).toBe("// my hand-written config\n");
+    // but AGENTS.md still scaffolded
+    expect(existsSync(join(root, "AGENTS.md"))).toBe(true);
+  });
+
+  it("appends only the keyshelf section to an existing AGENTS.md, leaving the rest untouched", async () => {
+    const agentsPath = join(root, "AGENTS.md");
+    await writeFile(agentsPath, "# AGENTS.md\n\n## build\nRun `npm test`.\n");
+
+    runInit(root);
+
+    const agents = await readFile(agentsPath, "utf-8");
+    expect(agents).toContain("## build");
+    expect(agents).toContain("Run `npm test`.");
+    expect(agents).toContain("## keyshelf");
+    expect(agents.startsWith("# AGENTS.md\n\n## build\nRun `npm test`.\n")).toBe(true);
+  });
+
+  it("is idempotent: running twice produces identical files and no duplicate section", async () => {
+    runInit(root);
+    const configAfterFirst = await readFile(join(root, "keyshelf.config.ts"), "utf-8");
+    const agentsAfterFirst = await readFile(join(root, "AGENTS.md"), "utf-8");
+
+    runInit(root);
+    const configAfterSecond = await readFile(join(root, "keyshelf.config.ts"), "utf-8");
+    const agentsAfterSecond = await readFile(join(root, "AGENTS.md"), "utf-8");
+
+    expect(configAfterSecond).toBe(configAfterFirst);
+    expect(agentsAfterSecond).toBe(agentsAfterFirst);
+    expect(agentsAfterSecond.split("## keyshelf").length - 1).toBe(1);
+  });
+});

--- a/packages/cli/test/unit/cli.test.ts
+++ b/packages/cli/test/unit/cli.test.ts
@@ -2,13 +2,14 @@ import { describe, expect, it } from "vitest";
 import { createProgram } from "../../src/index.js";
 
 describe("createProgram", () => {
-  it("registers run, ls, set, import, up, cp, and __cp-clear commands", () => {
+  it("registers init, run, ls, set, import, up, cp, and __cp-clear commands", () => {
     const program = createProgram();
     expect(program.name()).toBe("keyshelf");
     expect(program.commands.map((command) => command.name()).sort()).toEqual([
       "__cp-clear",
       "cp",
       "import",
+      "init",
       "ls",
       "run",
       "set",

--- a/packages/cli/test/unit/init.test.ts
+++ b/packages/cli/test/unit/init.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  KEYSHELF_SECTION_HEADING,
+  buildKeyshelfSection,
+  upsertKeyshelfSection
+} from "../../src/init/agents-md.js";
+
+describe("buildKeyshelfSection", () => {
+  it("starts with the keyshelf heading and points at the version-tracking commands", () => {
+    const section = buildKeyshelfSection();
+    expect(section.startsWith(`${KEYSHELF_SECTION_HEADING}\n`)).toBe(true);
+    expect(section).toContain("keyshelf.config.ts");
+    expect(section).toContain("keyshelf check");
+    expect(section).toContain("keyshelf rules");
+    expect(section).toContain("docs/spec.md");
+  });
+});
+
+describe("upsertKeyshelfSection", () => {
+  it("creates the section when there is no existing AGENTS.md content", () => {
+    const result = upsertKeyshelfSection(undefined);
+    expect(result).toContain(KEYSHELF_SECTION_HEADING);
+    expect(result.endsWith("\n")).toBe(true);
+  });
+
+  it("appends the section, preserving existing content, when AGENTS.md exists without one", () => {
+    const existing = "# AGENTS.md\n\n## build\nRun `npm test`.\n";
+    const result = upsertKeyshelfSection(existing);
+    expect(result).toContain("## build");
+    expect(result).toContain("Run `npm test`.");
+    expect(result).toContain(KEYSHELF_SECTION_HEADING);
+    // existing content stays at the top, untouched
+    expect(result.startsWith("# AGENTS.md\n\n## build\nRun `npm test`.\n")).toBe(true);
+  });
+
+  it("is idempotent: running twice does not duplicate the section", () => {
+    const once = upsertKeyshelfSection(undefined);
+    const twice = upsertKeyshelfSection(once);
+    expect(twice).toBe(once);
+    const occurrences = twice.split(KEYSHELF_SECTION_HEADING).length - 1;
+    expect(occurrences).toBe(1);
+  });
+
+  it("replaces only the keyshelf section, leaving other sections untouched", () => {
+    const existing = [
+      "# AGENTS.md",
+      "",
+      "## build",
+      "Run `npm test`.",
+      "",
+      KEYSHELF_SECTION_HEADING,
+      "Stale outdated text that should be replaced.",
+      "",
+      "## deploy",
+      "Push to main.",
+      ""
+    ].join("\n");
+    const result = upsertKeyshelfSection(existing);
+    expect(result).toContain("## build");
+    expect(result).toContain("## deploy");
+    expect(result).toContain("Push to main.");
+    expect(result).not.toContain("Stale outdated text");
+    expect(result).toContain("keyshelf check");
+    // exactly one keyshelf section
+    expect(result.split(KEYSHELF_SECTION_HEADING).length - 1).toBe(1);
+  });
+});


### PR DESCRIPTION
Implements `keyshelf init` — the distribution mechanism chosen in ADR-0003. It scaffolds a keyshelf setup into a repo so coding agents in a downstream repo (one that adopted keyshelf via npm) inherit the guidance they need.

## What it does

- Creates a minimal, valid, commented starter `keyshelf.config.ts` (name, envs, one config + one secret key as examples) when none exists; **refuses to overwrite** an existing one.
- Creates `AGENTS.md` with a `## keyshelf` section, or **appends/updates only that section** when `AGENTS.md` already exists, leaving the rest untouched. The section is a thin pointer at version-tracking sources (`keyshelf check`, `keyshelf rules`, `docs/spec.md`) rather than a copy of the ruleset — per ADR-0003.
- Idempotent and non-destructive: running twice produces identical files with no duplicate section.
- Registered in the CLI.

The scaffolded `AGENTS.md` references `keyshelf check` / `keyshelf rules`, which are separate slices; `init` scaffolds the references regardless (ADR-0003 consequence).

## Tests

- `test/unit/init.test.ts` — pure section upsert (create / append / replace-in-place / idempotent).
- `test/e2e/init.test.ts` — fresh repo, existing config (refused), existing AGENTS.md (append only), idempotency. The fresh-repo case proves the scaffolded config passes validation by running `keyshelf ls` against it.
- `test/unit/cli.test.ts` — command registration updated.

Local CI-equivalent checks all green: lint, format:check, typecheck, typecheck:examples, full test suite (328 cli / 24 action / 32 migrate).

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)