### PR TITLE
feat: teach the fix in errors for the five agent mistakes (#168)

### DIFF
--- a/packages/action/dist/emit-env.mjs
+++ b/packages/action/dist/emit-env.mjs
@@ -122,6 +122,16 @@ var keyNodeSchema = z.lazy(
     })
   ])
 );
+var PROVIDERS = "age/gcp/aws/sops/plain";
+function namespaceTrapMessage(kind) {
+  if (kind === "secret") {
+    return `every secret binding must be a provider call (${PROVIDERS}), not a plaintext value \u2014 use secret({ value: age({ ... }) }) (or config({ ... }) for non-secret values)`;
+  }
+  if (kind === "config") {
+    return "config record has invalid options \u2014 declare a record with config({ value, default, values, group, optional }) or secret({ ... })";
+  }
+  return "declared as a namespace, but its fields look like record options \u2014 wrap them in config({ ... }) or secret({ ... }) to declare a record here";
+}
 var keyshelfConfigSchema = z.object({
   __kind: z.literal("keyshelf:config"),
   name: z.string().min(1).refine((value) => CONFIG_NAME_RE.test(value), {
@@ -133,8 +143,41 @@ var keyshelfConfigSchema = z.object({
     message: "keys must contain at least one entry"
   })
 }).strict();
+function formatZodError(error, input) {
+  const lines = error.issues.map((issue) => {
+    const keyPath = issuePathToKeyPath(issue.path);
+    if (keyPath === void 0) return issue.message;
+    const node = nodeAtPath(input, issue.path);
+    const taught = keyNodeMessage(node);
+    return `${keyPath}: ${taught ?? issue.message}`;
+  });
+  return `Invalid keyshelf.config.ts:
+${lines.map((line) => `- ${line}`).join("\n")}`;
+}
+function keyNodeMessage(node) {
+  const kind = getKind(node);
+  if (kind === void 0) return void 0;
+  return namespaceTrapMessage(kind);
+}
+function nodeAtPath(input, path) {
+  let cursor = input;
+  for (const segment of path) {
+    if (cursor == null || typeof cursor !== "object") return void 0;
+    cursor = cursor[segment];
+  }
+  return cursor;
+}
+function issuePathToKeyPath(path) {
+  if (path[0] !== "keys") return void 0;
+  const segments = path.slice(1).filter((segment) => typeof segment === "string");
+  return segments.length === 0 ? void 0 : segments.join("/");
+}
 function normalizeConfig(input) {
-  const parsed = keyshelfConfigSchema.parse(input);
+  const result = keyshelfConfigSchema.safeParse(input);
+  if (!result.success) {
+    throw new Error(formatZodError(result.error, input));
+  }
+  const parsed = result.data;
   const errors = [];
   checkUnique("envs", parsed.envs, errors);
   const groups2 = [...parsed.groups ?? []];
@@ -165,7 +208,9 @@ function validateAppMappingReferences(mappings, flattenedKeys) {
     const references = isTemplateMapping(mapping) ? mapping.keyPaths : [mapping.keyPath];
     for (const reference of references) {
       if (!paths.has(reference)) {
-        errors.push(`${mapping.envVar}: references unknown key "${reference}"`);
+        errors.push(
+          `${mapping.envVar}: references unknown key "${reference}" \u2014 declare it in keyshelf.config.ts or fix the reference`
+        );
       }
     }
   }
@@ -2580,7 +2625,7 @@ function resolveSecretProvider(key, env, schemaDefault) {
   const override = env.overrides[key.path];
   if (override !== void 0 && !isTaggedValue(override)) {
     throw new Error(
-      `${env.name}:${key.path}: secret keys require a provider tag, got a plain value`
+      `${env.name}:${key.path}: every secret binding must be a provider call (age/gcp/aws/sops/plain), not a plain value \u2014 tag the override with a provider (e.g. !age, !gcp) or use config for non-secret values`
     );
   }
   const fallbackProvider = env.defaultProvider ?? schemaDefault;

--- a/packages/action/dist/emit-env.mjs
+++ b/packages/action/dist/emit-env.mjs
@@ -144,15 +144,16 @@ var keyshelfConfigSchema = z.object({
   })
 }).strict();
 function formatZodError(error, input) {
-  const lines = error.issues.map((issue) => {
-    const keyPath = issuePathToKeyPath(issue.path);
-    if (keyPath === void 0) return issue.message;
-    const node = nodeAtPath(input, issue.path);
-    const taught = keyNodeMessage(node);
-    return `${keyPath}: ${taught ?? issue.message}`;
-  });
+  const lines = error.issues.map((issue) => formatZodIssue(issue, input));
   return `Invalid keyshelf.config.ts:
 ${lines.map((line) => `- ${line}`).join("\n")}`;
+}
+function formatZodIssue(issue, input) {
+  const keyPath = issuePathToKeyPath(issue.path);
+  if (keyPath === void 0) return issue.message;
+  const node = nodeAtPath(input, issue.path);
+  const taught = keyNodeMessage(node);
+  return `${keyPath}: ${taught ?? issue.message}`;
 }
 function keyNodeMessage(node) {
   const kind = getKind(node);

--- a/packages/action/dist/write-identity.mjs
+++ b/packages/action/dist/write-identity.mjs
@@ -121,6 +121,16 @@ var keyNodeSchema = z.lazy(
     })
   ])
 );
+var PROVIDERS = "age/gcp/aws/sops/plain";
+function namespaceTrapMessage(kind) {
+  if (kind === "secret") {
+    return `every secret binding must be a provider call (${PROVIDERS}), not a plaintext value \u2014 use secret({ value: age({ ... }) }) (or config({ ... }) for non-secret values)`;
+  }
+  if (kind === "config") {
+    return "config record has invalid options \u2014 declare a record with config({ value, default, values, group, optional }) or secret({ ... })";
+  }
+  return "declared as a namespace, but its fields look like record options \u2014 wrap them in config({ ... }) or secret({ ... }) to declare a record here";
+}
 var keyshelfConfigSchema = z.object({
   __kind: z.literal("keyshelf:config"),
   name: z.string().min(1).refine((value) => CONFIG_NAME_RE.test(value), {
@@ -132,8 +142,41 @@ var keyshelfConfigSchema = z.object({
     message: "keys must contain at least one entry"
   })
 }).strict();
+function formatZodError(error, input) {
+  const lines = error.issues.map((issue) => {
+    const keyPath = issuePathToKeyPath(issue.path);
+    if (keyPath === void 0) return issue.message;
+    const node = nodeAtPath(input, issue.path);
+    const taught = keyNodeMessage(node);
+    return `${keyPath}: ${taught ?? issue.message}`;
+  });
+  return `Invalid keyshelf.config.ts:
+${lines.map((line) => `- ${line}`).join("\n")}`;
+}
+function keyNodeMessage(node) {
+  const kind = getKind(node);
+  if (kind === void 0) return void 0;
+  return namespaceTrapMessage(kind);
+}
+function nodeAtPath(input, path) {
+  let cursor = input;
+  for (const segment of path) {
+    if (cursor == null || typeof cursor !== "object") return void 0;
+    cursor = cursor[segment];
+  }
+  return cursor;
+}
+function issuePathToKeyPath(path) {
+  if (path[0] !== "keys") return void 0;
+  const segments = path.slice(1).filter((segment) => typeof segment === "string");
+  return segments.length === 0 ? void 0 : segments.join("/");
+}
 function normalizeConfig(input) {
-  const parsed = keyshelfConfigSchema.parse(input);
+  const result = keyshelfConfigSchema.safeParse(input);
+  if (!result.success) {
+    throw new Error(formatZodError(result.error, input));
+  }
+  const parsed = result.data;
   const errors = [];
   checkUnique("envs", parsed.envs, errors);
   const groups = [...parsed.groups ?? []];
@@ -164,7 +207,9 @@ function validateAppMappingReferences(mappings, flattenedKeys) {
     const references = isTemplateMapping(mapping) ? mapping.keyPaths : [mapping.keyPath];
     for (const reference of references) {
       if (!paths.has(reference)) {
-        errors.push(`${mapping.envVar}: references unknown key "${reference}"`);
+        errors.push(
+          `${mapping.envVar}: references unknown key "${reference}" \u2014 declare it in keyshelf.config.ts or fix the reference`
+        );
       }
     }
   }
@@ -2579,7 +2624,7 @@ function resolveSecretProvider(key, env, schemaDefault) {
   const override = env.overrides[key.path];
   if (override !== void 0 && !isTaggedValue(override)) {
     throw new Error(
-      `${env.name}:${key.path}: secret keys require a provider tag, got a plain value`
+      `${env.name}:${key.path}: every secret binding must be a provider call (age/gcp/aws/sops/plain), not a plain value \u2014 tag the override with a provider (e.g. !age, !gcp) or use config for non-secret values`
     );
   }
   const fallbackProvider = env.defaultProvider ?? schemaDefault;

--- a/packages/action/dist/write-identity.mjs
+++ b/packages/action/dist/write-identity.mjs
@@ -143,15 +143,16 @@ var keyshelfConfigSchema = z.object({
   })
 }).strict();
 function formatZodError(error, input) {
-  const lines = error.issues.map((issue) => {
-    const keyPath = issuePathToKeyPath(issue.path);
-    if (keyPath === void 0) return issue.message;
-    const node = nodeAtPath(input, issue.path);
-    const taught = keyNodeMessage(node);
-    return `${keyPath}: ${taught ?? issue.message}`;
-  });
+  const lines = error.issues.map((issue) => formatZodIssue(issue, input));
   return `Invalid keyshelf.config.ts:
 ${lines.map((line) => `- ${line}`).join("\n")}`;
+}
+function formatZodIssue(issue, input) {
+  const keyPath = issuePathToKeyPath(issue.path);
+  if (keyPath === void 0) return issue.message;
+  const node = nodeAtPath(input, issue.path);
+  const taught = keyNodeMessage(node);
+  return `${keyPath}: ${taught ?? issue.message}`;
 }
 function keyNodeMessage(node) {
   const kind = getKind(node);

--- a/packages/cli/src/cli/import.ts
+++ b/packages/cli/src/cli/import.ts
@@ -107,7 +107,7 @@ async function importOne(
   if (record.kind === "config") {
     return {
       kind: "skipped",
-      warning: `warning: ${envVar} -> ${keyPath} is a config key; keyshelf does not write config via import (edit keyshelf.config.ts directly)`
+      warning: `warning: ${envVar} -> "${keyPath}" is a config record. config values are edited in keyshelf.config.ts, not written via the CLI — edit the binding there directly.`
     };
   }
   if (

--- a/packages/cli/src/cli/run.ts
+++ b/packages/cli/src/cli/run.ts
@@ -47,7 +47,7 @@ export const runCommand = new Command("run")
     if (naReferences.length > 0) {
       for (const ref of naReferences) {
         console.error(
-          `error: ${ref.envVar}: referenced key "${ref.keyPath}" does not exist in env "${ref.envName}"`
+          `error: ${ref.envVar}: key "${ref.keyPath}" is N/A (not applicable) in the active env "${ref.envName}" — add "${ref.envName}" to its applicable envs in keyshelf.config.ts, or drop the reference`
         );
       }
       process.exit(1);

--- a/packages/cli/src/cli/set.ts
+++ b/packages/cli/src/cli/set.ts
@@ -26,7 +26,7 @@ export const setCommand = new Command("set")
 
     if (record.kind === "config") {
       console.error(
-        `error: "${keyPath}" is a config key. keyshelf does not write config values via set — edit keyshelf.config.ts directly.`
+        `error: "${keyPath}" is a config record. config values are edited in keyshelf.config.ts, not written via the CLI — edit the binding there directly.`
       );
       process.exit(1);
     }

--- a/packages/cli/src/cli/up.ts
+++ b/packages/cli/src/cli/up.ts
@@ -12,7 +12,7 @@ import {
 import { gatherListings, type ListingFailure } from "../reconcile/listings.js";
 import { planReconciliation } from "../reconcile/planner.js";
 import { countMutatingActions, renderPlan } from "../reconcile/format.js";
-import type { Plan } from "../reconcile/plan.js";
+import type { AmbiguousAction, Plan } from "../reconcile/plan.js";
 import type { NormalizedConfig } from "../config/types.js";
 
 interface UpOptions {
@@ -57,12 +57,11 @@ async function runUp(opts: UpOptions): Promise<number> {
   if (countMutatingActions(plan) === 0) return 0;
 
   // Apply path. Refuse on Ambiguous before prompting so the user sees the
-  // message immediately rather than after typing 'y'.
-  if (planHasAmbiguous(plan)) {
-    console.error(
-      "error: cannot apply — plan contains ambiguous actions. " +
-        "Add a movedFrom annotation on each ambiguous key, then re-run."
-    );
+  // message immediately rather than after typing 'y'. Reuse the apply error so
+  // the pre-prompt message names the same keys and movedFrom fix.
+  const ambiguous = plan.filter((a): a is AmbiguousAction => a.kind === "ambiguous");
+  if (ambiguous.length > 0) {
+    console.error(`error: ${new AmbiguousActionsError(ambiguous).message}`);
     return 1;
   }
 
@@ -94,11 +93,6 @@ async function runApply(
     }
     throw err;
   }
-}
-
-function planHasAmbiguous(plan: Plan): boolean {
-  for (const a of plan) if (a.kind === "ambiguous") return true;
-  return false;
 }
 
 function formatApplySummary(result: ApplyResult): string {

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -287,7 +287,9 @@ export function validateAppMappingReferences(
     const references = isTemplateMapping(mapping) ? mapping.keyPaths : [mapping.keyPath];
     for (const reference of references) {
       if (!paths.has(reference)) {
-        errors.push(`${mapping.envVar}: references unknown key "${reference}"`);
+        errors.push(
+          `${mapping.envVar}: references unknown key "${reference}" — declare it in keyshelf.config.ts or fix the reference`
+        );
       }
     }
   }

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -131,6 +131,11 @@ interface TemplateVisitState {
   stack: string[];
 }
 
+// A bare object literal is always a namespace. When one carries a `__kind` it
+// is a factory result (`config(...)` / `secret(...)` / a provider call) that
+// failed its declared schema and fell through to the namespace branch — the
+// namespace trap (mistake #1) and plaintext-in-secret (mistake #2). Teach the
+// fix here; `formatZodError` prefixes the offending path.
 const keyNodeSchema: z.ZodType<KeyNode> = z.lazy(() =>
   z.union([
     configScalarSchema,
@@ -146,6 +151,33 @@ const keyNodeSchema: z.ZodType<KeyNode> = z.lazy(() =>
       })
   ])
 );
+
+const PROVIDERS = "age/gcp/aws/sops/plain";
+
+function namespaceTrapMessage(kind: unknown): string {
+  if (kind === "secret") {
+    // Mistake #2: a secret whose binding is a plaintext value, or otherwise not
+    // a valid provider call.
+    return (
+      `every secret binding must be a provider call (${PROVIDERS}), not a plaintext value — ` +
+      `use secret({ value: age({ ... }) }) (or config({ ... }) for non-secret values)`
+    );
+  }
+  if (kind === "config") {
+    // A config factory with invalid options — name the valid record options and
+    // both factory forms so the fix is unambiguous.
+    return (
+      "config record has invalid options — declare a record with " +
+      "config({ value, default, values, group, optional }) or secret({ ... })"
+    );
+  }
+  // Mistake #1: the namespace trap — an object literal whose fields look like
+  // record options is a namespace, never a record.
+  return (
+    "declared as a namespace, but its fields look like record options — " +
+    "wrap them in config({ ... }) or secret({ ... }) to declare a record here"
+  );
+}
 
 const keyshelfConfigSchema = z
   .object({
@@ -166,8 +198,56 @@ const keyshelfConfigSchema = z
 
 export { keyshelfConfigSchema, providerRefSchema };
 
+// Render a ZodError from the config schema into the same teaching format as the
+// hand-rolled validation pass: each issue prefixed with the offending key path
+// (e.g. `db/host`) so the message names what to fix, not an opaque object dump.
+// When the failing node is a key entry, the message is rewritten to teach the
+// namespace-trap / plaintext-in-secret fixes.
+function formatZodError(error: z.ZodError, input: unknown): string {
+  const lines = error.issues.map((issue) => {
+    const keyPath = issuePathToKeyPath(issue.path);
+    if (keyPath === undefined) return issue.message;
+    const node = nodeAtPath(input, issue.path);
+    const taught = keyNodeMessage(node);
+    return `${keyPath}: ${taught ?? issue.message}`;
+  });
+  return `Invalid keyshelf.config.ts:\n${lines.map((line) => `- ${line}`).join("\n")}`;
+}
+
+// A teaching message for a key entry that failed schema validation, dispatched
+// on its `__kind`. Returns undefined for nodes we have nothing better to say
+// about (the raw zod message is used instead).
+function keyNodeMessage(node: unknown): string | undefined {
+  const kind = getKind(node);
+  if (kind === undefined) return undefined;
+  return namespaceTrapMessage(kind);
+}
+
+// Walk the input object down the zod issue path to fetch the failing node so we
+// can inspect its `__kind`.
+function nodeAtPath(input: unknown, path: ReadonlyArray<PropertyKey>): unknown {
+  let cursor: unknown = input;
+  for (const segment of path) {
+    if (cursor == null || typeof cursor !== "object") return undefined;
+    cursor = (cursor as Record<PropertyKey, unknown>)[segment];
+  }
+  return cursor;
+}
+
+// `["keys", "db", "host"]` → `db/host`. Drops the leading `keys` container and
+// any trailing schema-internal segments so the path reads as a declared key.
+function issuePathToKeyPath(path: ReadonlyArray<PropertyKey>): string | undefined {
+  if (path[0] !== "keys") return undefined;
+  const segments = path.slice(1).filter((segment) => typeof segment === "string");
+  return segments.length === 0 ? undefined : segments.join("/");
+}
+
 export function normalizeConfig(input: unknown): NormalizedConfig {
-  const parsed = keyshelfConfigSchema.parse(input) as KeyshelfConfig;
+  const result = keyshelfConfigSchema.safeParse(input);
+  if (!result.success) {
+    throw new Error(formatZodError(result.error, input));
+  }
+  const parsed = result.data as KeyshelfConfig;
   const errors: string[] = [];
 
   checkUnique("envs", parsed.envs, errors);

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -204,14 +204,18 @@ export { keyshelfConfigSchema, providerRefSchema };
 // When the failing node is a key entry, the message is rewritten to teach the
 // namespace-trap / plaintext-in-secret fixes.
 function formatZodError(error: z.ZodError, input: unknown): string {
-  const lines = error.issues.map((issue) => {
-    const keyPath = issuePathToKeyPath(issue.path);
-    if (keyPath === undefined) return issue.message;
-    const node = nodeAtPath(input, issue.path);
-    const taught = keyNodeMessage(node);
-    return `${keyPath}: ${taught ?? issue.message}`;
-  });
+  const lines = error.issues.map((issue) => formatZodIssue(issue, input));
   return `Invalid keyshelf.config.ts:\n${lines.map((line) => `- ${line}`).join("\n")}`;
+}
+
+// Render a single zod issue into a teaching line: prefix the offending key path
+// and rewrite the message for key entries; fall back to the raw zod message.
+function formatZodIssue(issue: z.ZodError["issues"][number], input: unknown): string {
+  const keyPath = issuePathToKeyPath(issue.path);
+  if (keyPath === undefined) return issue.message;
+  const node = nodeAtPath(input, issue.path);
+  const taught = keyNodeMessage(node);
+  return `${keyPath}: ${taught ?? issue.message}`;
 }
 
 // A teaching message for a key entry that failed schema validation, dispatched

--- a/packages/cli/src/config/yaml-loader.ts
+++ b/packages/cli/src/config/yaml-loader.ts
@@ -330,7 +330,7 @@ function resolveSecretProvider(
 
   if (override !== undefined && !isTaggedValue(override)) {
     throw new Error(
-      `${env.name}:${key.path}: secret keys require a provider tag, got a plain value`
+      `${env.name}:${key.path}: every secret binding must be a provider call (age/gcp/aws/sops/plain), not a plain value — tag the override with a provider (e.g. !age, !gcp) or use config for non-secret values`
     );
   }
 

--- a/packages/cli/src/reconcile/apply.ts
+++ b/packages/cli/src/reconcile/apply.ts
@@ -1,7 +1,7 @@
 import type { NormalizedConfig } from "../config/types.js";
 import type { ProviderRegistry } from "../providers/registry.js";
 import type { ProviderContext } from "../providers/types.js";
-import type { DeleteAction, Plan, RenameAction } from "./plan.js";
+import type { AmbiguousAction, DeleteAction, Plan, RenameAction } from "./plan.js";
 
 export interface ApplyContext {
   config: NormalizedConfig;
@@ -16,14 +16,26 @@ export interface ApplyResult {
 
 export class AmbiguousActionsError extends Error {
   readonly count: number;
-  constructor(count: number) {
-    super(
-      `Refusing to apply: plan contains ${count} ambiguous action${count === 1 ? "" : "s"}. ` +
-        `Add a movedFrom annotation to disambiguate, then re-run.`
-    );
+  constructor(actions: AmbiguousAction[]) {
+    super(buildAmbiguousMessage(actions));
     this.name = "AmbiguousActionsError";
-    this.count = count;
+    this.count = actions.length;
   }
+}
+
+// Name each renamed key and the orphan candidates it could not unambiguously
+// map, and embed the movedFrom fix on the renamed record.
+function buildAmbiguousMessage(actions: AmbiguousAction[]): string {
+  const count = actions.length;
+  const header =
+    `Refusing to apply: plan contains ${count} ambiguous rename${count === 1 ? "" : "s"}. ` +
+    `up cannot tell which orphan in storage maps to the renamed key — ` +
+    `add movedFrom on the renamed record to disambiguate, then re-run.`;
+  const details = actions.map((action) => {
+    const orphans = action.candidates.map((candidate) => `"${candidate.keyPath}"`).join(", ");
+    return `  "${action.desired.keyPath}": orphan candidates ${orphans} — set movedFrom to the one it was renamed from`;
+  });
+  return [header, ...details].join("\n");
 }
 
 // Thrown when copy succeeds but the new location does not validate. We do
@@ -49,8 +61,8 @@ export class ApplyValidationError extends Error {
 // is copy → validate → delete; standalone Deletes run after all renames so a
 // validate-fail can abort before any orphans are removed.
 export async function applyPlan(ctx: ApplyContext, plan: Plan): Promise<ApplyResult> {
-  const ambiguousCount = countAmbiguous(plan);
-  if (ambiguousCount > 0) throw new AmbiguousActionsError(ambiguousCount);
+  const ambiguous = collectAmbiguous(plan);
+  if (ambiguous.length > 0) throw new AmbiguousActionsError(ambiguous);
 
   let renamesApplied = 0;
   let deletesApplied = 0;
@@ -72,10 +84,8 @@ export async function applyPlan(ctx: ApplyContext, plan: Plan): Promise<ApplyRes
   return { renamesApplied, deletesApplied };
 }
 
-function countAmbiguous(plan: Plan): number {
-  let n = 0;
-  for (const a of plan) if (a.kind === "ambiguous") n += 1;
-  return n;
+function collectAmbiguous(plan: Plan): AmbiguousAction[] {
+  return plan.filter((action): action is AmbiguousAction => action.kind === "ambiguous");
 }
 
 async function applyRename(ctx: ApplyContext, action: RenameAction): Promise<void> {

--- a/packages/cli/test/e2e/import.test.ts
+++ b/packages/cli/test/e2e/import.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp } from "node:fs/promises";
 import { writeFileSync as fsWriteFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { CLI, TSX } from "./helpers/cli.js";
 import { setupAgeFixtureDir, writeEnvKeyshelf, writeKeyshelfConfig } from "./helpers/fixture.js";
 
@@ -71,6 +71,23 @@ describe("keyshelf-next import", () => {
       p: "imported-pw",
       k: "k1"
     });
+  });
+
+  it("warns with a teaching message when a mapped env var targets a config key", () => {
+    const envFile = join(root, ".env.values");
+    writeFileSync(envFile, ["DB_HOST=imported-host", "DB_PASSWORD=imported-pw"]);
+
+    const proc = spawnSync(TSX, [CLI, "import", "--env", "dev", "--file", envFile], {
+      cwd: root,
+      encoding: "utf-8"
+    });
+
+    // Names the offending env var and key, and states the corrective action:
+    // config values are edited in keyshelf.config.ts, not written via the CLI.
+    expect(proc.stderr).toContain("DB_HOST");
+    expect(proc.stderr).toContain("db/host");
+    expect(proc.stderr).toContain("config record");
+    expect(proc.stderr).toContain("keyshelf.config.ts");
   });
 
   it("skips unmapped env vars", () => {

--- a/packages/cli/test/e2e/run.test.ts
+++ b/packages/cli/test/e2e/run.test.ts
@@ -239,10 +239,12 @@ describe("keyshelf-next run (env-scoped key applicability)", () => {
     );
     expect(result.status).not.toBe(0);
     expect(result.stdout).not.toContain("ran");
-    // Message names the env var, the key, and the env.
+    // Message names the env var, the key, and the active env.
     expect(result.stderr).toContain("PROD_URL");
     expect(result.stderr).toContain("prodUrl");
     expect(result.stderr).toContain("dev");
+    // Uses the N/A domain vocabulary rather than a vague "does not exist".
+    expect(result.stderr).toMatch(/N\/A|not applicable/i);
     // It is an error, not the misleading "optional and has no value" skip line.
     expect(result.stderr).not.toMatch(/optional/i);
   });

--- a/packages/cli/test/e2e/set.test.ts
+++ b/packages/cli/test/e2e/set.test.ts
@@ -52,7 +52,13 @@ describe("keyshelf-next set", () => {
       });
       expect.unreachable("should have thrown");
     } catch (err) {
-      expect((err as { stderr: string }).stderr).toContain("keyshelf does not write config values");
+      const stderr = (err as { stderr: string }).stderr;
+      // Names the offending key.
+      expect(stderr).toContain("db/host");
+      // States the corrective action: config values are edited in the config
+      // file, not written via the CLI.
+      expect(stderr).toContain("config record");
+      expect(stderr).toContain("keyshelf.config.ts");
     }
   });
 

--- a/packages/cli/test/e2e/up.test.ts
+++ b/packages/cli/test/e2e/up.test.ts
@@ -321,6 +321,11 @@ describe("keyshelf up --yes (apply)", () => {
     const result = runUp(root, ["--yes"]);
     expect(result.status).toBe(1);
     expect(result.stderr).toContain("ambiguous");
+    // Names the renamed key and the candidate orphans, and points at movedFrom.
+    expect(result.stderr).toContain("newKey");
+    expect(result.stderr).toContain("oldA");
+    expect(result.stderr).toContain("oldB");
+    expect(result.stderr).toContain("movedFrom");
     // Storage left untouched.
     const baseCtx = { envName: undefined, rootDir: root, config: { identityFile, secretsDir } };
     expect(await provider.validate({ ...baseCtx, keyPath: "oldA" })).toBe(true);

--- a/packages/cli/test/unit/config.test.ts
+++ b/packages/cli/test/unit/config.test.ts
@@ -128,8 +128,9 @@ describe("config factories and validation", () => {
     ).toThrow("key namespaces must not be empty");
   });
 
-  it("rejects invalid provider options", () => {
-    expect(() =>
+  it("rejects invalid provider options, naming the record and the fix", () => {
+    let message = "";
+    try {
       normalizeConfig(
         defineConfig({
           name: "test",
@@ -139,8 +140,68 @@ describe("config factories and validation", () => {
             token: secret({ value: age({ identityFile: "./ci.txt" }) })
           }
         })
-      )
-    ).toThrow(/factory objects with __kind must match their declared schema/);
+      );
+    } catch (err) {
+      message = (err as Error).message;
+    }
+    // Names the offending record path.
+    expect(message).toContain("token");
+    // Teaches the corrective action: a secret binding must be a provider call.
+    expect(message).toContain("provider call");
+    expect(message).toMatch(/age.*gcp.*aws.*sops.*plain/);
+    // Does not leak the raw zod refine text.
+    expect(message).not.toContain("factory objects with __kind");
+  });
+
+  // Mistake #1: the namespace trap. An object literal whose fields look like
+  // record options ({ value, values, default, group, optional }) is a namespace,
+  // never a record. The error names the path and points at the factory form.
+  it("teaches the fix when a namespace-trap object literal is a malformed factory", () => {
+    let message = "";
+    try {
+      normalizeConfig({
+        __kind: "keyshelf:config",
+        name: "test",
+        envs: ["dev"],
+        // An object that carries __kind but fails its declared factory schema —
+        // e.g. a config factory with a stray unknown option — is the symptom of
+        // the namespace trap surfacing through a broken factory call.
+        keys: { db: { __kind: "config", value: "localhost", bogus: 1 } }
+      });
+    } catch (err) {
+      message = (err as Error).message;
+    }
+    // Names the offending path.
+    expect(message).toContain("db");
+    // Points at the factory form as the fix.
+    expect(message).toMatch(/config\(\{/);
+    expect(message).toMatch(/secret\(\{/);
+    expect(message).not.toContain("factory objects with __kind");
+  });
+
+  // Mistake #2: plaintext in secret(...). Every binding on a secret must be a
+  // provider call; a bare scalar is rejected with a message that names the key
+  // and embeds the fix.
+  it("teaches the fix for a plaintext binding inside secret(...)", () => {
+    let message = "";
+    try {
+      normalizeConfig({
+        __kind: "keyshelf:config",
+        name: "test",
+        envs: ["dev"],
+        keys: { password: { __kind: "secret", value: "hunter2" } }
+      });
+    } catch (err) {
+      message = (err as Error).message;
+    }
+    // Names the offending key.
+    expect(message).toContain("password");
+    // States every secret binding must be a provider call, listing the providers.
+    expect(message).toContain("provider call");
+    expect(message).toMatch(/age.*gcp.*aws.*sops.*plain/);
+    // Suggests config(...) for non-secret values.
+    expect(message).toContain("config(");
+    expect(message).not.toContain("factory objects with __kind");
   });
 
   it("rejects duplicate flattened paths", () => {

--- a/packages/cli/test/unit/config.test.ts
+++ b/packages/cli/test/unit/config.test.ts
@@ -275,7 +275,7 @@ describe("config factories and validation", () => {
   });
 
   it("validates template references and cycles", () => {
-    expect(() =>
+    const cfgMissing = (): void => {
       normalizeConfig(
         defineConfig({
           name: "test",
@@ -286,8 +286,11 @@ describe("config factories and validation", () => {
             }
           }
         })
-      )
-    ).toThrow('template references unknown key "db/missing"');
+      );
+    };
+    expect(cfgMissing).toThrow('template references unknown key "db/missing"');
+    // Embeds the corrective fix: declare the key in keyshelf.config.ts.
+    expect(cfgMissing).toThrow("keyshelf.config.ts");
 
     expect(() =>
       normalizeConfig(
@@ -428,6 +431,19 @@ describe("config factories and validation", () => {
         normalized.keys
       )
     ).toThrow('DB_PASSWORD: references unknown key "db/password"');
+
+    // Names the bad reference and embeds the corrective fix: declare the key in
+    // keyshelf.config.ts.
+    let message = "";
+    try {
+      validateAppMappingReferences(
+        [{ envVar: "DB_PASSWORD", keyPath: "db/password" }],
+        normalized.keys
+      );
+    } catch (err) {
+      message = (err as Error).message;
+    }
+    expect(message).toContain("keyshelf.config.ts");
   });
 });
 

--- a/packages/cli/test/unit/reconcile/apply.test.ts
+++ b/packages/cli/test/unit/reconcile/apply.test.ts
@@ -270,9 +270,19 @@ describe("applyPlan", () => {
       }
     ];
 
-    await expect(
-      applyPlan({ config: cfg, registry: buildRegistry([age]), rootDir: "/r" }, plan)
-    ).rejects.toBeInstanceOf(AmbiguousActionsError);
+    const error = await applyPlan(
+      { config: cfg, registry: buildRegistry([age]), rootDir: "/r" },
+      plan
+    ).catch((err: unknown) => err);
+
+    expect(error).toBeInstanceOf(AmbiguousActionsError);
+    const message = (error as Error).message;
+    // Names the renamed key and the candidate orphans it could not map.
+    expect(message).toContain("new");
+    expect(message).toContain("oldA");
+    expect(message).toContain("oldB");
+    // Points at movedFrom as the fix.
+    expect(message).toContain("movedFrom");
 
     expect(age.copy).not.toHaveBeenCalled();
     expect(age.delete).not.toHaveBeenCalled();

--- a/packages/cli/test/unit/yaml-loader.test.ts
+++ b/packages/cli/test/unit/yaml-loader.test.ts
@@ -95,9 +95,18 @@ describe("yaml-loader", () => {
       ".keyshelf/dev.yaml": ["keys:", "  api:", "    token: just-a-string"].join("\n")
     });
 
-    await expect(loadYamlConfig(join(root, "keyshelf.yaml"))).rejects.toThrow(
-      /secret keys require a provider tag/
-    );
+    let message = "";
+    try {
+      await loadYamlConfig(join(root, "keyshelf.yaml"));
+    } catch (err) {
+      message = (err as Error).message;
+    }
+    // Names the offending key and the active env.
+    expect(message).toContain("api/token");
+    expect(message).toContain("dev");
+    // States every secret binding must be a provider call, listing the providers.
+    expect(message).toContain("provider call");
+    expect(message).toMatch(/age.*gcp.*aws.*sops.*plain/);
   });
 
   it("accepts a !plain override on a !secret key", async () => {


### PR DESCRIPTION
## What

Make keyshelf's validation/CLI errors *teach the fix* for each of the five well-known agent mistakes (enumerated in `skills/keyshelf/SKILL.md`). Every error now names the offending key/path (and active env where relevant) and embeds the corrective action inline, using the domain vocabulary from `CONTEXT.md` (record, binding, namespace, applicable env, N/A).

This only changes the **text** of existing failures — no change to which inputs are accepted or rejected.

## The five mistakes

1. **Namespace trap** — an object literal whose fields look like record options now reports the path as a namespace and points at `config({ ... })` / `secret({ ... })`. (`config/schema.ts`)
2. **Plaintext in `secret(...)`** — both the TS schema path and the YAML `!secret` path now state that every secret binding must be a provider call (age/gcp/aws/sops/plain), and suggest `config(...)` for non-secret values. (`config/schema.ts`, `config/yaml-loader.ts`)
3. **`set` / `import` on a config record** — both commands now name the record and state that config values are edited in `keyshelf.config.ts`, not written via the CLI. (`cli/set.ts`, `cli/import.ts`)
4. **Rename without `movedFrom`** — an ambiguous rename during `keyshelf up` now names the renamed key and the candidate orphans in storage and points at `movedFrom` as the fix, both in the apply error and the pre-prompt refusal. (`reconcile/apply.ts`, `cli/up.ts`)
5. **`.env.keyshelf` / template reference to an undeclared or N/A key** — undeclared references point at declaring the key in `keyshelf.config.ts`; a `run --map` reference to a key that is N/A in the active env names the key and active env using the N/A vocabulary and states the corrective action. (`config/schema.ts`, `cli/run.ts`)

## How

`normalizeConfig` now `safeParse`s and routes the `ZodError` through `formatZodError`, which prefixes each issue with the offending key path and rewrites `__kind`-bearing node failures into the namespace-trap / plaintext-secret teaching messages. Other sites edit the literal message strings.

## Tests

Each of the five cases has a test asserting the **message content** (named key/path/env + corrective action), not just that an error is thrown. Full CLI suite: 322 passing. lint, format:check, typecheck all green locally.

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)