### PR TITLE
Reconcile lint / format / fallow / Codacy tooling over the v6 source

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,3 +1,11 @@
 exclude_paths:
   - ".claude/plans/**"
   - "*CHANGELOG.md"
+  # Generated build artifacts (mirrored in .gitignore) — not hand-authored source.
+  - "**/dist/**"
+  - "**/oclif.manifest.json"
+  - "packages/cli/platforms/**"
+  - "packages/cli/.cache/**"
+  # Stale v5 examples; rewritten under #179. Exclude until then so they don't
+  # gate this tooling reconciliation on code owned by another issue.
+  - "examples/**"

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,15 +1,14 @@
 root = true
 
+# Indentation matches Prettier (.prettierrc tabWidth: 2), the source of truth for
+# JS/TS/JSON/YAML formatting, so editors and `prettier --write` never disagree.
 [*]
 indent_style = space
-indent_size = 4
+indent_size = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
-
-[*.{json,yml,yaml}]
-indent_size = 2
 
 [*.md]
 trim_trailing_whitespace = false

--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -9,6 +9,24 @@
   "workspaces": {
     "packages": ["packages/*"]
   },
+  "ignoreDependencies": [
+    "@keyshelf/sops-darwin-arm64",
+    "@keyshelf/sops-darwin-x64",
+    "@keyshelf/sops-linux-arm64",
+    "@keyshelf/sops-linux-x64",
+    "@keyshelf/sops-win32-x64",
+    "verdaccio"
+  ],
+  "usedClassMembers": [
+    {
+      "extends": "Command",
+      "members": ["enableJsonFlag"]
+    }
+  ],
+  "health": {
+    "maxCrap": 50,
+    "maxCognitive": 18
+  },
   "duplicates": {
     "ignore": ["**/test/**"]
   },

--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -1,12 +1,16 @@
 {
   "$schema": "https://raw.githubusercontent.com/fallow-rs/fallow/main/schema.json",
-  "entry": ["packages/action/scripts/*.mjs"],
+  "entry": [
+    "packages/cli/bin/run.js",
+    "packages/cli/src/commands/*.ts",
+    "packages/cli/scripts/*.ts"
+  ],
   "ignorePatterns": ["examples/**"],
   "workspaces": {
     "packages": ["packages/*"]
   },
   "duplicates": {
-    "ignore": ["**/test/**", "packages/migrate/**"]
+    "ignore": ["**/test/**"]
   },
   "rules": {}
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,25 @@ on:
     branches: [main]
 
 jobs:
+  # Cheap, sops-free quality gate: eslint + prettier. Runs in parallel with the
+  # heavier test job so lint/format failures surface fast and gate every PR.
+  quality:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run lint
+
+      - run: npm run format:check
+
   test:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/gcp-conformance.yml
+++ b/.github/workflows/gcp-conformance.yml
@@ -6,7 +6,7 @@ name: gcp conformance
 # Per-PR signal rests on the hermetic `fake` + `sops` matrix in ci.yml.
 on:
   schedule:
-    - cron: '0 4 * * *' # nightly, 04:00 UTC
+    - cron: "0 4 * * *" # nightly, 04:00 UTC
   workflow_dispatch: {}
 
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ name: Publish
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
   # Manual dry-run: builds + verifies the integrity gates, never publishes
   # (the publish step's secret guard is still required).
   workflow_dispatch:
@@ -34,7 +34,7 @@ jobs:
         with:
           node-version: 20
           cache: npm
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
 
       - run: npm ci
 
@@ -79,7 +79,7 @@ jobs:
         if: steps.gate.outputs.enabled == 'true' && startsWith(github.ref, 'refs/tags/v')
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_CONFIG_PROVENANCE: 'true'
+          NPM_CONFIG_PROVENANCE: "true"
         run: |
           set -euo pipefail
           for key in linux-x64 linux-arm64 darwin-x64 darwin-arm64 win32-x64; do

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,7 @@
 node_modules
 dist
-!packages/action/dist
 coverage
 *.tsbuildinfo
 .keyshelf
-!packages/migrate/test/fixtures/**/.keyshelf/
-!packages/migrate/test/fixtures/**/.keyshelf/*.yaml
 .claude/worktrees/
 .fallow/

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,8 @@ dist/
 node_modules/
 .claude/
 CHANGELOG.md
+
+# Generated build artifacts (not hand-edited; mirrored in .gitignore)
+**/oclif.manifest.json
+platforms/
+packages/cli/.cache/

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "lint": "eslint .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "typecheck": "npm run typecheck --workspaces --if-present",
-    "typecheck:examples": "npm run build -w keyshelf && tsc -p examples"
+    "typecheck": "npm run typecheck --workspaces --if-present"
   },
   "license": "MIT",
   "engines": {

--- a/packages/cli/bin/run.js
+++ b/packages/cli/bin/run.js
@@ -1,4 +1,4 @@
 #!/usr/bin/env node
-import {execute} from '@oclif/core'
+import { execute } from "@oclif/core";
 
-await execute({dir: import.meta.url})
+await execute({ dir: import.meta.url });

--- a/packages/cli/scripts/build-platforms.ts
+++ b/packages/cli/scripts/build-platforms.ts
@@ -12,56 +12,91 @@
  *   tsx scripts/build-platforms.ts --host     # only the host's platform (fast; Tier 1)
  *   tsx scripts/build-platforms.ts linux-x64  # a specific platform
  */
-import process from 'node:process'
-import {assemblePackage, downloadBinary, packageDir, smokeTest} from './lib/build.js'
-import {hostPlatformKey, loadSopsManifest, platforms, type PlatformKey} from './lib/platforms.js'
+import process from "node:process";
+import { assemblePackage, downloadBinary, packageDir, smokeTest } from "./lib/build.js";
+import {
+  hostPlatformKey,
+  loadSopsManifest,
+  platforms,
+  type SopsManifest,
+  type PlatformKey
+} from "./lib/platforms.js";
 
-async function main(): Promise<void> {
-  const manifest = loadSopsManifest()
-  const args = process.argv.slice(2)
-
-  let targets: PlatformKey[]
-  if (args.includes('--host')) {
-    const host = hostPlatformKey()
+/**
+ * Resolve which platform packages this invocation should build from argv:
+ * `--host` → just the host's platform; explicit names → those; nothing → all five.
+ * Every resolved key is validated against the known platform set before returning.
+ */
+function resolveTargets(args: string[]): PlatformKey[] {
+  let targets: PlatformKey[];
+  if (args.includes("--host")) {
+    const host = hostPlatformKey();
     if (host === undefined) {
-      throw new Error(`Unsupported host ${process.platform}-${process.arch}; no bundled sops package.`)
+      throw new Error(
+        `Unsupported host ${process.platform}-${process.arch}; no bundled sops package.`
+      );
     }
-    targets = [host]
+    targets = [host];
   } else {
-    const named = args.filter((a) => !a.startsWith('--'))
-    targets = named.length > 0 ? (named as PlatformKey[]) : [...platforms]
+    const named = args.filter((a) => !a.startsWith("--"));
+    targets = named.length > 0 ? (named as PlatformKey[]) : [...platforms];
   }
 
   for (const key of targets) {
     if (!(platforms as readonly string[]).includes(key)) {
-      throw new Error(`Unknown platform '${key}'. Known: ${platforms.join(', ')}.`)
+      throw new Error(`Unknown platform '${key}'. Known: ${platforms.join(", ")}.`);
     }
   }
 
-  const host = hostPlatformKey()
+  return targets;
+}
+
+/** Smoke-test the just-assembled host binary; the only platform this machine can execute. */
+function smokeTestHost(key: PlatformKey, out: string, manifest: SopsManifest): void {
+  const version = smokeTest(`${out}/bin/${process.platform === "win32" ? "sops.exe" : "sops"}`);
+  if (!version.includes(manifest.sopsVersion)) {
+    throw new Error(
+      `Smoke test failed for ${key}: '${version}' does not report sops ${manifest.sopsVersion}.`
+    );
+  }
+  process.stdout.write(` … smoke-test ok (${version})`);
+}
+
+/** Download (checksum-verified), assemble, and — for the host — smoke-test one platform package. */
+async function buildPlatform(
+  key: PlatformKey,
+  manifest: SopsManifest,
+  host: PlatformKey | undefined
+): Promise<void> {
+  process.stdout.write(`• ${key}: downloading ${manifest.binaries[key].asset} … `);
+  const binary = await downloadBinary(key, manifest);
+  process.stdout.write("checksum ok … ");
+
+  const out = packageDir(key);
+  await assemblePackage(key, manifest, binary, out);
+  process.stdout.write("packaged");
+
+  if (key === host) {
+    smokeTestHost(key, out, manifest);
+  }
+  process.stdout.write("\n");
+}
+
+async function main(): Promise<void> {
+  const manifest = loadSopsManifest();
+  const targets = resolveTargets(process.argv.slice(2));
+  const host = hostPlatformKey();
+
   for (const key of targets) {
-    process.stdout.write(`• ${key}: downloading ${manifest.binaries[key].asset} … `)
-    const binary = await downloadBinary(key, manifest)
-    process.stdout.write('checksum ok … ')
-
-    const out = packageDir(key)
-    await assemblePackage(key, manifest, binary, out)
-    process.stdout.write('packaged')
-
-    if (key === host) {
-      const version = smokeTest(`${out}/bin/${process.platform === 'win32' ? 'sops.exe' : 'sops'}`)
-      if (!version.includes(manifest.sopsVersion)) {
-        throw new Error(`Smoke test failed for ${key}: '${version}' does not report sops ${manifest.sopsVersion}.`)
-      }
-      process.stdout.write(` … smoke-test ok (${version})`)
-    }
-    process.stdout.write('\n')
+    await buildPlatform(key, manifest, host);
   }
 
-  process.stdout.write(`\nDone. ${targets.length} platform package(s) written to platforms/.\n`)
+  process.stdout.write(`\nDone. ${targets.length} platform package(s) written to platforms/.\n`);
 }
 
 main().catch((error) => {
-  process.stderr.write(`\nplatforms build failed: ${error instanceof Error ? error.message : String(error)}\n`)
-  process.exitCode = 1
-})
+  process.stderr.write(
+    `\nplatforms build failed: ${error instanceof Error ? error.message : String(error)}\n`
+  );
+  process.exitCode = 1;
+});

--- a/packages/cli/scripts/build-platforms.ts
+++ b/packages/cli/scripts/build-platforms.ts
@@ -22,33 +22,39 @@ import {
   type PlatformKey
 } from "./lib/platforms.js";
 
+/** The host's platform key, or a hard error when this machine has no bundled sops package. */
+function requireHost(): PlatformKey {
+  const host = hostPlatformKey();
+  if (host === undefined) {
+    throw new Error(
+      `Unsupported host ${process.platform}-${process.arch}; no bundled sops package.`
+    );
+  }
+
+  return host;
+}
+
+/** Reject any key that isn't a known platform; returns the keys unchanged when all are valid. */
+function assertKnownPlatforms(keys: PlatformKey[]): PlatformKey[] {
+  for (const key of keys) {
+    if (!(platforms as readonly string[]).includes(key)) {
+      throw new Error(`Unknown platform '${key}'. Known: ${platforms.join(", ")}.`);
+    }
+  }
+
+  return keys;
+}
+
 /**
  * Resolve which platform packages this invocation should build from argv:
  * `--host` → just the host's platform; explicit names → those; nothing → all five.
  * Every resolved key is validated against the known platform set before returning.
  */
 function resolveTargets(args: string[]): PlatformKey[] {
-  let targets: PlatformKey[];
-  if (args.includes("--host")) {
-    const host = hostPlatformKey();
-    if (host === undefined) {
-      throw new Error(
-        `Unsupported host ${process.platform}-${process.arch}; no bundled sops package.`
-      );
-    }
-    targets = [host];
-  } else {
-    const named = args.filter((a) => !a.startsWith("--"));
-    targets = named.length > 0 ? (named as PlatformKey[]) : [...platforms];
-  }
+  if (args.includes("--host")) return [requireHost()];
 
-  for (const key of targets) {
-    if (!(platforms as readonly string[]).includes(key)) {
-      throw new Error(`Unknown platform '${key}'. Known: ${platforms.join(", ")}.`);
-    }
-  }
-
-  return targets;
+  const named = args.filter((a) => !a.startsWith("--"));
+  return assertKnownPlatforms(named.length > 0 ? (named as PlatformKey[]) : [...platforms]);
 }
 
 /** Smoke-test the just-assembled host binary; the only platform this machine can execute. */

--- a/packages/cli/scripts/lib/build.ts
+++ b/packages/cli/scripts/lib/build.ts
@@ -1,15 +1,15 @@
-import {execFileSync} from 'node:child_process'
-import {createHash} from 'node:crypto'
-import {existsSync} from 'node:fs'
-import {chmod, copyFile, mkdir, readFile, rm, writeFile} from 'node:fs/promises'
-import path from 'node:path'
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
+import { chmod, copyFile, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
 import {
   type PlatformKey,
   type SopsManifest,
   binaryName,
   platformPackageJson,
-  repoRoot,
-} from './platforms.js'
+  repoRoot
+} from "./platforms.js";
 
 /**
  * The supply-chain-critical half of the platform build: fetch each pinned sops
@@ -21,15 +21,15 @@ import {
  */
 
 /** Directory the downloaded release assets are cached in (gitignored). */
-const cacheDir = path.join(repoRoot, '.cache', 'sops-binaries')
+const cacheDir = path.join(repoRoot, ".cache", "sops-binaries");
 /** Where the assembled platform packages are written. */
-const platformsDir = path.join(repoRoot, 'platforms')
+const platformsDir = path.join(repoRoot, "platforms");
 /** The committed sops MPL-2.0 license text, copied into every package. */
-const sopsLicensePath = path.join(repoRoot, 'scripts', 'assets', 'sops-LICENSE')
+const sopsLicensePath = path.join(repoRoot, "scripts", "assets", "sops-LICENSE");
 
 /** Lowercase hex SHA256 of a buffer. */
 export function sha256(buf: Buffer): string {
-  return createHash('sha256').update(buf).digest('hex')
+  return createHash("sha256").update(buf).digest("hex");
 }
 
 /**
@@ -37,18 +37,18 @@ export function sha256(buf: Buffer): string {
  * gate that makes a tampered/substituted binary fail the build rather than ship.
  */
 export function verifySha256(buf: Buffer, expected: string, label: string): void {
-  const actual = sha256(buf)
+  const actual = sha256(buf);
   if (actual !== expected.toLowerCase()) {
     throw new Error(
       `Integrity check failed: checksum mismatch for ${label}.\n  expected ${expected}\n  actual   ${actual}\n` +
-        `Refusing to package an unverified binary.`,
-    )
+        `Refusing to package an unverified binary.`
+    );
   }
 }
 
 /** The download URL for one platform's pinned asset. */
 function assetUrl(key: PlatformKey, manifest: SopsManifest): string {
-  return `https://github.com/getsops/sops/releases/download/${manifest.tag}/${manifest.binaries[key].asset}`
+  return `https://github.com/getsops/sops/releases/download/${manifest.tag}/${manifest.binaries[key].asset}`;
 }
 
 /**
@@ -60,34 +60,34 @@ function assetUrl(key: PlatformKey, manifest: SopsManifest): string {
 export async function downloadBinary(
   key: PlatformKey,
   manifest: SopsManifest,
-  opts: {cacheDir?: string; fetchImpl?: typeof fetch} = {},
+  opts: { cacheDir?: string; fetchImpl?: typeof fetch } = {}
 ): Promise<Buffer> {
-  const dir = opts.cacheDir ?? cacheDir
-  const entry = manifest.binaries[key]
-  const cached = path.join(dir, entry.asset)
+  const dir = opts.cacheDir ?? cacheDir;
+  const entry = manifest.binaries[key];
+  const cached = path.join(dir, entry.asset);
 
   if (existsSync(cached)) {
-    const buf = await readFile(cached)
+    const buf = await readFile(cached);
     try {
-      verifySha256(buf, entry.sha256, key)
-      return buf
+      verifySha256(buf, entry.sha256, key);
+      return buf;
     } catch {
-      await rm(cached, {force: true})
+      await rm(cached, { force: true });
     }
   }
 
-  const doFetch = opts.fetchImpl ?? fetch
-  const res = await doFetch(assetUrl(key, manifest))
+  const doFetch = opts.fetchImpl ?? fetch;
+  const res = await doFetch(assetUrl(key, manifest));
   if (!res.ok) {
-    throw new Error(`Failed to download ${assetUrl(key, manifest)}: HTTP ${res.status}`)
+    throw new Error(`Failed to download ${assetUrl(key, manifest)}: HTTP ${res.status}`);
   }
 
-  const buf = Buffer.from(await res.arrayBuffer())
-  verifySha256(buf, entry.sha256, key)
+  const buf = Buffer.from(await res.arrayBuffer());
+  verifySha256(buf, entry.sha256, key);
 
-  await mkdir(dir, {recursive: true})
-  await writeFile(cached, buf)
-  return buf
+  await mkdir(dir, { recursive: true });
+  await writeFile(cached, buf);
+  return buf;
 }
 
 /**
@@ -99,19 +99,19 @@ export async function assemblePackage(
   key: PlatformKey,
   manifest: SopsManifest,
   binary: Buffer,
-  outDir: string,
+  outDir: string
 ): Promise<void> {
-  await rm(outDir, {recursive: true, force: true})
-  await mkdir(path.join(outDir, 'bin'), {recursive: true})
+  await rm(outDir, { recursive: true, force: true });
+  await mkdir(path.join(outDir, "bin"), { recursive: true });
 
-  const binPath = path.join(outDir, 'bin', binaryName(key))
-  await writeFile(binPath, binary)
-  await chmod(binPath, 0o755)
+  const binPath = path.join(outDir, "bin", binaryName(key));
+  await writeFile(binPath, binary);
+  await chmod(binPath, 0o755);
 
-  const pkg = platformPackageJson(key, manifest)
-  await writeFile(path.join(outDir, 'package.json'), JSON.stringify(pkg, null, 2) + '\n', 'utf8')
+  const pkg = platformPackageJson(key, manifest);
+  await writeFile(path.join(outDir, "package.json"), JSON.stringify(pkg, null, 2) + "\n", "utf8");
 
-  await copyFile(sopsLicensePath, path.join(outDir, 'LICENSE'))
+  await copyFile(sopsLicensePath, path.join(outDir, "LICENSE"));
 }
 
 /**
@@ -121,11 +121,13 @@ export async function assemblePackage(
  * `os`/`cpu` match the host (you cannot exec a foreign-arch binary).
  */
 export function smokeTest(binaryPath: string): string {
-  const out = execFileSync(binaryPath, ['--version', '--disable-version-check'], {encoding: 'utf8'})
-  return out.trim()
+  const out = execFileSync(binaryPath, ["--version", "--disable-version-check"], {
+    encoding: "utf8"
+  });
+  return out.trim();
 }
 
 /** Convenience: the assembled package directory for a platform key. */
 export function packageDir(key: PlatformKey): string {
-  return path.join(platformsDir, `sops-${key}`)
+  return path.join(platformsDir, `sops-${key}`);
 }

--- a/packages/cli/scripts/lib/platforms.ts
+++ b/packages/cli/scripts/lib/platforms.ts
@@ -1,6 +1,6 @@
-import {readFileSync} from 'node:fs'
-import {fileURLToPath} from 'node:url'
-import path from 'node:path'
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
 
 /**
  * Build-time model of the bundled-sops distribution. These pure helpers turn the
@@ -18,62 +18,68 @@ import path from 'node:path'
  * the exact getsops release the bytes came from.
  */
 
-const moduleDir = path.dirname(fileURLToPath(import.meta.url))
+const moduleDir = path.dirname(fileURLToPath(import.meta.url));
 /** Repo root: scripts/lib -> scripts -> repo. */
-export const repoRoot = path.resolve(moduleDir, '..', '..')
+export const repoRoot = path.resolve(moduleDir, "..", "..");
 
 /** The five supported `{platform}-{arch}` targets, matching `process.platform`/`process.arch`. */
-export const platforms = ['linux-x64', 'linux-arm64', 'darwin-x64', 'darwin-arm64', 'win32-x64'] as const
+export const platforms = [
+  "linux-x64",
+  "linux-arm64",
+  "darwin-x64",
+  "darwin-arm64",
+  "win32-x64"
+] as const;
 
-export type PlatformKey = (typeof platforms)[number]
+export type PlatformKey = (typeof platforms)[number];
 
 /** One platform's download + integrity record from `sops-version.json`. */
 export interface BinaryEntry {
   /** The getsops release asset name to download (e.g. `sops-v3.13.1.linux.amd64`). */
-  readonly asset: string
+  readonly asset: string;
   /** Lowercase hex SHA256 the downloaded asset must match before it is packaged. */
-  readonly sha256: string
+  readonly sha256: string;
 }
 
 /** The parsed `sops-version.json` source of truth. */
 export interface SopsManifest {
   /** The bundled sops version, stamped on all five packages and the main optionalDependencies. */
-  readonly sopsVersion: string
+  readonly sopsVersion: string;
   /** The getsops/sops git tag the binaries are downloaded from (`v${sopsVersion}`). */
-  readonly tag: string
+  readonly tag: string;
   /** Per-platform asset + checksum records. */
-  readonly binaries: Record<PlatformKey, BinaryEntry>
+  readonly binaries: Record<PlatformKey, BinaryEntry>;
 }
 
 /** The committed package metadata for one platform package. */
 export interface PlatformPackageJson {
-  readonly name: string
-  readonly version: string
-  readonly description: string
-  readonly license: 'MPL-2.0'
-  readonly os: [string]
-  readonly cpu: [string]
-  readonly files: ['bin']
-  readonly engines: {node: string}
-  readonly dependencies?: never
-  readonly optionalDependencies?: never
+  readonly name: string;
+  readonly version: string;
+  readonly description: string;
+  readonly license: "MPL-2.0";
+  readonly os: [string];
+  readonly cpu: [string];
+  readonly files: ["bin"];
+  readonly engines: { node: string };
+  readonly dependencies?: never;
+  readonly optionalDependencies?: never;
 }
 
 /** Read and parse the committed `sops-version.json`. */
 export function loadSopsManifest(root: string = repoRoot): SopsManifest {
-  const raw = readFileSync(path.join(root, 'sops-version.json'), 'utf8')
-  return JSON.parse(raw) as SopsManifest
+  const raw = readFileSync(path.join(root, "sops-version.json"), "utf8");
+  return JSON.parse(raw) as SopsManifest;
 }
 
 /** Split a `{platform}-{arch}` key into its npm `os`/`cpu` parts. */
-export function osCpu(key: PlatformKey): {os: string; cpu: string} {
-  const idx = key.lastIndexOf('-')
-  return {os: key.slice(0, idx), cpu: key.slice(idx + 1)}
+export function osCpu(key: PlatformKey): { os: string; cpu: string } {
+  const idx = key.lastIndexOf("-");
+  return { os: key.slice(0, idx), cpu: key.slice(idx + 1) };
 }
 
 /** The binary file name inside `bin/` for a platform (`sops.exe` on win32). */
-export function binaryName(key: PlatformKey): 'sops' | 'sops.exe' {
-  return key.startsWith('win32-') ? 'sops.exe' : 'sops'
+export function binaryName(key: PlatformKey): "sops" | "sops.exe" {
+  return key.startsWith("win32-") ? "sops.exe" : "sops";
 }
 
 /**
@@ -81,24 +87,24 @@ export function binaryName(key: PlatformKey): 'sops' | 'sops.exe' {
  * version tracking the bundled sops release, and the load-bearing `os`/`cpu`.
  */
 export function platformPackageJson(key: PlatformKey, manifest: SopsManifest): PlatformPackageJson {
-  const {os, cpu} = osCpu(key)
+  const { os, cpu } = osCpu(key);
   return {
     name: `@keyshelf/sops-${key}`,
     version: manifest.sopsVersion,
     description: `The sops ${manifest.sopsVersion} binary for ${os}/${cpu}, bundled for keyshelf. Installed automatically as a platform-specific optional dependency of keyshelf; not intended for direct use.`,
-    license: 'MPL-2.0',
+    license: "MPL-2.0",
     os: [os],
     cpu: [cpu],
-    files: ['bin'],
-    engines: {node: '>=18'},
-  }
+    files: ["bin"],
+    engines: { node: ">=18" }
+  };
 }
 
 /** The host's `{platform}-{arch}` key, or `undefined` if unsupported. */
 export function hostPlatformKey(
   platform: NodeJS.Platform = process.platform,
-  arch: string = process.arch,
+  arch: string = process.arch
 ): PlatformKey | undefined {
-  const key = `${platform}-${arch}`
-  return (platforms as readonly string[]).includes(key) ? (key as PlatformKey) : undefined
+  const key = `${platform}-${arch}`;
+  return (platforms as readonly string[]).includes(key) ? (key as PlatformKey) : undefined;
 }

--- a/packages/cli/scripts/lib/verdaccio.ts
+++ b/packages/cli/scripts/lib/verdaccio.ts
@@ -1,13 +1,13 @@
-import {type ChildProcess, execFile, spawn} from 'node:child_process'
-import {existsSync} from 'node:fs'
-import {mkdtemp, rm, writeFile} from 'node:fs/promises'
-import {createServer} from 'node:net'
-import os from 'node:os'
-import path from 'node:path'
-import {promisify} from 'node:util'
-import {repoRoot} from './platforms.js'
+import { type ChildProcess, execFile, spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { createServer } from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { repoRoot } from "./platforms.js";
 
-const execFileAsync = promisify(execFile)
+const execFileAsync = promisify(execFile);
 
 /**
  * An ephemeral, **strictly local** Verdaccio registry for the Tier 2 verification
@@ -25,63 +25,63 @@ const execFileAsync = promisify(execFile)
  */
 export interface VerdaccioRegistry {
   /** Base URL, always `http://127.0.0.1:<port>`. */
-  readonly url: string
+  readonly url: string;
   /** Absolute path to the throwaway npm userconfig pinned to this registry. */
-  readonly userconfig: string
+  readonly userconfig: string;
   /** A clean env for npm commands that publish/install against this registry only. */
-  npmEnv(extra?: Record<string, string>): NodeJS.ProcessEnv
+  npmEnv(extra?: Record<string, string>): NodeJS.ProcessEnv;
   /** Stop Verdaccio and remove its working directory. */
-  teardown(): Promise<void>
+  teardown(): Promise<void>;
 }
 
 /** Find a free TCP port on the loopback interface. */
 async function freePort(): Promise<number> {
   return new Promise((resolve, reject) => {
-    const srv = createServer()
-    srv.unref()
-    srv.on('error', reject)
-    srv.listen(0, '127.0.0.1', () => {
-      const addr = srv.address()
-      if (addr === null || typeof addr === 'string') {
-        reject(new Error('could not determine a free port'))
-        return
+    const srv = createServer();
+    srv.unref();
+    srv.on("error", reject);
+    srv.listen(0, "127.0.0.1", () => {
+      const addr = srv.address();
+      if (addr === null || typeof addr === "string") {
+        reject(new Error("could not determine a free port"));
+        return;
       }
 
-      const {port} = addr
-      srv.close(() => resolve(port))
-    })
-  })
+      const { port } = addr;
+      srv.close(() => resolve(port));
+    });
+  });
 }
 
 /** Resolve the verdaccio CLI entry from the repo's devDependencies. */
 function verdaccioBin(): string {
   const candidates = [
-    path.join(repoRoot, 'node_modules', '.bin', 'verdaccio'),
-    path.join(repoRoot, 'node_modules', 'verdaccio', 'bin', 'verdaccio'),
-  ]
-  const found = candidates.find((c) => existsSync(c))
+    path.join(repoRoot, "node_modules", ".bin", "verdaccio"),
+    path.join(repoRoot, "node_modules", "verdaccio", "bin", "verdaccio")
+  ];
+  const found = candidates.find((c) => existsSync(c));
   if (found === undefined) {
-    throw new Error('verdaccio is not installed; add it as a devDependency (npm i -D verdaccio).')
+    throw new Error("verdaccio is not installed; add it as a devDependency (npm i -D verdaccio).");
   }
 
-  return found
+  return found;
 }
 
 /** Poll the registry until it answers, or throw after `timeoutMs`. */
 async function waitForUp(url: string, timeoutMs = 30_000): Promise<void> {
-  const deadline = Date.now() + timeoutMs
+  const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     try {
-      const res = await fetch(`${url}/-/ping`)
-      if (res.ok || res.status === 404) return // 404 still means the HTTP server is up
+      const res = await fetch(`${url}/-/ping`);
+      if (res.ok || res.status === 404) return; // 404 still means the HTTP server is up
     } catch {
       // not up yet
     }
 
-    await new Promise((r) => setTimeout(r, 250))
+    await new Promise((r) => setTimeout(r, 250));
   }
 
-  throw new Error(`Verdaccio did not become ready at ${url} within ${timeoutMs}ms`)
+  throw new Error(`Verdaccio did not become ready at ${url} within ${timeoutMs}ms`);
 }
 
 /**
@@ -90,12 +90,12 @@ async function waitForUp(url: string, timeoutMs = 30_000): Promise<void> {
  * packages + keyshelf can be published and re-installed entirely offline.
  */
 export async function startVerdaccio(): Promise<VerdaccioRegistry> {
-  const workDir = await mkdtemp(path.join(os.tmpdir(), 'keyshelf-verdaccio-'))
-  const storage = path.join(workDir, 'storage')
-  const configPath = path.join(workDir, 'config.yaml')
-  const userconfig = path.join(workDir, '.npmrc')
-  const port = await freePort()
-  const url = `http://127.0.0.1:${port}`
+  const workDir = await mkdtemp(path.join(os.tmpdir(), "keyshelf-verdaccio-"));
+  const storage = path.join(workDir, "storage");
+  const configPath = path.join(workDir, "config.yaml");
+  const userconfig = path.join(workDir, ".npmrc");
+  const port = await freePort();
+  const url = `http://127.0.0.1:${port}`;
 
   // Safety model: keyshelf and every @keyshelf/* package are served **only** from
   // local storage with NO uplink proxy — they can never be fetched from, or
@@ -107,37 +107,37 @@ export async function startVerdaccio(): Promise<VerdaccioRegistry> {
     `storage: ${storage}`,
     // Each platform package carries a ~30-50MB sops binary; raise the body limit
     // well above Verdaccio's 10mb default so `npm publish` is not rejected (413).
-    'max_body_size: 200mb',
-    'auth:',
-    '  htpasswd:',
-    `    file: ${path.join(workDir, 'htpasswd')}`,
-    '    max_users: -1',
-    'uplinks:',
-    '  npmjs:',
-    '    url: https://registry.npmjs.org/',
-    '    cache: false',
-    'packages:',
+    "max_body_size: 200mb",
+    "auth:",
+    "  htpasswd:",
+    `    file: ${path.join(workDir, "htpasswd")}`,
+    "    max_users: -1",
+    "uplinks:",
+    "  npmjs:",
+    "    url: https://registry.npmjs.org/",
+    "    cache: false",
+    "packages:",
     // Our own packages: local-only, no proxy. Publishable, never proxied upstream.
     "  'keyshelf':",
-    '    access: $all',
-    '    publish: $all',
-    '    unpublish: $all',
+    "    access: $all",
+    "    publish: $all",
+    "    unpublish: $all",
     "  '@keyshelf/*':",
-    '    access: $all',
-    '    publish: $all',
-    '    unpublish: $all',
+    "    access: $all",
+    "    publish: $all",
+    "    unpublish: $all",
     // Everything else (third-party deps) is read-only via the npmjs uplink.
     "  '**':",
-    '    access: $all',
-    '    publish: $all',
-    '    proxy: npmjs',
-    'log:',
-    '  type: stdout',
-    '  format: pretty',
-    '  level: warn',
-    '',
-  ].join('\n')
-  await writeFile(configPath, config, 'utf8')
+    "    access: $all",
+    "    publish: $all",
+    "    proxy: npmjs",
+    "log:",
+    "  type: stdout",
+    "  format: pretty",
+    "  level: warn",
+    ""
+  ].join("\n");
+  await writeFile(configPath, config, "utf8");
 
   // An npm userconfig pinned to the local registry, with a dummy auth token so
   // `npm publish` is satisfied. Scoped to this registry only.
@@ -146,60 +146,67 @@ export async function startVerdaccio(): Promise<VerdaccioRegistry> {
     [
       `registry=${url}/`,
       `//127.0.0.1:${port}/:_authToken=local-verdaccio-token`,
-      'audit=false',
-      'fund=false',
-      '',
-    ].join('\n'),
-    'utf8',
-  )
+      "audit=false",
+      "fund=false",
+      ""
+    ].join("\n"),
+    "utf8"
+  );
 
   // Bind explicitly to the loopback IPv4 host; Verdaccio otherwise listens on
   // `localhost` (which can resolve to IPv6 ::1) and our 127.0.0.1 probe misses it.
   const child: ChildProcess = spawn(
     process.execPath,
-    [verdaccioBin(), '--config', configPath, '--listen', `127.0.0.1:${port}`],
-    {cwd: workDir, stdio: 'ignore', env: {...process.env, NODE_ENV: 'production'}},
-  )
-  child.unref()
+    [verdaccioBin(), "--config", configPath, "--listen", `127.0.0.1:${port}`],
+    { cwd: workDir, stdio: "ignore", env: { ...process.env, NODE_ENV: "production" } }
+  );
+  child.unref();
 
   try {
-    await waitForUp(url)
+    await waitForUp(url);
   } catch (error) {
-    child.kill('SIGKILL')
-    await rm(workDir, {recursive: true, force: true})
-    throw error
+    child.kill("SIGKILL");
+    await rm(workDir, { recursive: true, force: true });
+    throw error;
   }
 
   return {
     url,
     userconfig,
     npmEnv(extra: Record<string, string> = {}): NodeJS.ProcessEnv {
-      const env: NodeJS.ProcessEnv = {...process.env}
+      const env: NodeJS.ProcessEnv = { ...process.env };
       for (const k of Object.keys(env)) {
-        if (k === 'DEV' || k.startsWith('VITEST') || k.startsWith('npm_')) delete env[k]
+        if (k === "DEV" || k.startsWith("VITEST") || k.startsWith("npm_")) delete env[k];
       }
 
       return {
         ...env,
-        NODE_ENV: 'production',
+        NODE_ENV: "production",
         // Pin EVERY npm config knob that could redirect traffic to the local registry.
         npm_config_userconfig: userconfig,
         npm_config_registry: `${url}/`,
-        ...extra,
-      }
+        ...extra
+      };
     },
     async teardown() {
-      child.kill('SIGKILL')
-      await rm(workDir, {recursive: true, force: true})
-    },
-  }
+      child.kill("SIGKILL");
+      await rm(workDir, { recursive: true, force: true });
+    }
+  };
 }
 
 /** Publish a package directory to a registry, always with an explicit local --registry. */
-export async function publishToRegistry(pkgDir: string, registry: VerdaccioRegistry): Promise<void> {
-  await execFileAsync('npm', ['publish', '--registry', `${registry.url}/`, '--userconfig', registry.userconfig], {
-    cwd: pkgDir,
-    env: registry.npmEnv(),
-    maxBuffer: 64 * 1024 * 1024,
-  })
+export async function publishToRegistry(
+  pkgDir: string,
+  registry: VerdaccioRegistry
+): Promise<void> {
+  await execFileAsync(
+    "npm",
+    ["publish", "--registry", `${registry.url}/`, "--userconfig", registry.userconfig],
+    {
+      cwd: pkgDir,
+      env: registry.npmEnv(),
+      maxBuffer: 64 * 1024 * 1024
+    }
+  );
 }

--- a/packages/cli/scripts/verdaccio-verify.ts
+++ b/packages/cli/scripts/verdaccio-verify.ts
@@ -12,81 +12,123 @@
  *
  * Usage: npm run verdaccio
  */
-import {execFile} from 'node:child_process'
-import {existsSync} from 'node:fs'
-import {mkdtemp, readdir, rm, writeFile} from 'node:fs/promises'
-import os from 'node:os'
-import path from 'node:path'
-import process from 'node:process'
-import {promisify} from 'node:util'
-import {packageDir} from './lib/build.js'
-import {hostPlatformKey, platforms, repoRoot} from './lib/platforms.js'
-import {publishToRegistry, startVerdaccio} from './lib/verdaccio.js'
+import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { promisify } from "node:util";
+import { packageDir } from "./lib/build.js";
+import { hostPlatformKey, platforms, repoRoot, type PlatformKey } from "./lib/platforms.js";
+import { publishToRegistry, startVerdaccio, type VerdaccioRegistry } from "./lib/verdaccio.js";
 
-const execFileAsync = promisify(execFile)
+const execFileAsync = promisify(execFile);
 
 async function ensureBuilt(): Promise<void> {
-  const missing = platforms.filter((key) => !existsSync(path.join(packageDir(key), 'package.json')))
-  if (missing.length === 0) return
-  process.stdout.write(`Building ${missing.length} missing platform package(s) …\n`)
-  await execFileAsync('npx', ['tsx', 'scripts/build-platforms.ts'], {cwd: repoRoot, maxBuffer: 64 * 1024 * 1024})
+  const missing = platforms.filter(
+    (key) => !existsSync(path.join(packageDir(key), "package.json"))
+  );
+  if (missing.length === 0) return;
+  process.stdout.write(`Building ${missing.length} missing platform package(s) …\n`);
+  await execFileAsync("npx", ["tsx", "scripts/build-platforms.ts"], {
+    cwd: repoRoot,
+    maxBuffer: 64 * 1024 * 1024
+  });
+}
+
+/** Publish all five platform packages plus keyshelf itself to the local registry. */
+async function publishAll(registry: VerdaccioRegistry): Promise<void> {
+  for (const key of platforms) {
+    process.stdout.write(`Publishing @keyshelf/sops-${key} … `);
+    await publishToRegistry(packageDir(key), registry);
+    process.stdout.write("ok\n");
+  }
+
+  process.stdout.write("Publishing keyshelf … ");
+  await publishToRegistry(repoRoot, registry);
+  process.stdout.write("ok\n");
+}
+
+/** Which `@keyshelf/sops-*` packages npm actually installed into `proj`'s node_modules. */
+async function installedSopsPackages(proj: string): Promise<string[]> {
+  const scopeDir = path.join(proj, "node_modules", "@keyshelf");
+  if (!existsSync(scopeDir)) return [];
+  return (await readdir(scopeDir)).filter((d) => d.startsWith("sops-"));
+}
+
+/**
+ * Install keyshelf from the local registry into a throwaway project and assert
+ * npm selected ONLY the host's platform package (the other four os/cpu-skipped).
+ */
+async function verifyHostOnlyInstall(
+  registry: VerdaccioRegistry,
+  host: PlatformKey
+): Promise<void> {
+  const proj = await mkdtemp(path.join(os.tmpdir(), "keyshelf-verdaccio-verify-"));
+  try {
+    await writeFile(
+      path.join(proj, "package.json"),
+      JSON.stringify({ name: "verdaccio-verify", version: "1.0.0", private: true }, null, 2),
+      "utf8"
+    );
+    process.stdout.write("Installing keyshelf from the local registry … ");
+    await execFileAsync(
+      "npm",
+      [
+        "install",
+        "keyshelf",
+        "--registry",
+        `${registry.url}/`,
+        "--userconfig",
+        registry.userconfig,
+        "--no-audit",
+        "--no-fund"
+      ],
+      { cwd: proj, env: registry.npmEnv(), maxBuffer: 64 * 1024 * 1024 }
+    );
+    process.stdout.write("ok\n");
+
+    const present = await installedSopsPackages(proj);
+    const expected = [`sops-${host}`];
+    process.stdout.write(
+      `\nInstalled @keyshelf/sops-* packages: ${present.join(", ") || "(none)"}\n`
+    );
+    process.stdout.write(`Expected exactly: ${expected.join(", ")}\n`);
+    if (present.length !== 1 || present[0] !== expected[0]) {
+      throw new Error(
+        `os/cpu selection wrong: got [${present.join(", ")}], expected [${expected.join(", ")}]`
+      );
+    }
+
+    process.stdout.write(
+      "\n✔ Tier 2 OK: only the host platform package was installed; nothing published to npmjs.com.\n"
+    );
+  } finally {
+    await rm(proj, { recursive: true, force: true });
+  }
 }
 
 async function main(): Promise<void> {
-  const host = hostPlatformKey()
-  if (host === undefined) throw new Error(`Unsupported host ${process.platform}-${process.arch}`)
+  const host = hostPlatformKey();
+  if (host === undefined) throw new Error(`Unsupported host ${process.platform}-${process.arch}`);
 
-  await ensureBuilt()
-  process.stdout.write('Starting local Verdaccio …\n')
-  const registry = await startVerdaccio()
-  process.stdout.write(`  registry: ${registry.url}\n`)
+  await ensureBuilt();
+  process.stdout.write("Starting local Verdaccio …\n");
+  const registry = await startVerdaccio();
+  process.stdout.write(`  registry: ${registry.url}\n`);
 
   try {
-    for (const key of platforms) {
-      process.stdout.write(`Publishing @keyshelf/sops-${key} … `)
-      await publishToRegistry(packageDir(key), registry)
-      process.stdout.write('ok\n')
-    }
-
-    process.stdout.write('Publishing keyshelf … ')
-    await publishToRegistry(repoRoot, registry)
-    process.stdout.write('ok\n')
-
-    const proj = await mkdtemp(path.join(os.tmpdir(), 'keyshelf-verdaccio-verify-'))
-    try {
-      await writeFile(
-        path.join(proj, 'package.json'),
-        JSON.stringify({name: 'verdaccio-verify', version: '1.0.0', private: true}, null, 2),
-        'utf8',
-      )
-      process.stdout.write('Installing keyshelf from the local registry … ')
-      await execFileAsync(
-        'npm',
-        ['install', 'keyshelf', '--registry', `${registry.url}/`, '--userconfig', registry.userconfig, '--no-audit', '--no-fund'],
-        {cwd: proj, env: registry.npmEnv(), maxBuffer: 64 * 1024 * 1024},
-      )
-      process.stdout.write('ok\n')
-
-      const scopeDir = path.join(proj, 'node_modules', '@keyshelf')
-      const present = existsSync(scopeDir) ? (await readdir(scopeDir)).filter((d) => d.startsWith('sops-')) : []
-      const expected = [`sops-${host}`]
-      const ok = present.length === 1 && present[0] === expected[0]
-      process.stdout.write(`\nInstalled @keyshelf/sops-* packages: ${present.join(', ') || '(none)'}\n`)
-      process.stdout.write(`Expected exactly: ${expected.join(', ')}\n`)
-      if (!ok) {
-        throw new Error(`os/cpu selection wrong: got [${present.join(', ')}], expected [${expected.join(', ')}]`)
-      }
-
-      process.stdout.write('\n✔ Tier 2 OK: only the host platform package was installed; nothing published to npmjs.com.\n')
-    } finally {
-      await rm(proj, {recursive: true, force: true})
-    }
+    await publishAll(registry);
+    await verifyHostOnlyInstall(registry, host);
   } finally {
-    await registry.teardown()
+    await registry.teardown();
   }
 }
 
 main().catch((error) => {
-  process.stderr.write(`\nverdaccio verify failed: ${error instanceof Error ? error.message : String(error)}\n`)
-  process.exitCode = 1
-})
+  process.stderr.write(
+    `\nverdaccio verify failed: ${error instanceof Error ? error.message : String(error)}\n`
+  );
+  process.exitCode = 1;
+});

--- a/packages/cli/src/adapters/adapter.ts
+++ b/packages/cli/src/adapters/adapter.ts
@@ -1,4 +1,7 @@
-import type {KeyshelfError} from '../errors.js'
+// Imported solely so the {@link KeyshelfError} / @throws references in this
+// file's TSDoc resolve; it is not referenced in value or type position here.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { KeyshelfError } from "../errors.js";
 
 /**
  * The sole seam for backend-specific behavior (ADR-0002). An adapter is the code
@@ -34,7 +37,7 @@ export interface Adapter {
    * @throws {KeyshelfError} `SECRET_NOT_FOUND` when no value is stored; other
    *   codes per the mapping above.
    */
-  resolve(key: string, ref?: unknown): Promise<string>
+  resolve(key: string, ref?: unknown): Promise<string>;
 
   /**
    * Persist a secret's plaintext value into the store.
@@ -45,5 +48,5 @@ export interface Adapter {
    *   convention-resolvable write may return `undefined` (bare `!secret`); a
    *   foreign/explicit write returns the payload to embed under `{ ref: ... }`.
    */
-  write(key: string, value: string): Promise<unknown>
+  write(key: string, value: string): Promise<unknown>;
 }

--- a/packages/cli/src/adapters/fake.ts
+++ b/packages/cli/src/adapters/fake.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { KeyshelfError } from "../errors.js";
 import type { Adapter } from "./adapter.js";
+import { conventionName, refName } from "./shared.js";
 
 /**
  * The store backing the {@link FakeAdapter}: a flat `storedName -> value` map.
@@ -89,13 +90,8 @@ export class FakeAdapter implements Adapter {
     this.namespace = namespace;
   }
 
-  /** Compose the convention stored-name for a key: `{namespace}-{key}`. */
-  private conventionName(key: string): string {
-    return this.namespace === "" ? key : `${this.namespace}-${key}`;
-  }
-
   async resolve(key: string, ref?: unknown): Promise<string> {
-    const name = ref === undefined ? this.conventionName(key) : refName(ref);
+    const name = ref === undefined ? conventionName(this.namespace, key) : refName("fake", ref);
     const value = this.store.read(name);
     if (value === undefined) {
       throw new KeyshelfError("SECRET_NOT_FOUND", `No secret stored for '${name}'.`, {
@@ -108,31 +104,10 @@ export class FakeAdapter implements Adapter {
   }
 
   async write(key: string, value: string): Promise<unknown> {
-    const name = this.conventionName(key);
+    const name = conventionName(this.namespace, key);
     this.store.put(name, value);
     // Return the canonical stored name so a foreign environment can reference
     // this value explicitly via `!secret { ref: <name> }`.
     return name;
   }
-}
-
-/** Coerce an explicit `!secret` ref payload to the stored name string. */
-function refName(ref: unknown): string {
-  if (typeof ref === "string") return ref;
-  if (
-    ref &&
-    typeof ref === "object" &&
-    "ref" in ref &&
-    typeof (ref as { ref: unknown }).ref === "string"
-  ) {
-    return (ref as { ref: string }).ref;
-  }
-
-  throw new KeyshelfError(
-    "ADAPTER_ERROR",
-    `fake adapter: unsupported !secret ref payload: ${JSON.stringify(ref)}`,
-    {
-      ref
-    }
-  );
 }

--- a/packages/cli/src/adapters/fake.ts
+++ b/packages/cli/src/adapters/fake.ts
@@ -1,7 +1,7 @@
-import {existsSync, mkdirSync, readFileSync, writeFileSync} from 'node:fs'
-import path from 'node:path'
-import {KeyshelfError} from '../errors.js'
-import type {Adapter} from './adapter.js'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { KeyshelfError } from "../errors.js";
+import type { Adapter } from "./adapter.js";
 
 /**
  * The store backing the {@link FakeAdapter}: a flat `storedName -> value` map.
@@ -16,19 +16,19 @@ import type {Adapter} from './adapter.js'
  * and a `resolve` in the next must see the same store.
  */
 export interface FakeStore {
-  read(name: string): string | undefined
-  put(name: string, value: string): void
+  read(name: string): string | undefined;
+  put(name: string, value: string): void;
 }
 
 /** An in-memory store; lives only as long as the process that created it. */
 export function inMemoryStore(seed: Record<string, string> = {}): FakeStore {
-  const data = new Map<string, string>(Object.entries(seed))
+  const data = new Map<string, string>(Object.entries(seed));
   return {
     read: (name) => data.get(name),
     put: (name, value) => {
-      data.set(name, value)
-    },
-  }
+      data.set(name, value);
+    }
+  };
 }
 
 /**
@@ -39,30 +39,34 @@ export function inMemoryStore(seed: Record<string, string> = {}): FakeStore {
  */
 export function fileStore(filePath: string): FakeStore {
   function load(): Record<string, string> {
-    if (!existsSync(filePath)) return {}
+    if (!existsSync(filePath)) return {};
     try {
-      const parsed = JSON.parse(readFileSync(filePath, 'utf8')) as unknown
-      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-        return parsed as Record<string, string>
+      const parsed = JSON.parse(readFileSync(filePath, "utf8")) as unknown;
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed as Record<string, string>;
       }
     } catch (error) {
-      throw new KeyshelfError('ADAPTER_ERROR', `Could not read fake store '${filePath}': ${String(error)}`, {
-        file: filePath,
-      })
+      throw new KeyshelfError(
+        "ADAPTER_ERROR",
+        `Could not read fake store '${filePath}': ${String(error)}`,
+        {
+          file: filePath
+        }
+      );
     }
 
-    return {}
+    return {};
   }
 
   return {
     read: (name) => load()[name],
     put: (name, value) => {
-      const data = load()
-      data[name] = value
-      mkdirSync(path.dirname(filePath), {recursive: true})
-      writeFileSync(filePath, JSON.stringify(data, null, 2), 'utf8')
-    },
-  }
+      const data = load();
+      data[name] = value;
+      mkdirSync(path.dirname(filePath), { recursive: true });
+      writeFileSync(filePath, JSON.stringify(data, null, 2), "utf8");
+    }
+  };
 }
 
 /**
@@ -77,46 +81,58 @@ export function fileStore(filePath: string): FakeStore {
  * stored name.
  */
 export class FakeAdapter implements Adapter {
-  private readonly store: FakeStore
-  private readonly namespace: string
+  private readonly store: FakeStore;
+  private readonly namespace: string;
 
-  constructor(store: FakeStore, namespace = '') {
-    this.store = store
-    this.namespace = namespace
+  constructor(store: FakeStore, namespace = "") {
+    this.store = store;
+    this.namespace = namespace;
   }
 
   /** Compose the convention stored-name for a key: `{namespace}-{key}`. */
   private conventionName(key: string): string {
-    return this.namespace === '' ? key : `${this.namespace}-${key}`
+    return this.namespace === "" ? key : `${this.namespace}-${key}`;
   }
 
   async resolve(key: string, ref?: unknown): Promise<string> {
-    const name = ref === undefined ? this.conventionName(key) : refName(ref)
-    const value = this.store.read(name)
+    const name = ref === undefined ? this.conventionName(key) : refName(ref);
+    const value = this.store.read(name);
     if (value === undefined) {
-      throw new KeyshelfError('SECRET_NOT_FOUND', `No secret stored for '${name}'.`, {key, ref: name})
+      throw new KeyshelfError("SECRET_NOT_FOUND", `No secret stored for '${name}'.`, {
+        key,
+        ref: name
+      });
     }
 
-    return value
+    return value;
   }
 
   async write(key: string, value: string): Promise<unknown> {
-    const name = this.conventionName(key)
-    this.store.put(name, value)
+    const name = this.conventionName(key);
+    this.store.put(name, value);
     // Return the canonical stored name so a foreign environment can reference
     // this value explicitly via `!secret { ref: <name> }`.
-    return name
+    return name;
   }
 }
 
 /** Coerce an explicit `!secret` ref payload to the stored name string. */
 function refName(ref: unknown): string {
-  if (typeof ref === 'string') return ref
-  if (ref && typeof ref === 'object' && 'ref' in ref && typeof (ref as {ref: unknown}).ref === 'string') {
-    return (ref as {ref: string}).ref
+  if (typeof ref === "string") return ref;
+  if (
+    ref &&
+    typeof ref === "object" &&
+    "ref" in ref &&
+    typeof (ref as { ref: unknown }).ref === "string"
+  ) {
+    return (ref as { ref: string }).ref;
   }
 
-  throw new KeyshelfError('ADAPTER_ERROR', `fake adapter: unsupported !secret ref payload: ${JSON.stringify(ref)}`, {
-    ref,
-  })
+  throw new KeyshelfError(
+    "ADAPTER_ERROR",
+    `fake adapter: unsupported !secret ref payload: ${JSON.stringify(ref)}`,
+    {
+      ref
+    }
+  );
 }

--- a/packages/cli/src/adapters/gcp.ts
+++ b/packages/cli/src/adapters/gcp.ts
@@ -1,6 +1,6 @@
-import {SecretManagerServiceClient} from '@google-cloud/secret-manager'
-import {KeyshelfError} from '../errors.js'
-import type {Adapter} from './adapter.js'
+import { SecretManagerServiceClient } from "@google-cloud/secret-manager";
+import { KeyshelfError } from "../errors.js";
+import type { Adapter } from "./adapter.js";
 
 /**
  * The gcp adapter (ADR-0002, ADR-0006). It stores each key as its own Google
@@ -42,8 +42,8 @@ const GRPC = {
   NOT_FOUND: 5,
   ALREADY_EXISTS: 6,
   PERMISSION_DENIED: 7,
-  UNAUTHENTICATED: 16,
-} as const
+  UNAUTHENTICATED: 16
+} as const;
 
 /**
  * The slice of `SecretManagerServiceClient` the adapter depends on. Narrowing to
@@ -52,87 +52,101 @@ const GRPC = {
  * hermetic per-PR coverage of the adapter's own logic rides on this seam.
  */
 export interface SecretsClient {
-  accessSecretVersion(request: {name: string}): Promise<[AccessResponse, ...unknown[]]>
+  accessSecretVersion(request: { name: string }): Promise<[AccessResponse, ...unknown[]]>;
   createSecret(request: {
-    parent: string
-    secretId: string
-    secret: {replication: ReplicationPolicy}
-  }): Promise<[unknown, ...unknown[]]>
+    parent: string;
+    secretId: string;
+    secret: { replication: ReplicationPolicy };
+  }): Promise<[unknown, ...unknown[]]>;
   addSecretVersion(request: {
-    parent: string
-    payload: {data: Buffer}
-  }): Promise<[unknown, ...unknown[]]>
+    parent: string;
+    payload: { data: Buffer };
+  }): Promise<[unknown, ...unknown[]]>;
 }
 
 /** The fields of an accessSecretVersion response the adapter reads. */
 interface AccessResponse {
-  payload?: {data?: Uint8Array | string | null} | null
+  payload?: { data?: Uint8Array | string | null } | null;
 }
 
 /** A Secret Manager replication policy: automatic, or pinned to one region. */
-type ReplicationPolicy = {automatic: Record<string, never>} | {userManaged: {replicas: Array<{location: string}>}}
+type ReplicationPolicy =
+  | { automatic: Record<string, never> }
+  | { userManaged: { replicas: Array<{ location: string }> } };
 
 export class GcpAdapter implements Adapter {
-  private readonly client: SecretsClient
-  private readonly projectId: string
-  private readonly namespace: string
-  private readonly location?: string
+  private readonly client: SecretsClient;
+  private readonly projectId: string;
+  private readonly namespace: string;
+  private readonly location?: string;
 
-  constructor(opts: {projectId: string; namespace: string; location?: string; client?: SecretsClient}) {
-    this.projectId = opts.projectId
-    this.namespace = opts.namespace
-    this.location = opts.location
-    this.client = opts.client ?? (new SecretManagerServiceClient() as unknown as SecretsClient)
+  constructor(opts: {
+    projectId: string;
+    namespace: string;
+    location?: string;
+    client?: SecretsClient;
+  }) {
+    this.projectId = opts.projectId;
+    this.namespace = opts.namespace;
+    this.location = opts.location;
+    this.client = opts.client ?? (new SecretManagerServiceClient() as unknown as SecretsClient);
   }
 
   /** Compose the convention secret id for a key: `{namespace}-{key}`. */
   private conventionName(key: string): string {
-    return this.namespace === '' ? key : `${this.namespace}-${key}`
+    return this.namespace === "" ? key : `${this.namespace}-${key}`;
   }
 
   async resolve(key: string, ref?: unknown): Promise<string> {
-    const name = ref === undefined ? this.conventionName(key) : refName(ref)
-    const version = this.versionResource(name)
-    let response: AccessResponse
+    const name = ref === undefined ? this.conventionName(key) : refName(ref);
+    const version = this.versionResource(name);
+    let response: AccessResponse;
     try {
-      ;[response] = await this.client.accessSecretVersion({name: version})
+      [response] = await this.client.accessSecretVersion({ name: version });
     } catch (error) {
-      throw mapGcpError(error, {key, ref: name})
+      throw mapGcpError(error, { key, ref: name });
     }
 
-    const data = response.payload?.data
+    const data = response.payload?.data;
     if (data === undefined || data === null) {
       // A version with no payload should not happen for values we wrote, but a
       // foreign or hand-created secret could have one — treat it as absent.
-      throw new KeyshelfError('SECRET_NOT_FOUND', `Secret '${name}' has no payload in its latest version.`, {
-        key,
-        ref: name,
-      })
+      throw new KeyshelfError(
+        "SECRET_NOT_FOUND",
+        `Secret '${name}' has no payload in its latest version.`,
+        {
+          key,
+          ref: name
+        }
+      );
     }
 
     // Values were stored via JSON.stringify; recover the exact original. `data`
     // is bytes (a Buffer) for our writes, but the API may hand back a base64
     // string in some transports — Buffer.from handles both via the right coding.
-    const json = typeof data === 'string' ? Buffer.from(data, 'base64').toString('utf8') : Buffer.from(data).toString('utf8')
-    return decodeValue(json, name)
+    const json =
+      typeof data === "string"
+        ? Buffer.from(data, "base64").toString("utf8")
+        : Buffer.from(data).toString("utf8");
+    return decodeValue(json, name);
   }
 
   async write(key: string, value: string): Promise<unknown> {
-    const name = this.conventionName(key)
-    await this.ensureSecret(name)
+    const name = this.conventionName(key);
+    await this.ensureSecret(name);
     try {
       await this.client.addSecretVersion({
         parent: this.secretResource(name),
-        payload: {data: Buffer.from(JSON.stringify(value), 'utf8')},
-      })
+        payload: { data: Buffer.from(JSON.stringify(value), "utf8") }
+      });
     } catch (error) {
-      throw mapGcpError(error, {key, ref: name})
+      throw mapGcpError(error, { key, ref: name });
     }
 
     // The value is stored under the convention secret id, which is exactly the
     // name `set` resolves by — returning it records a bare `!secret`, and a
     // foreign environment can reference it explicitly via `!secret { ref: name }`.
-    return name
+    return name;
   }
 
   /** Create the secret container if it does not already exist (idempotent). */
@@ -141,63 +155,67 @@ export class GcpAdapter implements Adapter {
       await this.client.createSecret({
         parent: `projects/${this.projectId}`,
         secretId: name,
-        secret: {replication: this.replication()},
-      })
+        secret: { replication: this.replication() }
+      });
     } catch (error) {
       // A concurrent or prior write already created it — that is success here.
-      if (grpcCode(error) === GRPC.ALREADY_EXISTS) return
-      throw mapGcpError(error, {ref: name})
+      if (grpcCode(error) === GRPC.ALREADY_EXISTS) return;
+      throw mapGcpError(error, { ref: name });
     }
   }
 
   /** The replication policy from `location`: automatic, or single-region. */
   private replication(): ReplicationPolicy {
-    if (this.location === undefined || this.location === 'global') {
-      return {automatic: {}}
+    if (this.location === undefined || this.location === "global") {
+      return { automatic: {} };
     }
 
-    return {userManaged: {replicas: [{location: this.location}]}}
+    return { userManaged: { replicas: [{ location: this.location }] } };
   }
 
   /** The `projects/.../secrets/NAME` resource for a (possibly foreign) name. */
   private secretResource(name: string): string {
-    return name.startsWith('projects/') ? name : `projects/${this.projectId}/secrets/${name}`
+    return name.startsWith("projects/") ? name : `projects/${this.projectId}/secrets/${name}`;
   }
 
   /** The `.../versions/latest` resource to access for a name. */
   private versionResource(name: string): string {
-    if (name.startsWith('projects/')) {
-      return name.includes('/versions/') ? name : `${name}/versions/latest`
+    if (name.startsWith("projects/")) {
+      return name.includes("/versions/") ? name : `${name}/versions/latest`;
     }
 
-    return `projects/${this.projectId}/secrets/${name}/versions/latest`
+    return `projects/${this.projectId}/secrets/${name}/versions/latest`;
   }
 }
 
 /** Parse a JSON-encoded stored value back to its plaintext, defensively. */
 function decodeValue(json: string, name: string): string {
-  let parsed: unknown
+  let parsed: unknown;
   try {
-    parsed = JSON.parse(json)
+    parsed = JSON.parse(json);
   } catch (error) {
-    throw new KeyshelfError('ADAPTER_ERROR', `Secret '${name}' holds a value Keyshelf did not write: ${String(error)}`, {
-      ref: name,
-    })
+    throw new KeyshelfError(
+      "ADAPTER_ERROR",
+      `Secret '${name}' holds a value Keyshelf did not write: ${String(error)}`,
+      {
+        ref: name
+      }
+    );
   }
 
-  return typeof parsed === 'string' ? parsed : String(parsed)
+  return typeof parsed === "string" ? parsed : String(parsed);
 }
 
 /** A gRPC/GoogleError, narrowed to the fields we map on. */
 interface GrpcError {
-  code?: number
-  message?: string
+  code?: number;
+  message?: string;
 }
 
 /** The numeric gRPC status of a thrown error, if it carries one. */
 function grpcCode(error: unknown): number | undefined {
-  const code = (error as GrpcError | undefined)?.code
-  return typeof code === 'number' ? code : undefined
+  const code = (error as GrpcError | undefined)?.code;
+  return typeof code === "number" ? code : undefined;
 }
 
 /**
@@ -205,49 +223,70 @@ function grpcCode(error: unknown): number | undefined {
  * gRPC surfaces a numeric status on the error; credential problems thrown by the
  * auth layer before any RPC carry no status, so we fall back to a message probe.
  */
-function mapGcpError(error: unknown, ctx: {key?: string; ref: string}): KeyshelfError {
-  const code = grpcCode(error)
-  const message = (error as GrpcError | undefined)?.message ?? String(error)
-  const fields = ctx.key === undefined ? {ref: ctx.ref} : {key: ctx.key, ref: ctx.ref}
+function mapGcpError(error: unknown, ctx: { key?: string; ref: string }): KeyshelfError {
+  const code = grpcCode(error);
+  const message = (error as GrpcError | undefined)?.message ?? String(error);
+  const fields = ctx.key === undefined ? { ref: ctx.ref } : { key: ctx.key, ref: ctx.ref };
 
   if (code === GRPC.NOT_FOUND) {
-    return new KeyshelfError('SECRET_NOT_FOUND', `No secret stored for '${ctx.ref}'.`, fields)
+    return new KeyshelfError("SECRET_NOT_FOUND", `No secret stored for '${ctx.ref}'.`, fields);
   }
 
-  if (code === GRPC.PERMISSION_DENIED || code === GRPC.UNAUTHENTICATED || isCredentialFailure(message)) {
-    return new KeyshelfError('PROVIDER_AUTH', `Google Cloud rejected the credentials for '${ctx.ref}': ${firstLine(message)}`, fields)
+  if (
+    code === GRPC.PERMISSION_DENIED ||
+    code === GRPC.UNAUTHENTICATED ||
+    isCredentialFailure(message)
+  ) {
+    return new KeyshelfError(
+      "PROVIDER_AUTH",
+      `Google Cloud rejected the credentials for '${ctx.ref}': ${firstLine(message)}`,
+      fields
+    );
   }
 
-  return new KeyshelfError('ADAPTER_ERROR', `Secret Manager failed on '${ctx.ref}': ${firstLine(message)}`, fields)
+  return new KeyshelfError(
+    "ADAPTER_ERROR",
+    `Secret Manager failed on '${ctx.ref}': ${firstLine(message)}`,
+    fields
+  );
 }
 
 /** Heuristic over auth-layer error messages thrown before any RPC is made. */
 function isCredentialFailure(message: string): boolean {
-  const m = message.toLowerCase()
+  const m = message.toLowerCase();
   return (
-    m.includes('could not load the default credentials') ||
-    m.includes('credential') ||
-    m.includes('unauthenticated') ||
-    m.includes('permission denied')
-  )
+    m.includes("could not load the default credentials") ||
+    m.includes("credential") ||
+    m.includes("unauthenticated") ||
+    m.includes("permission denied")
+  );
 }
 
 /** The first non-empty line of a multi-line diagnostic, for terse messages. */
 function firstLine(text: string): string {
-  for (const line of text.split('\n')) {
-    const trimmed = line.trim()
-    if (trimmed.length > 0) return trimmed
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed.length > 0) return trimmed;
   }
 
-  return ''
+  return "";
 }
 
 /** Coerce an explicit `!secret` ref payload to the stored name string. */
 function refName(ref: unknown): string {
-  if (typeof ref === 'string') return ref
-  if (ref && typeof ref === 'object' && 'ref' in ref && typeof (ref as {ref: unknown}).ref === 'string') {
-    return (ref as {ref: string}).ref
+  if (typeof ref === "string") return ref;
+  if (
+    ref &&
+    typeof ref === "object" &&
+    "ref" in ref &&
+    typeof (ref as { ref: unknown }).ref === "string"
+  ) {
+    return (ref as { ref: string }).ref;
   }
 
-  throw new KeyshelfError('ADAPTER_ERROR', `gcp adapter: unsupported !secret ref payload: ${JSON.stringify(ref)}`, {ref})
+  throw new KeyshelfError(
+    "ADAPTER_ERROR",
+    `gcp adapter: unsupported !secret ref payload: ${JSON.stringify(ref)}`,
+    { ref }
+  );
 }

--- a/packages/cli/src/adapters/gcp.ts
+++ b/packages/cli/src/adapters/gcp.ts
@@ -1,6 +1,7 @@
 import { SecretManagerServiceClient } from "@google-cloud/secret-manager";
 import { KeyshelfError } from "../errors.js";
 import type { Adapter } from "./adapter.js";
+import { conventionName, firstLine, refName } from "./shared.js";
 
 /**
  * The gcp adapter (ADR-0002, ADR-0006). It stores each key as its own Google
@@ -92,13 +93,8 @@ export class GcpAdapter implements Adapter {
     this.client = opts.client ?? (new SecretManagerServiceClient() as unknown as SecretsClient);
   }
 
-  /** Compose the convention secret id for a key: `{namespace}-{key}`. */
-  private conventionName(key: string): string {
-    return this.namespace === "" ? key : `${this.namespace}-${key}`;
-  }
-
   async resolve(key: string, ref?: unknown): Promise<string> {
-    const name = ref === undefined ? this.conventionName(key) : refName(ref);
+    const name = ref === undefined ? conventionName(this.namespace, key) : refName("gcp", ref);
     const version = this.versionResource(name);
     let response: AccessResponse;
     try {
@@ -132,7 +128,7 @@ export class GcpAdapter implements Adapter {
   }
 
   async write(key: string, value: string): Promise<unknown> {
-    const name = this.conventionName(key);
+    const name = conventionName(this.namespace, key);
     await this.ensureSecret(name);
     try {
       await this.client.addSecretVersion({
@@ -259,34 +255,5 @@ function isCredentialFailure(message: string): boolean {
     m.includes("credential") ||
     m.includes("unauthenticated") ||
     m.includes("permission denied")
-  );
-}
-
-/** The first non-empty line of a multi-line diagnostic, for terse messages. */
-function firstLine(text: string): string {
-  for (const line of text.split("\n")) {
-    const trimmed = line.trim();
-    if (trimmed.length > 0) return trimmed;
-  }
-
-  return "";
-}
-
-/** Coerce an explicit `!secret` ref payload to the stored name string. */
-function refName(ref: unknown): string {
-  if (typeof ref === "string") return ref;
-  if (
-    ref &&
-    typeof ref === "object" &&
-    "ref" in ref &&
-    typeof (ref as { ref: unknown }).ref === "string"
-  ) {
-    return (ref as { ref: string }).ref;
-  }
-
-  throw new KeyshelfError(
-    "ADAPTER_ERROR",
-    `gcp adapter: unsupported !secret ref payload: ${JSON.stringify(ref)}`,
-    { ref }
   );
 }

--- a/packages/cli/src/adapters/registry.ts
+++ b/packages/cli/src/adapters/registry.ts
@@ -1,10 +1,10 @@
-import path from 'node:path'
-import {KeyshelfError} from '../errors.js'
-import type {Provider} from '../model.js'
-import type {Adapter} from './adapter.js'
-import {FakeAdapter, fileStore} from './fake.js'
-import {GcpAdapter} from './gcp.js'
-import {SopsAdapter} from './sops.js'
+import path from "node:path";
+import { KeyshelfError } from "../errors.js";
+import type { Provider } from "../model.js";
+import type { Adapter } from "./adapter.js";
+import { FakeAdapter, fileStore } from "./fake.js";
+import { GcpAdapter } from "./gcp.js";
+import { SopsAdapter } from "./sops.js";
 
 /**
  * Everything an adapter needs to bind to a concrete environment's store. The
@@ -15,17 +15,17 @@ import {SopsAdapter} from './sops.js'
  */
 export interface AdapterContext {
   /** The project root directory (where `.keyshelf/` lives). */
-  projectDir: string
+  projectDir: string;
   /** The project name from `config.yaml` (namespaces secrets). */
-  project: string
+  project: string;
   /** The shelf of the environment being resolved. */
-  shelf: string
+  shelf: string;
   /** The environment name being resolved. */
-  env: string
+  env: string;
 }
 
 /** Where the file-backed fake store lives, relative to the project root. */
-const FAKE_STORE_FILE = path.join('.keyshelf', '.fake-store.json')
+const FAKE_STORE_FILE = path.join(".keyshelf", ".fake-store.json");
 
 /**
  * Read a required string field from a provider's config, or fail with a
@@ -34,13 +34,13 @@ const FAKE_STORE_FILE = path.join('.keyshelf', '.fake-store.json')
  * agnostic) validator.
  */
 function requireStringField(provider: Provider, field: string, ctx: AdapterContext): string {
-  const value = provider[field]
-  if (typeof value === 'string' && value.length > 0) return value
+  const value = provider[field];
+  if (typeof value === "string" && value.length > 0) return value;
   throw new KeyshelfError(
-    'MALFORMED_FILE',
+    "MALFORMED_FILE",
     `Provider with adapter '${provider.adapter}' is missing required field '${field}'.`,
-    {file: path.join(ctx.projectDir, '.keyshelf', 'config.yaml'), reason: `missing '${field}'`},
-  )
+    { file: path.join(ctx.projectDir, ".keyshelf", "config.yaml"), reason: `missing '${field}'` }
+  );
 }
 
 /**
@@ -51,9 +51,11 @@ function requireStringField(provider: Provider, field: string, ctx: AdapterConte
  */
 function sopsStorePath(provider: Provider, ctx: AdapterContext): string {
   const template =
-    typeof provider.store === 'string' ? provider.store : path.join('.keyshelf', '{shelf}', '{env}.secrets.yaml')
-  const rel = template.replaceAll('{shelf}', ctx.shelf).replaceAll('{env}', ctx.env)
-  return path.resolve(ctx.projectDir, rel)
+    typeof provider.store === "string"
+      ? provider.store
+      : path.join(".keyshelf", "{shelf}", "{env}.secrets.yaml");
+  const rel = template.replaceAll("{shelf}", ctx.shelf).replaceAll("{env}", ctx.env);
+  return path.resolve(ctx.projectDir, rel);
 }
 
 /**
@@ -65,45 +67,45 @@ function sopsStorePath(provider: Provider, ctx: AdapterContext): string {
  */
 export function createAdapter(provider: Provider, ctx: AdapterContext): Adapter {
   switch (provider.adapter) {
-    case 'fake': {
+    case "fake": {
       // Persist to a JSON file under the project so a value written in one
       // `keyshelf` process is resolvable by a separate process later (the E2E
       // suite spawns the real binary across invocations). The namespace mirrors
       // the reference convention `{project}-{shelf}-{env}` so the same key in
       // different environments stays distinct in the shared store.
       const storePath =
-        typeof provider.store === 'string'
+        typeof provider.store === "string"
           ? path.resolve(ctx.projectDir, provider.store)
-          : path.join(ctx.projectDir, FAKE_STORE_FILE)
-      const namespace = `${ctx.project}-${ctx.shelf}-${ctx.env}`
-      return new FakeAdapter(fileStore(storePath), namespace)
+          : path.join(ctx.projectDir, FAKE_STORE_FILE);
+      const namespace = `${ctx.project}-${ctx.shelf}-${ctx.env}`;
+      return new FakeAdapter(fileStore(storePath), namespace);
     }
 
-    case 'sops': {
+    case "sops": {
       // The store is a per-environment encrypted sibling file; recipients come
       // from the project's `.sops.yaml`, which sops discovers by walking up from
       // the store path — so the adapter runs sops with the project root as cwd.
-      return new SopsAdapter({storePath: sopsStorePath(provider, ctx), cwd: ctx.projectDir})
+      return new SopsAdapter({ storePath: sopsStorePath(provider, ctx), cwd: ctx.projectDir });
     }
 
-    case 'gcp': {
+    case "gcp": {
       // One secret per key in the provider's GCP project, named by the reference
       // convention `{project}-{shelf}-{env}-{key}`; the namespace is the
       // `{project}-{shelf}-{env}` prefix so the same key across environments
       // stays distinct in the shared backend. `location` is an optional
       // replication hint (absent/`global` ⇒ automatic).
-      const projectId = requireStringField(provider, 'projectId', ctx)
-      const location = typeof provider.location === 'string' ? provider.location : undefined
-      const namespace = `${ctx.project}-${ctx.shelf}-${ctx.env}`
-      return new GcpAdapter({projectId, namespace, location})
+      const projectId = requireStringField(provider, "projectId", ctx);
+      const location = typeof provider.location === "string" ? provider.location : undefined;
+      const namespace = `${ctx.project}-${ctx.shelf}-${ctx.env}`;
+      return new GcpAdapter({ projectId, namespace, location });
     }
 
     default: {
       throw new KeyshelfError(
-        'ADAPTER_UNAVAILABLE',
+        "ADAPTER_UNAVAILABLE",
         `Unknown adapter '${provider.adapter}'. No adapter is registered for it.`,
-        {adapter: provider.adapter},
-      )
+        { adapter: provider.adapter }
+      );
     }
   }
 }

--- a/packages/cli/src/adapters/shared.ts
+++ b/packages/cli/src/adapters/shared.ts
@@ -1,0 +1,46 @@
+import { KeyshelfError } from "../errors.js";
+
+/**
+ * Helpers shared verbatim across the concrete adapters (fake, gcp, sops). They
+ * were previously copy-pasted per adapter; centralizing them keeps the
+ * convention-naming and `!secret` ref-coercion rules identical everywhere, which
+ * is exactly what the adapter contract (ADR-0005) requires.
+ */
+
+/** Compose the convention stored-name for a key: `{namespace}-{key}` (bare key when unnamespaced). */
+export function conventionName(namespace: string, key: string): string {
+  return namespace === "" ? key : `${namespace}-${key}`;
+}
+
+/**
+ * Coerce an explicit `!secret` ref payload to the stored name string. Accepts a
+ * bare string or a `{ ref: string }` object; anything else is an `ADAPTER_ERROR`
+ * tagged with the calling adapter's name.
+ */
+export function refName(adapterName: string, ref: unknown): string {
+  if (typeof ref === "string") return ref;
+  if (
+    ref &&
+    typeof ref === "object" &&
+    "ref" in ref &&
+    typeof (ref as { ref: unknown }).ref === "string"
+  ) {
+    return (ref as { ref: string }).ref;
+  }
+
+  throw new KeyshelfError(
+    "ADAPTER_ERROR",
+    `${adapterName} adapter: unsupported !secret ref payload: ${JSON.stringify(ref)}`,
+    { ref }
+  );
+}
+
+/** The first non-empty line of a multi-line diagnostic, for terse messages. */
+export function firstLine(text: string): string {
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed.length > 0) return trimmed;
+  }
+
+  return "";
+}

--- a/packages/cli/src/adapters/sops-binary.ts
+++ b/packages/cli/src/adapters/sops-binary.ts
@@ -1,9 +1,9 @@
-import {execFileSync} from 'node:child_process'
-import {existsSync} from 'node:fs'
-import {createRequire} from 'node:module'
-import path from 'node:path'
-import process from 'node:process'
-import {KeyshelfError} from '../errors.js'
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import process from "node:process";
+import { KeyshelfError } from "../errors.js";
 
 /**
  * Resolve the `sops` binary to shell out to (ADR-0003). The distribution model is
@@ -29,30 +29,30 @@ import {KeyshelfError} from '../errors.js'
  * but until they ship the PATH fallback is what is actually exercised.
  */
 export function resolveSopsBinary(): string {
-  const override = process.env.KEYSHELF_SOPS_BIN
+  const override = process.env.KEYSHELF_SOPS_BIN;
   if (override !== undefined && override.length > 0) {
     if (!existsSync(override)) {
-      throw unavailable(`KEYSHELF_SOPS_BIN points at '${override}', which does not exist.`)
+      throw unavailable(`KEYSHELF_SOPS_BIN points at '${override}', which does not exist.`);
     }
 
-    return override
+    return override;
   }
 
-  const bundled = bundledBinaryPath()
-  if (bundled !== undefined) return bundled
+  const bundled = bundledBinaryPath();
+  if (bundled !== undefined) return bundled;
 
-  const onPath = sopsOnPath()
-  if (onPath !== undefined) return onPath
+  const onPath = sopsOnPath();
+  if (onPath !== undefined) return onPath;
 
   throw unavailable(
     `No usable 'sops' binary found. Keyshelf bundles one as the optional dependency ` +
-      `'${platformPackage()}'; install it (or any 'sops' on your PATH) to use the sops adapter.`,
-  )
+      `'${platformPackage()}'; install it (or any 'sops' on your PATH) to use the sops adapter.`
+  );
 }
 
 /** The optional-dependency package name carrying this host's bundled binary. */
 export function platformPackage(): string {
-  return `@keyshelf/sops-${process.platform}-${process.arch}`
+  return `@keyshelf/sops-${process.platform}-${process.arch}`;
 }
 
 /**
@@ -62,30 +62,34 @@ export function platformPackage(): string {
  * lookup works regardless of where the dependency was hoisted.
  */
 function bundledBinaryPath(): string | undefined {
-  const pkg = platformPackage()
-  const require = createRequire(import.meta.url)
-  let pkgJson: string
+  const pkg = platformPackage();
+  const require = createRequire(import.meta.url);
+  let pkgJson: string;
   try {
-    pkgJson = require.resolve(`${pkg}/package.json`)
+    pkgJson = require.resolve(`${pkg}/package.json`);
   } catch {
-    return undefined
+    return undefined;
   }
 
-  const binary = path.join(path.dirname(pkgJson), 'bin', process.platform === 'win32' ? 'sops.exe' : 'sops')
-  return existsSync(binary) ? binary : undefined
+  const binary = path.join(
+    path.dirname(pkgJson),
+    "bin",
+    process.platform === "win32" ? "sops.exe" : "sops"
+  );
+  return existsSync(binary) ? binary : undefined;
 }
 
 /** Find a `sops` on `PATH`, or `undefined` if none is discoverable/usable. */
 function sopsOnPath(): string | undefined {
-  const lookup = process.platform === 'win32' ? 'where' : 'which'
+  const lookup = process.platform === "win32" ? "where" : "which";
   try {
-    const found = execFileSync(lookup, ['sops'], {encoding: 'utf8'}).split('\n')[0]?.trim()
-    return found && found.length > 0 && existsSync(found) ? found : undefined
+    const found = execFileSync(lookup, ["sops"], { encoding: "utf8" }).split("\n")[0]?.trim();
+    return found && found.length > 0 && existsSync(found) ? found : undefined;
   } catch {
-    return undefined
+    return undefined;
   }
 }
 
 function unavailable(message: string): KeyshelfError {
-  return new KeyshelfError('ADAPTER_UNAVAILABLE', message)
+  return new KeyshelfError("ADAPTER_UNAVAILABLE", message);
 }

--- a/packages/cli/src/adapters/sops.ts
+++ b/packages/cli/src/adapters/sops.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { promisify } from "node:util";
 import { KeyshelfError } from "../errors.js";
 import type { Adapter } from "./adapter.js";
+import { firstLine, refName } from "./shared.js";
 import { resolveSopsBinary } from "./sops-binary.js";
 
 const execFileAsync = promisify(execFile);
@@ -48,7 +49,7 @@ export class SopsAdapter implements Adapter {
   }
 
   async resolve(key: string, ref?: unknown): Promise<string> {
-    const name = ref === undefined ? key : refName(ref);
+    const name = ref === undefined ? key : refName("sops", ref);
     const store = await this.decryptStore();
     if (!Object.prototype.hasOwnProperty.call(store, name)) {
       throw new KeyshelfError(
@@ -204,35 +205,6 @@ function isAuthFailure(stderr: string): boolean {
     s.includes("no master key") ||
     s.includes("master key was able to decrypt") ||
     s.includes("did not find keys")
-  );
-}
-
-/** The first non-empty line of a multi-line diagnostic, for terse messages. */
-function firstLine(text: string): string {
-  for (const line of text.split("\n")) {
-    const trimmed = line.trim();
-    if (trimmed.length > 0) return trimmed;
-  }
-
-  return "";
-}
-
-/** Coerce an explicit `!secret` ref payload to the stored name string. */
-function refName(ref: unknown): string {
-  if (typeof ref === "string") return ref;
-  if (
-    ref &&
-    typeof ref === "object" &&
-    "ref" in ref &&
-    typeof (ref as { ref: unknown }).ref === "string"
-  ) {
-    return (ref as { ref: string }).ref;
-  }
-
-  throw new KeyshelfError(
-    "ADAPTER_ERROR",
-    `sops adapter: unsupported !secret ref payload: ${JSON.stringify(ref)}`,
-    { ref }
   );
 }
 

--- a/packages/cli/src/adapters/sops.ts
+++ b/packages/cli/src/adapters/sops.ts
@@ -1,13 +1,13 @@
-import {execFile} from 'node:child_process'
-import {existsSync} from 'node:fs'
-import {mkdir, writeFile} from 'node:fs/promises'
-import path from 'node:path'
-import {promisify} from 'node:util'
-import {KeyshelfError} from '../errors.js'
-import type {Adapter} from './adapter.js'
-import {resolveSopsBinary} from './sops-binary.js'
+import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+import { KeyshelfError } from "../errors.js";
+import type { Adapter } from "./adapter.js";
+import { resolveSopsBinary } from "./sops-binary.js";
 
-const execFileAsync = promisify(execFile)
+const execFileAsync = promisify(execFile);
 
 /**
  * The sops adapter (ADR-0002, ADR-0003). It owns no cryptography of its own —
@@ -38,41 +38,45 @@ const execFileAsync = promisify(execFile)
  */
 export class SopsAdapter implements Adapter {
   /** Absolute path to the per-environment encrypted store. */
-  private readonly storePath: string
+  private readonly storePath: string;
   /** Directory sops runs in, so it discovers the project's `.sops.yaml`. */
-  private readonly cwd: string
+  private readonly cwd: string;
 
-  constructor(opts: {storePath: string; cwd: string}) {
-    this.storePath = opts.storePath
-    this.cwd = opts.cwd
+  constructor(opts: { storePath: string; cwd: string }) {
+    this.storePath = opts.storePath;
+    this.cwd = opts.cwd;
   }
 
   async resolve(key: string, ref?: unknown): Promise<string> {
-    const name = ref === undefined ? key : refName(ref)
-    const store = await this.decryptStore()
+    const name = ref === undefined ? key : refName(ref);
+    const store = await this.decryptStore();
     if (!Object.prototype.hasOwnProperty.call(store, name)) {
-      throw new KeyshelfError('SECRET_NOT_FOUND', `No secret stored for '${name}' in '${this.storePath}'.`, {
-        key,
-        ref: name,
-        file: this.storePath,
-      })
+      throw new KeyshelfError(
+        "SECRET_NOT_FOUND",
+        `No secret stored for '${name}' in '${this.storePath}'.`,
+        {
+          key,
+          ref: name,
+          file: this.storePath
+        }
+      );
     }
 
-    return store[name]
+    return store[name];
   }
 
   async write(key: string, value: string): Promise<unknown> {
-    await this.ensureStore()
+    await this.ensureStore();
     // `sops set` mutates the encrypted file in place, re-encrypting under the
     // recipients its `.sops.yaml` creation rules define. The value is carried as
     // a JSON string so it survives the YAML round-trip byte-exactly.
-    await this.sops(['set', this.storePath, `["${jsonPathSegment(key)}"]`, JSON.stringify(value)])
+    await this.sops(["set", this.storePath, `["${jsonPathSegment(key)}"]`, JSON.stringify(value)]);
     // The value is stored under the key itself, which is exactly how `resolve`
     // finds it by convention — so a convention write records a *bare* `!secret`
     // (the contract lets `write` return `undefined` for this). A foreign
     // environment can still reference the value explicitly via
     // `!secret { ref: <key> }`, which `resolve` honours.
-    return undefined
+    return undefined;
   }
 
   /**
@@ -81,29 +85,35 @@ export class SopsAdapter implements Adapter {
    * represented here as an empty map (the caller raises the structured error).
    */
   private async decryptStore(): Promise<Record<string, string>> {
-    if (!existsSync(this.storePath)) return {}
-    const {stdout} = await this.sops(['decrypt', '--output-type', 'json', this.storePath])
-    let parsed: unknown
+    if (!existsSync(this.storePath)) return {};
+    const { stdout } = await this.sops(["decrypt", "--output-type", "json", this.storePath]);
+    let parsed: unknown;
     try {
-      parsed = JSON.parse(stdout)
+      parsed = JSON.parse(stdout);
     } catch (error) {
-      throw new KeyshelfError('ADAPTER_ERROR', `sops produced unparseable output for '${this.storePath}': ${String(error)}`, {
-        file: this.storePath,
-      })
+      throw new KeyshelfError(
+        "ADAPTER_ERROR",
+        `sops produced unparseable output for '${this.storePath}': ${String(error)}`,
+        {
+          file: this.storePath
+        }
+      );
     }
 
-    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
-      throw new KeyshelfError('ADAPTER_ERROR', `sops store '${this.storePath}' is not a mapping.`, {file: this.storePath})
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new KeyshelfError("ADAPTER_ERROR", `sops store '${this.storePath}' is not a mapping.`, {
+        file: this.storePath
+      });
     }
 
     // Every value was stored via JSON.stringify, so it decrypts back to a JSON
     // string; coerce non-string scalars defensively.
-    const out: Record<string, string> = {}
+    const out: Record<string, string> = {};
     for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
-      out[k] = typeof v === 'string' ? v : String(v)
+      out[k] = typeof v === "string" ? v : String(v);
     }
 
-    return out
+    return out;
   }
 
   /**
@@ -112,34 +122,34 @@ export class SopsAdapter implements Adapter {
    * applies the project's `.sops.yaml` creation rules (recipients) to it.
    */
   private async ensureStore(): Promise<void> {
-    if (existsSync(this.storePath)) return
-    await mkdir(path.dirname(this.storePath), {recursive: true})
+    if (existsSync(this.storePath)) return;
+    await mkdir(path.dirname(this.storePath), { recursive: true });
     // An empty JSON object is a valid empty YAML mapping; sops encrypts it in
     // place under the recipients its creation rules resolve for this path.
-    await writeFile(this.storePath, '{}\n', 'utf8')
-    await this.sops(['encrypt', '--in-place', '--input-type', 'yaml', this.storePath])
+    await writeFile(this.storePath, "{}\n", "utf8");
+    await this.sops(["encrypt", "--in-place", "--input-type", "yaml", this.storePath]);
   }
 
   /** Run sops, translating spawn/exit failures into the structured error codes. */
-  private async sops(args: string[]): Promise<{stdout: string; stderr: string}> {
-    const bin = resolveSopsBinary()
+  private async sops(args: string[]): Promise<{ stdout: string; stderr: string }> {
+    const bin = resolveSopsBinary();
     try {
-      const {stdout, stderr} = await execFileAsync(bin, args, {
+      const { stdout, stderr } = await execFileAsync(bin, args, {
         cwd: this.cwd,
-        maxBuffer: 64 * 1024 * 1024,
-      })
-      return {stdout, stderr}
+        maxBuffer: 64 * 1024 * 1024
+      });
+      return { stdout, stderr };
     } catch (error) {
-      throw mapSopsError(error, this.storePath)
+      throw mapSopsError(error, this.storePath);
     }
   }
 }
 
 /** A failed `execFile`, narrowed to the fields we map on. */
 interface ExecError {
-  code?: number | string
-  stderr?: string | Buffer
-  message?: string
+  code?: number | string;
+  stderr?: string | Buffer;
+  message?: string;
 }
 
 /**
@@ -151,61 +161,82 @@ interface ExecError {
  * fall back to `ADAPTER_ERROR`.
  */
 function mapSopsError(error: unknown, file: string): KeyshelfError {
-  const e = error as ExecError
-  const stderr = e.stderr === undefined ? '' : e.stderr.toString()
+  const e = error as ExecError;
+  const stderr = e.stderr === undefined ? "" : e.stderr.toString();
 
-  if (e.code === 'ENOENT') {
-    return new KeyshelfError('ADAPTER_UNAVAILABLE', `The 'sops' binary could not be executed: ${e.message ?? 'ENOENT'}.`, {
-      file,
-    })
+  if (e.code === "ENOENT") {
+    return new KeyshelfError(
+      "ADAPTER_UNAVAILABLE",
+      `The 'sops' binary could not be executed: ${e.message ?? "ENOENT"}.`,
+      {
+        file
+      }
+    );
   }
 
   // sops reports a decryption-key/credential failure when no configured key can
   // recover the data key. These are the user's credential problem → PROVIDER_AUTH.
   if (isAuthFailure(stderr)) {
-    return new KeyshelfError('PROVIDER_AUTH', `sops could not decrypt '${file}': no usable decryption key. ${firstLine(stderr)}`, {
-      file,
-    })
+    return new KeyshelfError(
+      "PROVIDER_AUTH",
+      `sops could not decrypt '${file}': no usable decryption key. ${firstLine(stderr)}`,
+      {
+        file
+      }
+    );
   }
 
-  return new KeyshelfError('ADAPTER_ERROR', `sops failed on '${file}': ${firstLine(stderr) || e.message || 'unknown error'}`, {
-    file,
-  })
+  return new KeyshelfError(
+    "ADAPTER_ERROR",
+    `sops failed on '${file}': ${firstLine(stderr) || e.message || "unknown error"}`,
+    {
+      file
+    }
+  );
 }
 
 /** Heuristic over sops stderr identifying a missing/wrong decryption key. */
 function isAuthFailure(stderr: string): boolean {
-  const s = stderr.toLowerCase()
+  const s = stderr.toLowerCase();
   return (
-    s.includes('data key') ||
-    s.includes('no identity matched') ||
-    s.includes('no master key') ||
-    s.includes('master key was able to decrypt') ||
-    s.includes('did not find keys')
-  )
+    s.includes("data key") ||
+    s.includes("no identity matched") ||
+    s.includes("no master key") ||
+    s.includes("master key was able to decrypt") ||
+    s.includes("did not find keys")
+  );
 }
 
 /** The first non-empty line of a multi-line diagnostic, for terse messages. */
 function firstLine(text: string): string {
-  for (const line of text.split('\n')) {
-    const trimmed = line.trim()
-    if (trimmed.length > 0) return trimmed
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed.length > 0) return trimmed;
   }
 
-  return ''
+  return "";
 }
 
 /** Coerce an explicit `!secret` ref payload to the stored name string. */
 function refName(ref: unknown): string {
-  if (typeof ref === 'string') return ref
-  if (ref && typeof ref === 'object' && 'ref' in ref && typeof (ref as {ref: unknown}).ref === 'string') {
-    return (ref as {ref: string}).ref
+  if (typeof ref === "string") return ref;
+  if (
+    ref &&
+    typeof ref === "object" &&
+    "ref" in ref &&
+    typeof (ref as { ref: unknown }).ref === "string"
+  ) {
+    return (ref as { ref: string }).ref;
   }
 
-  throw new KeyshelfError('ADAPTER_ERROR', `sops adapter: unsupported !secret ref payload: ${JSON.stringify(ref)}`, {ref})
+  throw new KeyshelfError(
+    "ADAPTER_ERROR",
+    `sops adapter: unsupported !secret ref payload: ${JSON.stringify(ref)}`,
+    { ref }
+  );
 }
 
 /** Escape a key for embedding inside the `["KEY"]` JSON path sops set expects. */
 function jsonPathSegment(key: string): string {
-  return key.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+  return key.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
 }

--- a/packages/cli/src/base-command.ts
+++ b/packages/cli/src/base-command.ts
@@ -1,5 +1,5 @@
-import {Command} from '@oclif/core'
-import {KeyshelfError} from './errors.js'
+import { Command } from "@oclif/core";
+import { KeyshelfError } from "./errors.js";
 
 /**
  * Base for every Keyshelf command.
@@ -12,19 +12,19 @@ import {KeyshelfError} from './errors.js'
  *   Framework errors (bad flags, `--help`) fall through to oclif's defaults.
  */
 export abstract class BaseCommand extends Command {
-  static enableJsonFlag = true
+  static enableJsonFlag = true;
 
-  protected async catch(err: Error & {exitCode?: number}): Promise<unknown> {
+  protected async catch(err: Error & { exitCode?: number }): Promise<unknown> {
     if (err instanceof KeyshelfError) {
       if (this.jsonEnabled()) {
-        process.stdout.write(`${JSON.stringify({error: err.toJSON()})}\n`)
+        process.stdout.write(`${JSON.stringify({ error: err.toJSON() })}\n`);
       } else {
-        process.stderr.write(`error[${err.code}]: ${err.message}\n`)
+        process.stderr.write(`error[${err.code}]: ${err.message}\n`);
       }
 
-      return this.exit(1)
+      return this.exit(1);
     }
 
-    return super.catch(err)
+    return super.catch(err);
   }
 }

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,10 +1,10 @@
-import {Flags} from '@oclif/core'
-import {existsSync} from 'node:fs'
-import {mkdir, writeFile} from 'node:fs/promises'
-import path from 'node:path'
-import {stringify} from 'yaml'
-import {BaseCommand} from '../base-command.js'
-import {KeyshelfError} from '../errors.js'
+import { Flags } from "@oclif/core";
+import { existsSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { stringify } from "yaml";
+import { BaseCommand } from "../base-command.js";
+import { KeyshelfError } from "../errors.js";
 
 /**
  * Scaffold a new Keyshelf project: a `.keyshelf/` directory holding `config.yaml`
@@ -13,56 +13,60 @@ import {KeyshelfError} from '../errors.js'
  * unless `--force` is given.
  */
 export default class Init extends BaseCommand {
-  static description = 'Scaffold a new Keyshelf project in the current directory.'
+  static description = "Scaffold a new Keyshelf project in the current directory.";
 
   static examples = [
-    '<%= config.bin %> init',
-    '<%= config.bin %> init --project my-app --shelf web',
-    '<%= config.bin %> init --force',
-  ]
+    "<%= config.bin %> init",
+    "<%= config.bin %> init --project my-app --shelf web",
+    "<%= config.bin %> init --force"
+  ];
 
   static flags = {
     project: Flags.string({
-      description: 'Project name (defaults to the current directory name).',
+      description: "Project name (defaults to the current directory name)."
     }),
     shelf: Flags.string({
-      description: 'Name of the starter shelf to create.',
-      default: 'app',
+      description: "Name of the starter shelf to create.",
+      default: "app"
     }),
     force: Flags.boolean({
-      description: 'Overwrite an existing Keyshelf project.',
-      default: false,
-    }),
-  }
+      description: "Overwrite an existing Keyshelf project.",
+      default: false
+    })
+  };
 
-  async run(): Promise<{project: string; shelf: string; path: string; created: string[]}> {
-    const {flags} = await this.parse(Init)
+  async run(): Promise<{ project: string; shelf: string; path: string; created: string[] }> {
+    const { flags } = await this.parse(Init);
 
-    const cwd = process.cwd()
-    const root = path.join(cwd, '.keyshelf')
-    const configPath = path.join(root, 'config.yaml')
-    const project = flags.project ?? path.basename(cwd)
-    const {shelf} = flags
+    const cwd = process.cwd();
+    const root = path.join(cwd, ".keyshelf");
+    const configPath = path.join(root, "config.yaml");
+    const project = flags.project ?? path.basename(cwd);
+    const { shelf } = flags;
 
     if (existsSync(configPath) && !flags.force) {
       throw new KeyshelfError(
-        'ALREADY_INITIALIZED',
+        "ALREADY_INITIALIZED",
         `A Keyshelf project already exists at ${configPath}. Pass --force to overwrite.`,
-        {path: configPath},
-      )
+        { path: configPath }
+      );
     }
 
-    const shelfDir = path.join(root, shelf)
-    await mkdir(shelfDir, {recursive: true})
+    const shelfDir = path.join(root, shelf);
+    await mkdir(shelfDir, { recursive: true });
 
-    await writeFile(configPath, stringify({project, providers: {local: {adapter: 'sops'}}}), 'utf8')
-    await writeFile(path.join(shelfDir, 'schema.yaml'), stringify({keys: {}}), 'utf8')
+    await writeFile(
+      configPath,
+      stringify({ project, providers: { local: { adapter: "sops" } } }),
+      "utf8"
+    );
+    await writeFile(path.join(shelfDir, "schema.yaml"), stringify({ keys: {} }), "utf8");
 
-    const created = ['config.yaml', `${shelf}/schema.yaml`]
+    const created = ["config.yaml", `${shelf}/schema.yaml`];
     if (!this.jsonEnabled()) {
-      this.log(`Initialized Keyshelf project '${project}' with shelf '${shelf}'.`)
+      this.log(`Initialized Keyshelf project '${project}' with shelf '${shelf}'.`);
     }
 
-    return {project, shelf, path: root, created}
+    return { project, shelf, path: root, created };
   }
 }

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -1,12 +1,12 @@
-import {spawn} from 'node:child_process'
-import {Args, Flags} from '@oclif/core'
-import {createAdapter} from '../adapters/registry.js'
-import {BaseCommand} from '../base-command.js'
-import {KeyshelfError} from '../errors.js'
-import {loadEnvironment} from '../loader.js'
-import {buildChildEnv, parseSet, resolveEnvironment} from '../resolve.js'
-import {parseTarget} from '../target.js'
-import {validateEnvironment} from '../validate.js'
+import { spawn } from "node:child_process";
+import { Args, Flags } from "@oclif/core";
+import { createAdapter } from "../adapters/registry.js";
+import { BaseCommand } from "../base-command.js";
+import { KeyshelfError } from "../errors.js";
+import { loadEnvironment } from "../loader.js";
+import { buildChildEnv, parseSet, resolveEnvironment } from "../resolve.js";
+import { parseTarget } from "../target.js";
+import { validateEnvironment } from "../validate.js";
 
 /**
  * Resolve a `{shelf}/{env}`'s config into environment variables, overlay them on
@@ -28,61 +28,62 @@ import {validateEnvironment} from '../validate.js'
  * the pre-exec resolution; an unresolvable secret aborts before exec.
  */
 export default class Run extends BaseCommand {
-  static description = "Resolve a shelf/env's config into env vars and exec a wrapped command after '--'."
+  static description =
+    "Resolve a shelf/env's config into env vars and exec a wrapped command after '--'.";
 
   static examples = [
-    '<%= config.bin %> run web/staging -- printenv REGION',
-    '<%= config.bin %> run web/staging --set LOG_LEVEL=trace -- node server.js',
-  ]
+    "<%= config.bin %> run web/staging -- printenv REGION",
+    "<%= config.bin %> run web/staging --set LOG_LEVEL=trace -- node server.js"
+  ];
 
   // The wrapped command and its arguments are arbitrary positionals; oclif must
   // not reject them. We split argv on `--` ourselves so the wrapped command's own
   // flags are never parsed as keyshelf flags.
-  static strict = false
+  static strict = false;
 
   static args = {
     target: Args.string({
-      description: 'The environment to run as <shelf>/<env>.',
-      required: true,
-    }),
-  }
+      description: "The environment to run as <shelf>/<env>.",
+      required: true
+    })
+  };
 
   static flags = {
     set: Flags.string({
-      description: 'Override or add an env var (highest precedence). Repeatable. KEY=VALUE.',
-      multiple: true,
-    }),
-  }
+      description: "Override or add an env var (highest precedence). Repeatable. KEY=VALUE.",
+      multiple: true
+    })
+  };
 
   async run(): Promise<never> {
-    const {target, command} = this.splitArgv()
+    const { target, command } = this.splitArgv();
 
-    const {shelf, env} = parseTarget(target)
+    const { shelf, env } = parseTarget(target);
 
     // --set flags (and --json) live before `--`; parse only that left side.
-    const {flags} = await this.parse(Run)
-    const sets: Record<string, string> = {}
+    const { flags } = await this.parse(Run);
+    const sets: Record<string, string> = {};
     for (const assignment of flags.set ?? []) {
-      const {key, value} = parseSet(assignment)
-      sets[key] = value
+      const { key, value } = parseSet(assignment);
+      sets[key] = value;
     }
 
     // Fail-fast: load + structurally validate + resolve before exec.
-    const projectDir = process.cwd()
-    const loaded = await loadEnvironment(projectDir, shelf, env)
-    validateEnvironment(loaded)
+    const projectDir = process.cwd();
+    const loaded = await loadEnvironment(projectDir, shelf, env);
+    validateEnvironment(loaded);
 
     // Secrets resolve through the environment's provider's adapter, built lazily
     // (only if the environment declares a !secret). The provider is known to
     // exist (validateEnvironment checked PROVIDER_NOT_FOUND).
     const managed = await resolveEnvironment(loaded, () => {
-      const provider = loaded.config.providers[loaded.environment.provider]
-      return createAdapter(provider, {projectDir, project: loaded.config.project, shelf, env})
-    })
+      const provider = loaded.config.providers[loaded.environment.provider];
+      return createAdapter(provider, { projectDir, project: loaded.config.project, shelf, env });
+    });
 
-    const childEnv = buildChildEnv({ambient: process.env, managed, sets})
+    const childEnv = buildChildEnv({ ambient: process.env, managed, sets });
 
-    return this.exec(command, childEnv)
+    return this.exec(command, childEnv);
   }
 
   /**
@@ -90,62 +91,62 @@ export default class Run extends BaseCommand {
    * keyshelf's own flags/args; the right side is the wrapped command + args,
    * captured verbatim.
    */
-  private splitArgv(): {target: string; command: string[]} {
-    const raw = this.argv
-    const sep = raw.indexOf('--')
+  private splitArgv(): { target: string; command: string[] } {
+    const raw = this.argv;
+    const sep = raw.indexOf("--");
     if (sep === -1) {
       throw new KeyshelfError(
-        'MALFORMED_FILE',
+        "MALFORMED_FILE",
         "run requires a wrapped command after '--' (e.g. 'keyshelf run web/staging -- printenv').",
-        {reason: "missing '--' separator"},
-      )
+        { reason: "missing '--' separator" }
+      );
     }
 
-    const command = raw.slice(sep + 1)
+    const command = raw.slice(sep + 1);
     if (command.length === 0) {
-      throw new KeyshelfError('MALFORMED_FILE', "run requires a command after '--'.", {
-        reason: "empty command after '--'",
-      })
+      throw new KeyshelfError("MALFORMED_FILE", "run requires a command after '--'.", {
+        reason: "empty command after '--'"
+      });
     }
 
     // The target is the first non-flag token before `--`.
-    const left = raw.slice(0, sep)
-    const target = left.find((token) => !token.startsWith('-'))
+    const left = raw.slice(0, sep);
+    const target = left.find((token) => !token.startsWith("-"));
     if (target === undefined) {
-      throw new KeyshelfError('MALFORMED_FILE', 'run requires a <shelf>/<env> target.', {
-        reason: 'missing <shelf>/<env> target',
-      })
+      throw new KeyshelfError("MALFORMED_FILE", "run requires a <shelf>/<env> target.", {
+        reason: "missing <shelf>/<env> target"
+      });
     }
 
-    return {target, command}
+    return { target, command };
   }
 
   /** Spawn the wrapped command, propagate its exit code, map spawn failure to EXEC_FAILED. */
   private async exec(command: string[], childEnv: Record<string, string>): Promise<never> {
-    const [cmd, ...args] = command
+    const [cmd, ...args] = command;
 
     const status = await new Promise<number>((resolve, reject) => {
-      const child = spawn(cmd, args, {stdio: 'inherit', env: childEnv})
+      const child = spawn(cmd, args, { stdio: "inherit", env: childEnv });
 
-      child.on('error', (error) => {
+      child.on("error", (error) => {
         reject(
-          new KeyshelfError('EXEC_FAILED', `Could not start command '${cmd}': ${error.message}`, {
+          new KeyshelfError("EXEC_FAILED", `Could not start command '${cmd}': ${error.message}`, {
             command: cmd,
-            reason: error.message,
-          }),
-        )
-      })
+            reason: error.message
+          })
+        );
+      });
 
-      child.on('exit', (code, signal) => {
+      child.on("exit", (code, signal) => {
         // Propagate the wrapped command's status. A signal-terminated child maps
         // to the conventional 128 + signal number.
-        resolve(signal === null ? (code ?? 0) : 128 + signalNumber(signal))
-      })
-    })
+        resolve(signal === null ? (code ?? 0) : 128 + signalNumber(signal));
+      });
+    });
 
     // Exit with the wrapped command's status. oclif's run loop catches the
     // thrown ExitError and exits the process with this code.
-    return this.exit(status)
+    return this.exit(status);
   }
 }
 
@@ -156,7 +157,7 @@ function signalNumber(signal: NodeJS.Signals): number {
     SIGINT: 2,
     SIGQUIT: 3,
     SIGKILL: 9,
-    SIGTERM: 15,
-  }
-  return known[signal] ?? 1
+    SIGTERM: 15
+  };
+  return known[signal] ?? 1;
 }

--- a/packages/cli/src/commands/set.ts
+++ b/packages/cli/src/commands/set.ts
@@ -1,20 +1,20 @@
-import {Args, Flags} from '@oclif/core'
-import {readFile, writeFile} from 'node:fs/promises'
-import path from 'node:path'
-import * as readline from 'node:readline/promises'
-import {parseDocument} from 'yaml'
-import {createAdapter} from '../adapters/registry.js'
-import {BaseCommand} from '../base-command.js'
-import {KeyshelfError} from '../errors.js'
-import {loadEnvironment} from '../loader.js'
-import {secretRefForm, setConfigValue, setSecretRef} from '../set.js'
-import {parseTarget} from '../target.js'
+import { Args, Flags } from "@oclif/core";
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import * as readline from "node:readline/promises";
+import { parseDocument } from "yaml";
+import { createAdapter } from "../adapters/registry.js";
+import { BaseCommand } from "../base-command.js";
+import { KeyshelfError } from "../errors.js";
+import { loadEnvironment } from "../loader.js";
+import { secretRefForm, setConfigValue, setSecretRef } from "../set.js";
+import { parseTarget } from "../target.js";
 
 /** The structured result of a successful `set`. */
 interface SetResult {
-  key: string
-  environment: string
-  secret: boolean
+  key: string;
+  environment: string;
+  secret: boolean;
 }
 
 /**
@@ -33,73 +33,78 @@ interface SetResult {
  * lands in the environment file.
  */
 export default class Set extends BaseCommand {
-  static description = "Write a value into a shelf/env. The value is read from stdin (or a prompt), never argv."
+  static description =
+    "Write a value into a shelf/env. The value is read from stdin (or a prompt), never argv.";
 
   static examples = [
-    'echo my-region | <%= config.bin %> set REGION web/staging',
-    'printf "%s" "$PW" | <%= config.bin %> set DATABASE_PASSWORD web/staging --secret',
-  ]
+    "echo my-region | <%= config.bin %> set REGION web/staging",
+    'printf "%s" "$PW" | <%= config.bin %> set DATABASE_PASSWORD web/staging --secret'
+  ];
 
   static args = {
     key: Args.string({
-      description: 'The schema-declared key to set.',
-      required: true,
+      description: "The schema-declared key to set.",
+      required: true
     }),
     target: Args.string({
-      description: 'The environment to write to, as <shelf>/<env>.',
-      required: true,
-    }),
-  }
+      description: "The environment to write to, as <shelf>/<env>.",
+      required: true
+    })
+  };
 
   static flags = {
     secret: Flags.boolean({
-      description: 'Store the value via the provider and record only a !secret reference.',
-      default: false,
-    }),
-  }
+      description: "Store the value via the provider and record only a !secret reference.",
+      default: false
+    })
+  };
 
   async run(): Promise<SetResult> {
-    const {args, flags} = await this.parse(Set)
-    const {shelf, env} = parseTarget(args.target)
-    const {key} = args
+    const { args, flags } = await this.parse(Set);
+    const { shelf, env } = parseTarget(args.target);
+    const { key } = args;
 
     // The value is never taken from argv. A TTY prompts; otherwise stdin is read
     // raw (byte-exact), and an empty stdin is NO_INPUT.
-    const value = await this.readValue(key)
+    const value = await this.readValue(key);
 
-    const projectDir = process.cwd()
+    const projectDir = process.cwd();
     // Loads config + schema + environment, surfacing NOT_INITIALIZED /
     // SHELF_NOT_FOUND / SCHEMA_NOT_FOUND / ENVIRONMENT_NOT_FOUND / MALFORMED_FILE.
-    const loaded = await loadEnvironment(projectDir, shelf, env)
+    const loaded = await loadEnvironment(projectDir, shelf, env);
 
     // The key must already exist in the shelf's schema — set never declares keys.
     if (!Object.prototype.hasOwnProperty.call(loaded.schema.keys, key)) {
-      throw new KeyshelfError('UNKNOWN_KEY', `Key '${key}' is not declared in the schema for shelf '${shelf}'.`, {
-        key,
-        shelf,
-        environment: `${shelf}/${env}`,
-      })
+      throw new KeyshelfError(
+        "UNKNOWN_KEY",
+        `Key '${key}' is not declared in the schema for shelf '${shelf}'.`,
+        {
+          key,
+          shelf,
+          environment: `${shelf}/${env}`
+        }
+      );
     }
 
     // Edit the existing environment file in place, preserving every other key,
     // the provider line, and comments.
-    const file = path.join(projectDir, '.keyshelf', shelf, `${env}.yaml`)
-    const doc = parseDocument(await readFile(file, 'utf8'))
+    const file = path.join(projectDir, ".keyshelf", shelf, `${env}.yaml`);
+    const doc = parseDocument(await readFile(file, "utf8"));
 
     if (flags.secret) {
-      await this.writeSecret(loaded, projectDir, shelf, env, key, value, doc)
+      await this.writeSecret(loaded, projectDir, shelf, env, key, value, doc);
     } else {
-      setConfigValue(doc, key, value)
+      setConfigValue(doc, key, value);
     }
 
-    await writeFile(file, doc.toString(), 'utf8')
+    await writeFile(file, doc.toString(), "utf8");
 
-    const result: SetResult = {key, environment: `${shelf}/${env}`, secret: flags.secret}
+    const result: SetResult = { key, environment: `${shelf}/${env}`, secret: flags.secret };
     if (!this.jsonEnabled()) {
-      this.log(`Set ${result.environment} ${key}${flags.secret ? ' (secret)' : ''}.`)
+      this.log(`Set ${result.environment} ${key}${flags.secret ? " (secret)" : ""}.`);
     }
 
-    return result
+    return result;
   }
 
   /**
@@ -116,24 +121,29 @@ export default class Set extends BaseCommand {
     env: string,
     key: string,
     value: string,
-    doc: ReturnType<typeof parseDocument>,
+    doc: ReturnType<typeof parseDocument>
   ): Promise<void> {
-    const provider = loaded.config.providers[loaded.environment.provider]
+    const provider = loaded.config.providers[loaded.environment.provider];
     if (provider === undefined) {
       throw new KeyshelfError(
-        'PROVIDER_NOT_FOUND',
+        "PROVIDER_NOT_FOUND",
         `Environment '${shelf}/${env}' references undefined provider '${loaded.environment.provider}'.`,
-        {shelf, environment: `${shelf}/${env}`, provider: loaded.environment.provider},
-      )
+        { shelf, environment: `${shelf}/${env}`, provider: loaded.environment.provider }
+      );
     }
 
-    const adapter = createAdapter(provider, {projectDir, project: loaded.config.project, shelf, env})
-    const ref = await adapter.write(key, value)
+    const adapter = createAdapter(provider, {
+      projectDir,
+      project: loaded.config.project,
+      shelf,
+      env
+    });
+    const ref = await adapter.write(key, value);
 
     // The fake/reference convention names a secret `{project}-{shelf}-{env}-{key}`;
     // a returned ref matching that resolves by convention (bare !secret).
-    const conventionRef = `${loaded.config.project}-${shelf}-${env}-${key}`
-    setSecretRef(doc, key, secretRefForm(ref, conventionRef))
+    const conventionRef = `${loaded.config.project}-${shelf}-${env}-${key}`;
+    setSecretRef(doc, key, secretRefForm(ref, conventionRef));
   }
 
   /**
@@ -143,38 +153,38 @@ export default class Set extends BaseCommand {
    */
   private async readValue(key: string): Promise<string> {
     if (process.stdin.isTTY) {
-      const rl = readline.createInterface({input: process.stdin, output: process.stderr})
+      const rl = readline.createInterface({ input: process.stdin, output: process.stderr });
       try {
-        const entered = await rl.question(`Value for ${key}: `)
-        if (entered === '') {
-          throw noInput(key)
+        const entered = await rl.question(`Value for ${key}: `);
+        if (entered === "") {
+          throw noInput(key);
         }
 
-        return entered
+        return entered;
       } finally {
-        rl.close()
+        rl.close();
       }
     }
 
-    const value = await readStdin()
+    const value = await readStdin();
     if (value.length === 0) {
-      throw noInput(key)
+      throw noInput(key);
     }
 
-    return value
+    return value;
   }
 }
 
 function noInput(key: string): KeyshelfError {
-  return new KeyshelfError('NO_INPUT', `No value provided on stdin for '${key}'.`, {key})
+  return new KeyshelfError("NO_INPUT", `No value provided on stdin for '${key}'.`, { key });
 }
 
 /** Read all of stdin to EOF as a UTF-8 string, byte-exact. */
 async function readStdin(): Promise<string> {
-  const chunks: Buffer[] = []
+  const chunks: Buffer[] = [];
   for await (const chunk of process.stdin) {
-    chunks.push(Buffer.from(chunk))
+    chunks.push(Buffer.from(chunk));
   }
 
-  return Buffer.concat(chunks).toString('utf8')
+  return Buffer.concat(chunks).toString("utf8");
 }

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -128,17 +128,7 @@ export default class Validate extends BaseCommand {
     }
 
     const valid = results.every((r) => r.valid);
-    const result: ProjectResult = { valid, results };
-
-    if (!this.jsonEnabled()) {
-      for (const r of results) {
-        this.log(
-          r.valid
-            ? `ok    ${r.environment}`
-            : `FAIL  ${r.environment}  [${r.error?.code}] ${r.error?.message}`
-        );
-      }
-    }
+    if (!this.jsonEnabled()) this.logResults(results);
 
     if (!valid) {
       // The whole-project outcome is an aggregate, not a single KeyshelfError,
@@ -149,6 +139,17 @@ export default class Validate extends BaseCommand {
       process.exitCode = 1;
     }
 
-    return result;
+    return { valid, results };
+  }
+
+  /** Print the human-readable per-environment lines (non-JSON mode only). */
+  private logResults(results: EnvironmentResult[]): void {
+    for (const r of results) {
+      this.log(
+        r.valid
+          ? `ok    ${r.environment}`
+          : `FAIL  ${r.environment}  [${r.error?.code}] ${r.error?.message}`
+      );
+    }
   }
 }

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -1,29 +1,29 @@
-import {Args} from '@oclif/core'
-import {createAdapter} from '../adapters/registry.js'
-import {BaseCommand} from '../base-command.js'
-import {KeyshelfError} from '../errors.js'
-import {listEnvironments, loadEnvironment} from '../loader.js'
-import type {LoadedEnvironment} from '../model.js'
-import {resolveEnvironment} from '../resolve.js'
-import {parseTarget} from '../target.js'
-import {validateEnvironment} from '../validate.js'
+import { Args } from "@oclif/core";
+import { createAdapter } from "../adapters/registry.js";
+import { BaseCommand } from "../base-command.js";
+import { KeyshelfError } from "../errors.js";
+import { listEnvironments, loadEnvironment } from "../loader.js";
+import type { LoadedEnvironment } from "../model.js";
+import { resolveEnvironment } from "../resolve.js";
+import { parseTarget } from "../target.js";
+import { validateEnvironment } from "../validate.js";
 
 /** The structured outcome of validating one environment in whole-project mode. */
 interface EnvironmentResult {
-  environment: string
-  valid: boolean
-  error?: ReturnType<KeyshelfError['toJSON']>
+  environment: string;
+  valid: boolean;
+  error?: ReturnType<KeyshelfError["toJSON"]>;
 }
 
 interface SingleResult {
-  shelf: string
-  environment: string
-  valid: true
+  shelf: string;
+  environment: string;
+  valid: true;
 }
 
 interface ProjectResult {
-  valid: boolean
-  results: EnvironmentResult[]
+  valid: boolean;
+  results: EnvironmentResult[];
 }
 
 /**
@@ -34,26 +34,35 @@ interface ProjectResult {
  * the only step here that touches a backend; it never executes anything.
  */
 async function verify(projectDir: string, loaded: LoadedEnvironment): Promise<void> {
-  validateEnvironment(loaded)
+  validateEnvironment(loaded);
 
-  const {shelf, name} = loaded.environment
+  const { shelf, name } = loaded.environment;
   await resolveEnvironment(loaded, () => {
-    const provider = loaded.config.providers[loaded.environment.provider]
-    return createAdapter(provider, {projectDir, project: loaded.config.project, shelf, env: name})
-  })
+    const provider = loaded.config.providers[loaded.environment.provider];
+    return createAdapter(provider, {
+      projectDir,
+      project: loaded.config.project,
+      shelf,
+      env: name
+    });
+  });
 }
 
 /** Verify one environment, returning the structured error if any. */
-function checkOne(projectDir: string, shelf: string, env: string): Promise<KeyshelfError | undefined> {
+function checkOne(
+  projectDir: string,
+  shelf: string,
+  env: string
+): Promise<KeyshelfError | undefined> {
   return loadEnvironment(projectDir, shelf, env)
     .then(async (loaded) => {
-      await verify(projectDir, loaded)
-      return undefined
+      await verify(projectDir, loaded);
+      return undefined;
     })
     .catch((error: unknown) => {
-      if (error instanceof KeyshelfError) return error
-      throw error
-    })
+      if (error instanceof KeyshelfError) return error;
+      throw error;
+    });
 }
 
 /**
@@ -68,59 +77,66 @@ function checkOne(projectDir: string, shelf: string, env: string): Promise<Keysh
  * an unresolvable secret makes the environment invalid. Nothing is executed.
  */
 export default class Validate extends BaseCommand {
-  static description = 'Validate that environments conform to their schema and that declared secrets resolve.'
+  static description =
+    "Validate that environments conform to their schema and that declared secrets resolve.";
 
-  static examples = ['<%= config.bin %> validate', '<%= config.bin %> validate web/staging']
+  static examples = ["<%= config.bin %> validate", "<%= config.bin %> validate web/staging"];
 
   static args = {
     target: Args.string({
-      description: 'The environment to validate as <shelf>/<env>. Omit to validate the whole project.',
-      required: false,
-    }),
-  }
+      description:
+        "The environment to validate as <shelf>/<env>. Omit to validate the whole project.",
+      required: false
+    })
+  };
 
   async run(): Promise<SingleResult | ProjectResult> {
-    const {args} = await this.parse(Validate)
-    const cwd = process.cwd()
+    const { args } = await this.parse(Validate);
+    const cwd = process.cwd();
 
     if (args.target === undefined) {
-      return this.validateProject(cwd)
+      return this.validateProject(cwd);
     }
 
-    return this.validateSingle(cwd, args.target)
+    return this.validateSingle(cwd, args.target);
   }
 
   private async validateSingle(cwd: string, target: string): Promise<SingleResult> {
-    const {shelf, env} = parseTarget(target)
-    const loaded = await loadEnvironment(cwd, shelf, env)
-    await verify(cwd, loaded)
+    const { shelf, env } = parseTarget(target);
+    const loaded = await loadEnvironment(cwd, shelf, env);
+    await verify(cwd, loaded);
 
-    const environment = `${shelf}/${env}`
+    const environment = `${shelf}/${env}`;
     if (!this.jsonEnabled()) {
-      this.log(`${environment} is valid.`)
+      this.log(`${environment} is valid.`);
     }
 
-    return {shelf, environment, valid: true}
+    return { shelf, environment, valid: true };
   }
 
   private async validateProject(cwd: string): Promise<ProjectResult> {
-    const refs = await listEnvironments(cwd)
-    refs.sort((a, b) => `${a.shelf}/${a.env}`.localeCompare(`${b.shelf}/${b.env}`))
+    const refs = await listEnvironments(cwd);
+    refs.sort((a, b) => `${a.shelf}/${a.env}`.localeCompare(`${b.shelf}/${b.env}`));
 
-    const results: EnvironmentResult[] = []
+    const results: EnvironmentResult[] = [];
     for (const ref of refs) {
-      const environment = `${ref.shelf}/${ref.env}`
-      // eslint-disable-next-line no-await-in-loop
-      const error = await checkOne(cwd, ref.shelf, ref.env)
-      results.push(error ? {environment, valid: false, error: error.toJSON()} : {environment, valid: true})
+      const environment = `${ref.shelf}/${ref.env}`;
+      const error = await checkOne(cwd, ref.shelf, ref.env);
+      results.push(
+        error ? { environment, valid: false, error: error.toJSON() } : { environment, valid: true }
+      );
     }
 
-    const valid = results.every((r) => r.valid)
-    const result: ProjectResult = {valid, results}
+    const valid = results.every((r) => r.valid);
+    const result: ProjectResult = { valid, results };
 
     if (!this.jsonEnabled()) {
       for (const r of results) {
-        this.log(r.valid ? `ok    ${r.environment}` : `FAIL  ${r.environment}  [${r.error?.code}] ${r.error?.message}`)
+        this.log(
+          r.valid
+            ? `ok    ${r.environment}`
+            : `FAIL  ${r.environment}  [${r.error?.code}] ${r.error?.message}`
+        );
       }
     }
 
@@ -130,9 +146,9 @@ export default class Validate extends BaseCommand {
       // (the returned value, in --json mode) and signal failure via exit status
       // — exit status is success/failure only; granularity lives in each
       // result's error.code.
-      process.exitCode = 1
+      process.exitCode = 1;
     }
 
-    return result
+    return result;
   }
 }

--- a/packages/cli/src/errors.ts
+++ b/packages/cli/src/errors.ts
@@ -3,25 +3,25 @@
  * code is a breaking change to the machine contract. See docs/reference.md.
  */
 export const ERROR_CODES = [
-  'NOT_INITIALIZED',
-  'ALREADY_INITIALIZED',
-  'SHELF_NOT_FOUND',
-  'SCHEMA_NOT_FOUND',
-  'ENVIRONMENT_NOT_FOUND',
-  'PROVIDER_NOT_FOUND',
-  'UNKNOWN_KEY',
-  'MISSING_REQUIRED',
-  'INVALID_KEY_NAME',
-  'ADAPTER_UNAVAILABLE',
-  'PROVIDER_AUTH',
-  'SECRET_NOT_FOUND',
-  'NO_INPUT',
-  'MALFORMED_FILE',
-  'ADAPTER_ERROR',
-  'EXEC_FAILED',
-] as const
+  "NOT_INITIALIZED",
+  "ALREADY_INITIALIZED",
+  "SHELF_NOT_FOUND",
+  "SCHEMA_NOT_FOUND",
+  "ENVIRONMENT_NOT_FOUND",
+  "PROVIDER_NOT_FOUND",
+  "UNKNOWN_KEY",
+  "MISSING_REQUIRED",
+  "INVALID_KEY_NAME",
+  "ADAPTER_UNAVAILABLE",
+  "PROVIDER_AUTH",
+  "SECRET_NOT_FOUND",
+  "NO_INPUT",
+  "MALFORMED_FILE",
+  "ADAPTER_ERROR",
+  "EXEC_FAILED"
+] as const;
 
-export type ErrorCode = (typeof ERROR_CODES)[number]
+export type ErrorCode = (typeof ERROR_CODES)[number];
 
 /**
  * A domain error carrying a stable machine `code`, a human `message`, and
@@ -29,17 +29,17 @@ export type ErrorCode = (typeof ERROR_CODES)[number]
  * as `{ "error": { code, message, ...fields } }` in `--json` mode.
  */
 export class KeyshelfError extends Error {
-  readonly code: ErrorCode
-  readonly fields: Record<string, unknown>
+  readonly code: ErrorCode;
+  readonly fields: Record<string, unknown>;
 
   constructor(code: ErrorCode, message: string, fields: Record<string, unknown> = {}) {
-    super(message)
-    this.name = 'KeyshelfError'
-    this.code = code
-    this.fields = fields
+    super(message);
+    this.name = "KeyshelfError";
+    this.code = code;
+    this.fields = fields;
   }
 
-  toJSON(): {code: ErrorCode; message: string} & Record<string, unknown> {
-    return {code: this.code, message: this.message, ...this.fields}
+  toJSON(): { code: ErrorCode; message: string } & Record<string, unknown> {
+    return { code: this.code, message: this.message, ...this.fields };
   }
 }

--- a/packages/cli/src/loader.ts
+++ b/packages/cli/src/loader.ts
@@ -1,172 +1,196 @@
-import {existsSync} from 'node:fs'
-import {readdir, readFile} from 'node:fs/promises'
-import path from 'node:path'
-import {isMap, isScalar, parseDocument, type YAMLMap} from 'yaml'
-import {KeyshelfError} from './errors.js'
-import type {Config, Environment, EnvironmentValue, LoadedEnvironment, Provider, Schema, SchemaKey} from './model.js'
+import { existsSync } from "node:fs";
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { isMap, isScalar, parseDocument, type YAMLMap } from "yaml";
+import { KeyshelfError } from "./errors.js";
+import type {
+  Config,
+  Environment,
+  EnvironmentValue,
+  LoadedEnvironment,
+  Provider,
+  Schema,
+  SchemaKey
+} from "./model.js";
 
-const ROOT_DIR = '.keyshelf'
-const CONFIG_FILE = 'config.yaml'
-const SCHEMA_FILE = 'schema.yaml'
+const ROOT_DIR = ".keyshelf";
+const CONFIG_FILE = "config.yaml";
+const SCHEMA_FILE = "schema.yaml";
 
 /** Resolve the `.keyshelf` root for a project, asserting it is initialized. */
 function keyshelfRoot(projectDir: string): string {
-  const root = path.join(projectDir, ROOT_DIR)
+  const root = path.join(projectDir, ROOT_DIR);
   if (!existsSync(path.join(root, CONFIG_FILE))) {
-    throw new KeyshelfError('NOT_INITIALIZED', `No Keyshelf project found in '${projectDir}'. Run 'keyshelf init' first.`, {
-      path: root,
-    })
+    throw new KeyshelfError(
+      "NOT_INITIALIZED",
+      `No Keyshelf project found in '${projectDir}'. Run 'keyshelf init' first.`,
+      {
+        path: root
+      }
+    );
   }
 
-  return root
+  return root;
 }
 
 /** Parse YAML text into a document, mapping syntax errors to MALFORMED_FILE. */
 function parse(text: string, file: string) {
-  let doc
+  let doc;
   try {
-    doc = parseDocument(text)
+    doc = parseDocument(text);
   } catch (error) {
-    throw malformed(file, error instanceof Error ? error.message : String(error))
+    throw malformed(file, error instanceof Error ? error.message : String(error));
   }
 
   if (doc.errors.length > 0) {
-    throw malformed(file, doc.errors[0].message)
+    throw malformed(file, doc.errors[0].message);
   }
 
-  return doc
+  return doc;
 }
 
 function malformed(file: string, reason: string): KeyshelfError {
-  return new KeyshelfError('MALFORMED_FILE', `Could not parse '${file}': ${reason}`, {file, reason})
+  return new KeyshelfError("MALFORMED_FILE", `Could not parse '${file}': ${reason}`, {
+    file,
+    reason
+  });
 }
 
 async function loadConfig(root: string): Promise<Config> {
-  const file = path.join(root, CONFIG_FILE)
-  const doc = parse(await readFile(file, 'utf8'), file)
-  const value = doc.toJS() as unknown
+  const file = path.join(root, CONFIG_FILE);
+  const doc = parse(await readFile(file, "utf8"), file);
+  const value = doc.toJS() as unknown;
 
-  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
-    throw malformed(file, 'expected a mapping at the top level')
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw malformed(file, "expected a mapping at the top level");
   }
 
-  const obj = value as Record<string, unknown>
-  if (typeof obj.project !== 'string' || obj.project.length === 0) {
-    throw malformed(file, "missing required 'project' string")
+  const obj = value as Record<string, unknown>;
+  if (typeof obj.project !== "string" || obj.project.length === 0) {
+    throw malformed(file, "missing required 'project' string");
   }
 
-  const providers: Record<string, Provider> = {}
-  const rawProviders = obj.providers
+  const providers: Record<string, Provider> = {};
+  const rawProviders = obj.providers;
   if (rawProviders !== undefined) {
-    if (rawProviders === null || typeof rawProviders !== 'object' || Array.isArray(rawProviders)) {
-      throw malformed(file, "'providers' must be a mapping")
+    if (rawProviders === null || typeof rawProviders !== "object" || Array.isArray(rawProviders)) {
+      throw malformed(file, "'providers' must be a mapping");
     }
 
     for (const [name, raw] of Object.entries(rawProviders as Record<string, unknown>)) {
-      if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
-        throw malformed(file, `provider '${name}' must be a mapping`)
+      if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+        throw malformed(file, `provider '${name}' must be a mapping`);
       }
 
-      const entry = raw as Record<string, unknown>
-      if (typeof entry.adapter !== 'string') {
-        throw malformed(file, `provider '${name}' is missing an 'adapter' string`)
+      const entry = raw as Record<string, unknown>;
+      if (typeof entry.adapter !== "string") {
+        throw malformed(file, `provider '${name}' is missing an 'adapter' string`);
       }
 
-      providers[name] = {...entry, adapter: entry.adapter}
+      providers[name] = { ...entry, adapter: entry.adapter };
     }
   }
 
-  return {project: obj.project, providers}
+  return { project: obj.project, providers };
 }
 
 /** Read a `keys:` mapping node, applying `parseValue` to each entry's value node. */
 function readKeysMap<T>(
   doc: ReturnType<typeof parseDocument>,
   file: string,
-  parseValue: (node: unknown, key: string) => T,
+  parseValue: (node: unknown, key: string) => T
 ): Record<string, T> {
-  const top = doc.contents
+  const top = doc.contents;
   if (!isMap(top)) {
-    throw malformed(file, 'expected a mapping at the top level')
+    throw malformed(file, "expected a mapping at the top level");
   }
 
-  const keysNode = (top as YAMLMap).get('keys', true)
+  const keysNode = (top as YAMLMap).get("keys", true);
   if (keysNode === undefined || keysNode === null) {
-    return {}
+    return {};
   }
 
   if (!isMap(keysNode)) {
-    throw malformed(file, "'keys' must be a mapping")
+    throw malformed(file, "'keys' must be a mapping");
   }
 
-  const out: Record<string, T> = {}
+  const out: Record<string, T> = {};
   for (const item of (keysNode as YAMLMap).items) {
-    const key = isScalar(item.key) ? String(item.key.value) : String((item.key as {value?: unknown})?.value ?? item.key)
-    out[key] = parseValue(item.value, key)
+    const key = isScalar(item.key)
+      ? String(item.key.value)
+      : String((item.key as { value?: unknown })?.value ?? item.key);
+    out[key] = parseValue(item.value, key);
   }
 
-  return out
+  return out;
 }
 
 async function loadSchema(root: string, shelf: string): Promise<Schema> {
-  const file = path.join(root, shelf, SCHEMA_FILE)
-  const doc = parse(await readFile(file, 'utf8'), file)
+  const file = path.join(root, shelf, SCHEMA_FILE);
+  const doc = parse(await readFile(file, "utf8"), file);
 
   const keys = readKeysMap<SchemaKey>(doc, file, (node) => {
     if (isScalar(node)) {
-      const {tag} = node
-      if (tag === '!required') return {kind: 'required'}
-      if (tag === '!optional') return {kind: 'optional'}
+      const { tag } = node;
+      if (tag === "!required") return { kind: "required" };
+      if (tag === "!optional") return { kind: "optional" };
       // A bare scalar with no presence tag is a config default.
-      return {kind: 'config', default: node.value === null ? '' : String(node.value)}
+      return { kind: "config", default: node.value === null ? "" : String(node.value) };
     }
 
     if (node === null || node === undefined) {
       // `KEY:` with no value — treat as an empty config default.
-      return {kind: 'config', default: ''}
+      return { kind: "config", default: "" };
     }
 
-    throw malformed(file, `key has an unsupported declaration (expected a default value, !required, or !optional)`)
-  })
+    throw malformed(
+      file,
+      `key has an unsupported declaration (expected a default value, !required, or !optional)`
+    );
+  });
 
-  return {keys}
+  return { keys };
 }
 
-async function loadEnvironmentFile(root: string, shelf: string, name: string): Promise<Environment> {
-  const file = path.join(root, shelf, `${name}.yaml`)
-  const doc = parse(await readFile(file, 'utf8'), file)
+async function loadEnvironmentFile(
+  root: string,
+  shelf: string,
+  name: string
+): Promise<Environment> {
+  const file = path.join(root, shelf, `${name}.yaml`);
+  const doc = parse(await readFile(file, "utf8"), file);
 
-  const top = doc.contents
+  const top = doc.contents;
   if (!isMap(top)) {
-    throw malformed(file, 'expected a mapping at the top level')
+    throw malformed(file, "expected a mapping at the top level");
   }
 
-  const providerNode = (top as YAMLMap).get('provider')
-  if (typeof providerNode !== 'string' || providerNode.length === 0) {
-    throw malformed(file, "missing required 'provider' string")
+  const providerNode = (top as YAMLMap).get("provider");
+  if (typeof providerNode !== "string" || providerNode.length === 0) {
+    throw malformed(file, "missing required 'provider' string");
   }
 
   const keys = readKeysMap<EnvironmentValue>(doc, file, (node, key) => {
     if (isScalar(node)) {
-      if (node.tag === '!secret') {
-        return {kind: 'secret'}
+      if (node.tag === "!secret") {
+        return { kind: "secret" };
       }
 
-      return {kind: 'config', value: node.value === null ? '' : String(node.value)}
+      return { kind: "config", value: node.value === null ? "" : String(node.value) };
     }
 
-    if (isMap(node) && (node as YAMLMap).tag === '!secret') {
-      return {kind: 'secret', ref: (node as YAMLMap).toJSON()}
+    if (isMap(node) && (node as YAMLMap).tag === "!secret") {
+      return { kind: "secret", ref: (node as YAMLMap).toJSON() };
     }
 
     if (node === null || node === undefined) {
-      return {kind: 'config', value: ''}
+      return { kind: "config", value: "" };
     }
 
-    throw malformed(file, `key '${key}' has an unsupported value (expected a string or !secret)`)
-  })
+    throw malformed(file, `key '${key}' has an unsupported value (expected a string or !secret)`);
+  });
 
-  return {shelf, name, provider: providerNode, keys}
+  return { shelf, name, provider: providerNode, keys };
 }
 
 /**
@@ -176,36 +200,46 @@ async function loadEnvironmentFile(root: string, shelf: string, name: string): P
  * `SHELF_NOT_FOUND`, `SCHEMA_NOT_FOUND`, `ENVIRONMENT_NOT_FOUND`,
  * `MALFORMED_FILE`. Does not resolve any `!secret` values.
  */
-export async function loadEnvironment(projectDir: string, shelf: string, env: string): Promise<LoadedEnvironment> {
-  const root = keyshelfRoot(projectDir)
-  const config = await loadConfig(root)
+export async function loadEnvironment(
+  projectDir: string,
+  shelf: string,
+  env: string
+): Promise<LoadedEnvironment> {
+  const root = keyshelfRoot(projectDir);
+  const config = await loadConfig(root);
 
-  const shelfDir = path.join(root, shelf)
+  const shelfDir = path.join(root, shelf);
   if (!existsSync(shelfDir)) {
-    throw new KeyshelfError('SHELF_NOT_FOUND', `Shelf '${shelf}' does not exist.`, {shelf})
+    throw new KeyshelfError("SHELF_NOT_FOUND", `Shelf '${shelf}' does not exist.`, { shelf });
   }
 
   if (!existsSync(path.join(shelfDir, SCHEMA_FILE))) {
-    throw new KeyshelfError('SCHEMA_NOT_FOUND', `Shelf '${shelf}' has no ${SCHEMA_FILE}.`, {shelf})
+    throw new KeyshelfError("SCHEMA_NOT_FOUND", `Shelf '${shelf}' has no ${SCHEMA_FILE}.`, {
+      shelf
+    });
   }
 
   if (!existsSync(path.join(shelfDir, `${env}.yaml`))) {
-    throw new KeyshelfError('ENVIRONMENT_NOT_FOUND', `Environment '${shelf}/${env}' does not exist.`, {
-      shelf,
-      environment: `${shelf}/${env}`,
-    })
+    throw new KeyshelfError(
+      "ENVIRONMENT_NOT_FOUND",
+      `Environment '${shelf}/${env}' does not exist.`,
+      {
+        shelf,
+        environment: `${shelf}/${env}`
+      }
+    );
   }
 
-  const schema = await loadSchema(root, shelf)
-  const environment = await loadEnvironmentFile(root, shelf, env)
+  const schema = await loadSchema(root, shelf);
+  const environment = await loadEnvironmentFile(root, shelf, env);
 
-  return {config, schema, environment}
+  return { config, schema, environment };
 }
 
 /** An environment's filesystem-derived identity, discovered by {@link listEnvironments}. */
 export interface EnvironmentRef {
-  shelf: string
-  env: string
+  shelf: string;
+  env: string;
 }
 
 /**
@@ -215,24 +249,24 @@ export interface EnvironmentRef {
  * project is not initialized.
  */
 export async function listEnvironments(projectDir: string): Promise<EnvironmentRef[]> {
-  const root = keyshelfRoot(projectDir)
-  const refs: EnvironmentRef[] = []
+  const root = keyshelfRoot(projectDir);
+  const refs: EnvironmentRef[] = [];
 
-  const shelves = await readdir(root, {withFileTypes: true})
+  const shelves = await readdir(root, { withFileTypes: true });
   for (const shelfEntry of shelves) {
-    if (!shelfEntry.isDirectory()) continue
-    const shelf = shelfEntry.name
+    if (!shelfEntry.isDirectory()) continue;
+    const shelf = shelfEntry.name;
 
-    const files = await readdir(path.join(root, shelf), {withFileTypes: true})
+    const files = await readdir(path.join(root, shelf), { withFileTypes: true });
     for (const file of files) {
-      if (!file.isFile()) continue
-      const {name} = file
-      if (name === SCHEMA_FILE) continue
-      if (name.endsWith('.secrets.yaml')) continue
-      if (!name.endsWith('.yaml')) continue
-      refs.push({shelf, env: name.slice(0, -'.yaml'.length)})
+      if (!file.isFile()) continue;
+      const { name } = file;
+      if (name === SCHEMA_FILE) continue;
+      if (name.endsWith(".secrets.yaml")) continue;
+      if (!name.endsWith(".yaml")) continue;
+      refs.push({ shelf, env: name.slice(0, -".yaml".length) });
     }
   }
 
-  return refs
+  return refs;
 }

--- a/packages/cli/src/loader.ts
+++ b/packages/cli/src/loader.ts
@@ -56,6 +56,31 @@ function malformed(file: string, reason: string): KeyshelfError {
   });
 }
 
+/** Parse the optional `providers:` mapping, validating each entry has an `adapter` string. */
+function parseProviders(file: string, rawProviders: unknown): Record<string, Provider> {
+  const providers: Record<string, Provider> = {};
+  if (rawProviders === undefined) return providers;
+
+  if (rawProviders === null || typeof rawProviders !== "object" || Array.isArray(rawProviders)) {
+    throw malformed(file, "'providers' must be a mapping");
+  }
+
+  for (const [name, raw] of Object.entries(rawProviders as Record<string, unknown>)) {
+    if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+      throw malformed(file, `provider '${name}' must be a mapping`);
+    }
+
+    const entry = raw as Record<string, unknown>;
+    if (typeof entry.adapter !== "string") {
+      throw malformed(file, `provider '${name}' is missing an 'adapter' string`);
+    }
+
+    providers[name] = { ...entry, adapter: entry.adapter };
+  }
+
+  return providers;
+}
+
 async function loadConfig(root: string): Promise<Config> {
   const file = path.join(root, CONFIG_FILE);
   const doc = parse(await readFile(file, "utf8"), file);
@@ -70,28 +95,7 @@ async function loadConfig(root: string): Promise<Config> {
     throw malformed(file, "missing required 'project' string");
   }
 
-  const providers: Record<string, Provider> = {};
-  const rawProviders = obj.providers;
-  if (rawProviders !== undefined) {
-    if (rawProviders === null || typeof rawProviders !== "object" || Array.isArray(rawProviders)) {
-      throw malformed(file, "'providers' must be a mapping");
-    }
-
-    for (const [name, raw] of Object.entries(rawProviders as Record<string, unknown>)) {
-      if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
-        throw malformed(file, `provider '${name}' must be a mapping`);
-      }
-
-      const entry = raw as Record<string, unknown>;
-      if (typeof entry.adapter !== "string") {
-        throw malformed(file, `provider '${name}' is missing an 'adapter' string`);
-      }
-
-      providers[name] = { ...entry, adapter: entry.adapter };
-    }
-  }
-
-  return { project: obj.project, providers };
+  return { project: obj.project, providers: parseProviders(file, obj.providers) };
 }
 
 /** Read a `keys:` mapping node, applying `parseValue` to each entry's value node. */
@@ -248,24 +252,29 @@ export interface EnvironmentRef {
  * `schema.yaml` nor a `*.secrets.yaml` store. Throws `NOT_INITIALIZED` when the
  * project is not initialized.
  */
+/** Whether a directory entry is an environment file (a `*.yaml` that is neither schema nor a secrets store). */
+function isEnvironmentFile(name: string): boolean {
+  if (name === SCHEMA_FILE) return false;
+  if (name.endsWith(".secrets.yaml")) return false;
+  return name.endsWith(".yaml");
+}
+
+/** The environments declared in a single shelf directory. */
+async function listShelfEnvironments(root: string, shelf: string): Promise<EnvironmentRef[]> {
+  const files = await readdir(path.join(root, shelf), { withFileTypes: true });
+  return files
+    .filter((file) => file.isFile() && isEnvironmentFile(file.name))
+    .map((file) => ({ shelf, env: file.name.slice(0, -".yaml".length) }));
+}
+
 export async function listEnvironments(projectDir: string): Promise<EnvironmentRef[]> {
   const root = keyshelfRoot(projectDir);
-  const refs: EnvironmentRef[] = [];
-
   const shelves = await readdir(root, { withFileTypes: true });
+
+  const refs: EnvironmentRef[] = [];
   for (const shelfEntry of shelves) {
     if (!shelfEntry.isDirectory()) continue;
-    const shelf = shelfEntry.name;
-
-    const files = await readdir(path.join(root, shelf), { withFileTypes: true });
-    for (const file of files) {
-      if (!file.isFile()) continue;
-      const { name } = file;
-      if (name === SCHEMA_FILE) continue;
-      if (name.endsWith(".secrets.yaml")) continue;
-      if (!name.endsWith(".yaml")) continue;
-      refs.push({ shelf, env: name.slice(0, -".yaml".length) });
-    }
+    refs.push(...(await listShelfEnvironments(root, shelfEntry.name)));
   }
 
   return refs;

--- a/packages/cli/src/loader.ts
+++ b/packages/cli/src/loader.ts
@@ -56,26 +56,35 @@ function malformed(file: string, reason: string): KeyshelfError {
   });
 }
 
+/** A non-null, non-array object — i.e. a YAML mapping once parsed to JS. */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+/** Validate and normalize one provider entry into a {@link Provider}. */
+function parseProvider(file: string, name: string, raw: unknown): Provider {
+  if (!isPlainObject(raw)) {
+    throw malformed(file, `provider '${name}' must be a mapping`);
+  }
+
+  if (typeof raw.adapter !== "string") {
+    throw malformed(file, `provider '${name}' is missing an 'adapter' string`);
+  }
+
+  return { ...raw, adapter: raw.adapter };
+}
+
 /** Parse the optional `providers:` mapping, validating each entry has an `adapter` string. */
 function parseProviders(file: string, rawProviders: unknown): Record<string, Provider> {
-  const providers: Record<string, Provider> = {};
-  if (rawProviders === undefined) return providers;
+  if (rawProviders === undefined) return {};
 
-  if (rawProviders === null || typeof rawProviders !== "object" || Array.isArray(rawProviders)) {
+  if (!isPlainObject(rawProviders)) {
     throw malformed(file, "'providers' must be a mapping");
   }
 
-  for (const [name, raw] of Object.entries(rawProviders as Record<string, unknown>)) {
-    if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
-      throw malformed(file, `provider '${name}' must be a mapping`);
-    }
-
-    const entry = raw as Record<string, unknown>;
-    if (typeof entry.adapter !== "string") {
-      throw malformed(file, `provider '${name}' is missing an 'adapter' string`);
-    }
-
-    providers[name] = { ...entry, adapter: entry.adapter };
+  const providers: Record<string, Provider> = {};
+  for (const [name, raw] of Object.entries(rawProviders)) {
+    providers[name] = parseProvider(file, name, raw);
   }
 
   return providers;
@@ -84,13 +93,12 @@ function parseProviders(file: string, rawProviders: unknown): Record<string, Pro
 async function loadConfig(root: string): Promise<Config> {
   const file = path.join(root, CONFIG_FILE);
   const doc = parse(await readFile(file, "utf8"), file);
-  const value = doc.toJS() as unknown;
+  const obj = doc.toJS() as unknown;
 
-  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+  if (!isPlainObject(obj)) {
     throw malformed(file, "expected a mapping at the top level");
   }
 
-  const obj = value as Record<string, unknown>;
   if (typeof obj.project !== "string" || obj.project.length === 0) {
     throw malformed(file, "missing required 'project' string");
   }

--- a/packages/cli/src/model.ts
+++ b/packages/cli/src/model.ts
@@ -9,58 +9,58 @@
  */
 
 /** The kind of presence requirement a schema declares for a key. */
-export type SchemaKeyKind = 'config' | 'required' | 'optional'
+export type SchemaKeyKind = "config" | "required" | "optional";
 
 /** One declared key in a shelf's schema — presence only, never representation. */
 export interface SchemaKey {
-  kind: SchemaKeyKind
+  kind: SchemaKeyKind;
   /** The default value, present only for `kind === 'config'`. */
-  default?: string
+  default?: string;
 }
 
 /** A shelf's closed validation contract, parsed from `schema.yaml`. */
 export interface Schema {
-  keys: Record<string, SchemaKey>
+  keys: Record<string, SchemaKey>;
 }
 
 /** How a key's value is represented in an environment file. */
-export type ValueKind = 'config' | 'secret'
+export type ValueKind = "config" | "secret";
 
 /** One key/value entry in an environment file. */
 export interface EnvironmentValue {
-  kind: ValueKind
+  kind: ValueKind;
   /** Plaintext value, present only for `kind === 'config'`. */
-  value?: string
+  value?: string;
   /** Adapter-defined `!secret` reference payload, when explicitly given. */
-  ref?: unknown
+  ref?: unknown;
 }
 
 /** An environment, parsed from `{shelf}/{env}.yaml`. */
 export interface Environment {
   /** The shelf this environment belongs to (its directory name). */
-  shelf: string
+  shelf: string;
   /** The environment name (its filename without extension). */
-  name: string
+  name: string;
   /** The provider name this environment references in `config.yaml`. */
-  provider: string
-  keys: Record<string, EnvironmentValue>
+  provider: string;
+  keys: Record<string, EnvironmentValue>;
 }
 
 /** A configured provider (an adapter plus its config) from `config.yaml`. */
 export interface Provider {
-  adapter: string
-  [field: string]: unknown
+  adapter: string;
+  [field: string]: unknown;
 }
 
 /** The project-global `config.yaml`. */
 export interface Config {
-  project: string
-  providers: Record<string, Provider>
+  project: string;
+  providers: Record<string, Provider>;
 }
 
 /** Everything needed to validate a single environment, assembled by the loader. */
 export interface LoadedEnvironment {
-  config: Config
-  schema: Schema
-  environment: Environment
+  config: Config;
+  schema: Schema;
+  environment: Environment;
 }

--- a/packages/cli/src/resolve.ts
+++ b/packages/cli/src/resolve.ts
@@ -1,9 +1,9 @@
-import type {Adapter} from './adapters/adapter.js'
-import {KeyshelfError} from './errors.js'
-import type {LoadedEnvironment} from './model.js'
+import type { Adapter } from "./adapters/adapter.js";
+import { KeyshelfError } from "./errors.js";
+import type { LoadedEnvironment } from "./model.js";
 
 /** The canonical env-var identifier rule (docs/reference.md). */
-const KEY_NAME_PATTERN = /^[A-Z_][A-Z0-9_]*$/
+const KEY_NAME_PATTERN = /^[A-Z_][A-Z0-9_]*$/;
 
 /**
  * Resolve a structurally-valid environment into the flat `string→string` map of
@@ -28,73 +28,75 @@ const KEY_NAME_PATTERN = /^[A-Z_][A-Z0-9_]*$/
  */
 export async function resolveEnvironment(
   loaded: LoadedEnvironment,
-  adapterFor: () => Adapter,
+  adapterFor: () => Adapter
 ): Promise<Record<string, string>> {
-  const {schema, environment} = loaded
-  const map: Record<string, string> = {}
+  const { schema, environment } = loaded;
+  const map: Record<string, string> = {};
 
   // Schema config defaults form the base layer.
   for (const [key, declared] of Object.entries(schema.keys)) {
-    if (declared.kind === 'config' && declared.default !== undefined) {
-      map[key] = declared.default
+    if (declared.kind === "config" && declared.default !== undefined) {
+      map[key] = declared.default;
     }
   }
 
   // Build the adapter once, on first secret only.
-  let adapter: Adapter | undefined
+  let adapter: Adapter | undefined;
 
   // Environment values overlay the defaults: plaintext wins directly; a !secret
   // resolves through the provider's adapter (convention, or explicit ref).
   for (const [key, value] of Object.entries(environment.keys)) {
-    if (value.kind === 'secret') {
-      adapter ??= adapterFor()
-      // eslint-disable-next-line no-await-in-loop
-      map[key] = await resolveSecret(adapter, key, value.ref)
+    if (value.kind === "secret") {
+      adapter ??= adapterFor();
+      map[key] = await resolveSecret(adapter, key, value.ref);
     } else {
-      map[key] = value.value ?? ''
+      map[key] = value.value ?? "";
     }
   }
 
-  return map
+  return map;
 }
 
 /** Resolve one secret through the adapter, normalising non-Keyshelf throws. */
 async function resolveSecret(adapter: Adapter, key: string, ref: unknown): Promise<string> {
   try {
-    return await adapter.resolve(key, ref)
+    return await adapter.resolve(key, ref);
   } catch (error) {
-    if (error instanceof KeyshelfError) throw error
-    throw new KeyshelfError('ADAPTER_ERROR', `Failed to resolve secret '${key}': ${String(error)}`, {key})
+    if (error instanceof KeyshelfError) throw error;
+    throw new KeyshelfError(
+      "ADAPTER_ERROR",
+      `Failed to resolve secret '${key}': ${String(error)}`,
+      { key }
+    );
   }
 }
 
 /** A parsed `--set KEY=VALUE` flag. */
 export interface SetAssignment {
-  key: string
-  value: string
+  key: string;
+  value: string;
 }
 
 /** Parse a single `--set KEY=VALUE` token, splitting on the first `=` only. */
 export function parseSet(assignment: string): SetAssignment {
-  const eq = assignment.indexOf('=')
+  const eq = assignment.indexOf("=");
   if (eq === -1) {
-    throw new KeyshelfError(
-      'MALFORMED_FILE',
-      `--set expects KEY=VALUE; got '${assignment}'.`,
-      {reason: 'expected KEY=VALUE', value: assignment},
-    )
+    throw new KeyshelfError("MALFORMED_FILE", `--set expects KEY=VALUE; got '${assignment}'.`, {
+      reason: "expected KEY=VALUE",
+      value: assignment
+    });
   }
 
-  const key = assignment.slice(0, eq)
+  const key = assignment.slice(0, eq);
   if (!KEY_NAME_PATTERN.test(key)) {
     throw new KeyshelfError(
-      'INVALID_KEY_NAME',
+      "INVALID_KEY_NAME",
       `--set key '${key}' is not a valid env-var identifier (expected ${KEY_NAME_PATTERN}).`,
-      {key},
-    )
+      { key }
+    );
   }
 
-  return {key, value: assignment.slice(eq + 1)}
+  return { key, value: assignment.slice(eq + 1) };
 }
 
 /**
@@ -105,16 +107,16 @@ export function parseSet(assignment: string): SetAssignment {
  * stale ambient var of a managed key is overridden by the resolved value.
  */
 export function buildChildEnv(input: {
-  ambient: Record<string, string | undefined>
-  managed: Record<string, string>
-  sets: Record<string, string>
+  ambient: Record<string, string | undefined>;
+  managed: Record<string, string>;
+  sets: Record<string, string>;
 }): Record<string, string> {
-  const out: Record<string, string> = {}
+  const out: Record<string, string> = {};
 
   for (const [key, value] of Object.entries(input.ambient)) {
-    if (value !== undefined) out[key] = value
+    if (value !== undefined) out[key] = value;
   }
 
-  Object.assign(out, input.managed, input.sets)
-  return out
+  Object.assign(out, input.managed, input.sets);
+  return out;
 }

--- a/packages/cli/src/set.ts
+++ b/packages/cli/src/set.ts
@@ -1,4 +1,4 @@
-import {type Document, isMap, Scalar, YAMLMap} from 'yaml'
+import { type Document, isMap, Scalar, YAMLMap } from "yaml";
 
 /**
  * The form a `!secret` reference takes in the environment file. The adapter's
@@ -8,7 +8,7 @@ import {type Document, isMap, Scalar, YAMLMap} from 'yaml'
  * Anything else — a foreign/explicit name, or a non-string payload — is recorded
  * verbatim as `!secret { ref: ... }` so it round-trips back through the loader.
  */
-export type SecretRefForm = {bare: true} | {bare: false; ref: unknown}
+export type SecretRefForm = { bare: true } | { bare: false; ref: unknown };
 
 /**
  * Decide how to record a written secret's reference. `adapterRef` is whatever
@@ -19,10 +19,10 @@ export type SecretRefForm = {bare: true} | {bare: false; ref: unknown}
  */
 export function secretRefForm(adapterRef: unknown, conventionRef: string): SecretRefForm {
   if (adapterRef === undefined || adapterRef === conventionRef) {
-    return {bare: true}
+    return { bare: true };
   }
 
-  return {bare: false, ref: adapterRef}
+  return { bare: false, ref: adapterRef };
 }
 
 /**
@@ -31,21 +31,21 @@ export function secretRefForm(adapterRef: unknown, conventionRef: string): Secre
  * every other key are left untouched.
  */
 function keysMap(doc: Document): YAMLMap {
-  const top = doc.contents
+  const top = doc.contents;
   if (!isMap(top)) {
     // An environment with no mapping (or only a provider that parsed oddly) is a
     // caller bug here — the loader has already accepted the file as a mapping.
-    throw new Error('environment document is not a mapping')
+    throw new Error("environment document is not a mapping");
   }
 
-  const existing = top.get('keys', true)
+  const existing = top.get("keys", true);
   if (isMap(existing)) {
-    return existing
+    return existing;
   }
 
-  const created = new YAMLMap()
-  top.set('keys', created)
-  return created
+  const created = new YAMLMap();
+  top.set("keys", created);
+  return created;
 }
 
 /**
@@ -56,7 +56,7 @@ function keysMap(doc: Document): YAMLMap {
  * (spaces, `=`, quotes, newlines) round-trip byte-exactly.
  */
 export function setConfigValue(doc: Document, key: string, value: string): void {
-  keysMap(doc).set(key, new Scalar(value))
+  keysMap(doc).set(key, new Scalar(value));
 }
 
 /**
@@ -66,16 +66,16 @@ export function setConfigValue(doc: Document, key: string, value: string): void 
  * through the loader's `!secret` handling.
  */
 export function setSecretRef(doc: Document, key: string, form: SecretRefForm): void {
-  const map = keysMap(doc)
+  const map = keysMap(doc);
 
   if (form.bare) {
-    const scalar = new Scalar(null)
-    scalar.tag = '!secret'
-    map.set(key, scalar)
-    return
+    const scalar = new Scalar(null);
+    scalar.tag = "!secret";
+    map.set(key, scalar);
+    return;
   }
 
-  const node = doc.createNode({ref: form.ref}) as YAMLMap
-  node.tag = '!secret'
-  map.set(key, node)
+  const node = doc.createNode({ ref: form.ref }) as YAMLMap;
+  node.tag = "!secret";
+  map.set(key, node);
 }

--- a/packages/cli/src/target.ts
+++ b/packages/cli/src/target.ts
@@ -1,19 +1,19 @@
-import {KeyshelfError} from './errors.js'
+import { KeyshelfError } from "./errors.js";
 
 /**
  * Parse a `<shelf>/<env>` environment address (docs/reference.md "CLI surface"),
  * mapping a malformed argument to `MALFORMED_FILE`. Exactly one `/`, with a
  * non-empty shelf and env on either side.
  */
-export function parseTarget(target: string): {shelf: string; env: string} {
-  const slash = target.indexOf('/')
-  if (slash <= 0 || slash === target.length - 1 || target.indexOf('/', slash + 1) !== -1) {
+export function parseTarget(target: string): { shelf: string; env: string } {
+  const slash = target.indexOf("/");
+  if (slash <= 0 || slash === target.length - 1 || target.indexOf("/", slash + 1) !== -1) {
     throw new KeyshelfError(
-      'MALFORMED_FILE',
+      "MALFORMED_FILE",
       `'${target}' is not a valid environment address; expected '<shelf>/<env>'.`,
-      {reason: "expected '<shelf>/<env>'", target},
-    )
+      { reason: "expected '<shelf>/<env>'", target }
+    );
   }
 
-  return {shelf: target.slice(0, slash), env: target.slice(slash + 1)}
+  return { shelf: target.slice(0, slash), env: target.slice(slash + 1) };
 }

--- a/packages/cli/src/validate.ts
+++ b/packages/cli/src/validate.ts
@@ -1,8 +1,8 @@
-import {KeyshelfError} from './errors.js'
-import type {LoadedEnvironment} from './model.js'
+import { KeyshelfError } from "./errors.js";
+import type { LoadedEnvironment } from "./model.js";
 
 /** The canonical env-var identifier rule (docs/reference.md). */
-const KEY_NAME_PATTERN = /^[A-Z_][A-Z0-9_]*$/
+const KEY_NAME_PATTERN = /^[A-Z_][A-Z0-9_]*$/;
 
 /**
  * Validate a single loaded environment against the closed-contract and presence
@@ -19,43 +19,46 @@ const KEY_NAME_PATTERN = /^[A-Z_][A-Z0-9_]*$/
  * structured fields (`shelf`, `environment`, `key`, `provider`).
  */
 export function validateEnvironment(loaded: LoadedEnvironment): void {
-  const {config, schema, environment} = loaded
-  const {shelf, name} = environment
-  const where = {shelf, environment: `${shelf}/${name}`}
+  const { config, schema, environment } = loaded;
+  const { shelf, name } = environment;
+  const where = { shelf, environment: `${shelf}/${name}` };
 
   if (!Object.prototype.hasOwnProperty.call(config.providers, environment.provider)) {
     throw new KeyshelfError(
-      'PROVIDER_NOT_FOUND',
+      "PROVIDER_NOT_FOUND",
       `Environment '${shelf}/${name}' references undefined provider '${environment.provider}'.`,
-      {...where, provider: environment.provider},
-    )
+      { ...where, provider: environment.provider }
+    );
   }
 
   for (const key of Object.keys(environment.keys)) {
     if (!KEY_NAME_PATTERN.test(key)) {
       throw new KeyshelfError(
-        'INVALID_KEY_NAME',
+        "INVALID_KEY_NAME",
         `Key '${key}' in '${shelf}/${name}' is not a valid env-var identifier (expected ${KEY_NAME_PATTERN}).`,
-        {...where, key},
-      )
+        { ...where, key }
+      );
     }
 
     if (!Object.prototype.hasOwnProperty.call(schema.keys, key)) {
       throw new KeyshelfError(
-        'UNKNOWN_KEY',
+        "UNKNOWN_KEY",
         `Key '${key}' is not declared in the schema for shelf '${shelf}'.`,
-        {...where, key},
-      )
+        { ...where, key }
+      );
     }
   }
 
   for (const [key, declared] of Object.entries(schema.keys)) {
-    if (declared.kind === 'required' && !Object.prototype.hasOwnProperty.call(environment.keys, key)) {
+    if (
+      declared.kind === "required" &&
+      !Object.prototype.hasOwnProperty.call(environment.keys, key)
+    ) {
       throw new KeyshelfError(
-        'MISSING_REQUIRED',
+        "MISSING_REQUIRED",
         `Required key '${key}' is missing from environment '${shelf}/${name}'.`,
-        {...where, key},
-      )
+        { ...where, key }
+      );
     }
   }
 }

--- a/packages/cli/test/conformance/adapter-contract.ts
+++ b/packages/cli/test/conformance/adapter-contract.ts
@@ -1,6 +1,6 @@
-import {afterEach, beforeEach, describe, expect, it} from 'vitest'
-import type {Adapter} from '../../src/adapters/adapter.js'
-import {KeyshelfError} from '../../src/errors.js'
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Adapter } from "../../src/adapters/adapter.js";
+import { captureError } from "../support/capture-error.js";
 
 /**
  * A per-adapter harness: the only thing that knows which adapter is behind the
@@ -10,34 +10,23 @@ import {KeyshelfError} from '../../src/errors.js'
  */
 export interface AdapterHarness {
   /** A label for the test report (e.g. `'fake'`). */
-  readonly name: string
+  readonly name: string;
   /** Provision a fresh backend + adapter for a single test. */
-  setup(): Promise<{adapter: Adapter}>
+  setup(): Promise<{ adapter: Adapter }>;
   /** Tear down whatever {@link setup} provisioned. */
-  teardown(): Promise<void>
+  teardown(): Promise<void>;
 }
 
 /** Adversarial values that must round-trip byte-exactly through any adapter. */
 const ADVERSARIAL_VALUES: ReadonlyArray<readonly [label: string, value: string]> = [
-  ['embedded newlines', 'line1\nline2\nline3'],
-  ['trailing/leading whitespace', '  padded value \t'],
-  ['equals signs', 'postgres://h?a=b=c&d=e'],
-  ['single and double quotes', `it's a "quoted" 'value'`],
-  ['unicode', 'café — 日本語 — 🔐 — Ω'],
-  ['multi-KB blob', 'x'.repeat(8192)],
-  ['empty string', ''],
-]
-
-async function captureError(fn: () => Promise<unknown>): Promise<KeyshelfError> {
-  try {
-    await fn()
-  } catch (error) {
-    if (error instanceof KeyshelfError) return error
-    throw new Error(`expected a KeyshelfError, got: ${String(error)}`)
-  }
-
-  throw new Error('expected a KeyshelfError, but nothing was thrown')
-}
+  ["embedded newlines", "line1\nline2\nline3"],
+  ["trailing/leading whitespace", "  padded value \t"],
+  ["equals signs", "postgres://h?a=b=c&d=e"],
+  ["single and double quotes", `it's a "quoted" 'value'`],
+  ["unicode", "café — 日本語 — 🔐 — Ω"],
+  ["multi-KB blob", "x".repeat(8192)],
+  ["empty string", ""]
+];
 
 /**
  * The shared, adapter-agnostic contract suite (ADR-0005). It exercises the
@@ -47,57 +36,59 @@ async function captureError(fn: () => Promise<unknown>): Promise<KeyshelfError> 
  */
 export function runAdapterContractSuite(harness: AdapterHarness): void {
   describe(`adapter contract: ${harness.name}`, () => {
-    let adapter: Adapter
+    let adapter: Adapter;
 
     beforeEach(async () => {
-      ;({adapter} = await harness.setup())
-    })
+      ({ adapter } = await harness.setup());
+    });
 
     afterEach(async () => {
-      await harness.teardown()
-    })
+      await harness.teardown();
+    });
 
-    describe('error-code mapping', () => {
-      it('maps a missing secret to SECRET_NOT_FOUND', async () => {
-        const error = await captureError(() => adapter.resolve('ABSENT_KEY'))
-        expect(error.code).toBe('SECRET_NOT_FOUND')
-      })
+    describe("error-code mapping", () => {
+      it("maps a missing secret to SECRET_NOT_FOUND", async () => {
+        const error = await captureError(() => adapter.resolve("ABSENT_KEY"));
+        expect(error.code).toBe("SECRET_NOT_FOUND");
+      });
 
-      it('maps a missing secret behind an explicit ref to SECRET_NOT_FOUND', async () => {
-        const error = await captureError(() => adapter.resolve('SOME_KEY', {ref: 'nonexistent-foreign-name'}))
-        expect(error.code).toBe('SECRET_NOT_FOUND')
-      })
-    })
+      it("maps a missing secret behind an explicit ref to SECRET_NOT_FOUND", async () => {
+        const error = await captureError(() =>
+          adapter.resolve("SOME_KEY", { ref: "nonexistent-foreign-name" })
+        );
+        expect(error.code).toBe("SECRET_NOT_FOUND");
+      });
+    });
 
-    describe('value fidelity (byte-exact write -> resolve round-trip)', () => {
+    describe("value fidelity (byte-exact write -> resolve round-trip)", () => {
       for (const [label, value] of ADVERSARIAL_VALUES) {
         it(`round-trips ${label}`, async () => {
-          await adapter.write('FIDELITY_KEY', value)
-          const resolved = await adapter.resolve('FIDELITY_KEY')
-          expect(resolved).toBe(value)
-        })
+          await adapter.write("FIDELITY_KEY", value);
+          const resolved = await adapter.resolve("FIDELITY_KEY");
+          expect(resolved).toBe(value);
+        });
       }
 
-      it('keeps distinct keys independent', async () => {
-        await adapter.write('KEY_A', 'value-a')
-        await adapter.write('KEY_B', 'value-b')
-        expect(await adapter.resolve('KEY_A')).toBe('value-a')
-        expect(await adapter.resolve('KEY_B')).toBe('value-b')
-      })
+      it("keeps distinct keys independent", async () => {
+        await adapter.write("KEY_A", "value-a");
+        await adapter.write("KEY_B", "value-b");
+        expect(await adapter.resolve("KEY_A")).toBe("value-a");
+        expect(await adapter.resolve("KEY_B")).toBe("value-b");
+      });
 
-      it('overwrites an existing value on a repeated write', async () => {
-        await adapter.write('KEY', 'first')
-        await adapter.write('KEY', 'second')
-        expect(await adapter.resolve('KEY')).toBe('second')
-      })
+      it("overwrites an existing value on a repeated write", async () => {
+        await adapter.write("KEY", "first");
+        await adapter.write("KEY", "second");
+        expect(await adapter.resolve("KEY")).toBe("second");
+      });
 
-      it('resolves a foreign value through an explicit ref returned by write', async () => {
+      it("resolves a foreign value through an explicit ref returned by write", async () => {
         // A write may return a reference that names the stored value; resolving
         // with that ref must locate the same value even under a different key.
-        const ref = await adapter.write('CANONICAL_KEY', 'foreign-value')
-        const resolved = await adapter.resolve('A_DIFFERENT_KEY', ref ?? 'CANONICAL_KEY')
-        expect(resolved).toBe('foreign-value')
-      })
-    })
-  })
+        const ref = await adapter.write("CANONICAL_KEY", "foreign-value");
+        const resolved = await adapter.resolve("A_DIFFERENT_KEY", ref ?? "CANONICAL_KEY");
+        expect(resolved).toBe("foreign-value");
+      });
+    });
+  });
 }

--- a/packages/cli/test/conformance/fake.contract.test.ts
+++ b/packages/cli/test/conformance/fake.contract.test.ts
@@ -1,15 +1,15 @@
-import {FakeAdapter, inMemoryStore} from '../../src/adapters/fake.js'
-import {runAdapterContractSuite} from './adapter-contract.js'
+import { FakeAdapter, inMemoryStore } from "../../src/adapters/fake.js";
+import { runAdapterContractSuite } from "./adapter-contract.js";
 
 // The fake harness: the only fake-aware code. It provisions a fresh in-memory
 // store + adapter per test and tears it down by discarding it. A new adapter
 // runs the identical suite by supplying its own harness here.
 runAdapterContractSuite({
-  name: 'fake',
+  name: "fake",
   async setup() {
-    return {adapter: new FakeAdapter(inMemoryStore())}
+    return { adapter: new FakeAdapter(inMemoryStore()) };
   },
   async teardown() {
     // Nothing to clean up: the in-memory store is dropped with the adapter.
-  },
-})
+  }
+});

--- a/packages/cli/test/conformance/gcp.contract.test.ts
+++ b/packages/cli/test/conformance/gcp.contract.test.ts
@@ -1,7 +1,7 @@
-import {SecretManagerServiceClient} from '@google-cloud/secret-manager'
-import {describe, it} from 'vitest'
-import {GcpAdapter} from '../../src/adapters/gcp.js'
-import {runAdapterContractSuite} from './adapter-contract.js'
+import { SecretManagerServiceClient } from "@google-cloud/secret-manager";
+import { describe, it } from "vitest";
+import { GcpAdapter } from "../../src/adapters/gcp.js";
+import { runAdapterContractSuite } from "./adapter-contract.js";
 
 // The gcp harness: the only gcp-aware code wiring the shared contract suite to
 // real Google Cloud Secret Manager. There is no faithful local emulator
@@ -11,46 +11,54 @@ import {runAdapterContractSuite} from './adapter-contract.js'
 // runs and reruns never collide. Without the env var the suite skips, keeping
 // local `npm test` and per-PR CI green; the gated cadence (nightly on `main`)
 // sets it and asserts the matrix genuinely runs.
-const testProject = process.env.KEYSHELF_GCP_TEST_PROJECT
-const testLocation = process.env.KEYSHELF_GCP_TEST_LOCATION // optional; default automatic replication
+const testProject = process.env.KEYSHELF_GCP_TEST_PROJECT;
+const testLocation = process.env.KEYSHELF_GCP_TEST_LOCATION; // optional; default automatic replication
 
 if (testProject) {
-  const client = new SecretManagerServiceClient()
+  const client = new SecretManagerServiceClient();
   // A per-run prefix keeps this run's secrets distinct from any other run sharing
   // the project; a per-test counter keeps each test within the run isolated too.
-  const runPrefix = `ksconf-${process.pid}-${Date.now()}`
-  let counter = 0
-  let namespace = runPrefix
+  const runPrefix = `ksconf-${process.pid}-${Date.now()}`;
+  let counter = 0;
+  let namespace = runPrefix;
 
   runAdapterContractSuite({
-    name: 'gcp',
+    name: "gcp",
     async setup() {
-      counter += 1
-      namespace = `${runPrefix}-${counter}`
+      counter += 1;
+      namespace = `${runPrefix}-${counter}`;
       return {
-        adapter: new GcpAdapter({projectId: testProject, namespace, location: testLocation, client: client as never}),
-      }
+        adapter: new GcpAdapter({
+          projectId: testProject,
+          namespace,
+          location: testLocation,
+          client: client as never
+        })
+      };
     },
     async teardown() {
       // Delete every secret this test created (those whose id carries the test's
       // unique namespace), leaving the shared project clean.
-      const [secrets] = await client.listSecrets({parent: `projects/${testProject}`, filter: `name:${namespace}`})
+      const [secrets] = await client.listSecrets({
+        parent: `projects/${testProject}`,
+        filter: `name:${namespace}`
+      });
       await Promise.all(
         secrets
           .filter((s) => secretId(s.name).startsWith(namespace))
-          .map((s) => client.deleteSecret({name: s.name as string})),
-      )
-    },
-  })
+          .map((s) => client.deleteSecret({ name: s.name as string }))
+      );
+    }
+  });
 } else {
-  describe('adapter contract: gcp', () => {
-    it.skip('skipped: set KEYSHELF_GCP_TEST_PROJECT to run against real Secret Manager', () => {})
-  })
+  describe("adapter contract: gcp", () => {
+    it.skip("skipped: set KEYSHELF_GCP_TEST_PROJECT to run against real Secret Manager", () => {});
+  });
 }
 
 /** The short secret id (last path segment) of a `projects/.../secrets/ID` name. */
 function secretId(name: string | null | undefined): string {
-  if (!name) return ''
-  const parts = name.split('/')
-  return parts[parts.length - 1]
+  if (!name) return "";
+  const parts = name.split("/");
+  return parts[parts.length - 1];
 }

--- a/packages/cli/test/conformance/sops-fixture.ts
+++ b/packages/cli/test/conformance/sops-fixture.ts
@@ -1,10 +1,10 @@
-import {execFile, execFileSync} from 'node:child_process'
-import {mkdtemp, rm, writeFile} from 'node:fs/promises'
-import os from 'node:os'
-import path from 'node:path'
-import {promisify} from 'node:util'
+import { execFile, execFileSync } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
 
-const execFileAsync = promisify(execFile)
+const execFileAsync = promisify(execFile);
 
 /**
  * Whether a usable `sops` binary is resolvable on this host. The hermetic sops
@@ -14,15 +14,15 @@ const execFileAsync = promisify(execFile)
  * the matrix actually runs there rather than silently skipping.
  */
 export function sopsAvailable(): boolean {
-  return onPath('sops') && onPath('age-keygen')
+  return onPath("sops") && onPath("age-keygen");
 }
 
 function onPath(bin: string): boolean {
   try {
-    execFileSync(process.platform === 'win32' ? 'where' : 'which', [bin], {stdio: 'ignore'})
-    return true
+    execFileSync(process.platform === "win32" ? "where" : "which", [bin], { stdio: "ignore" });
+    return true;
   } catch {
-    return false
+    return false;
   }
 }
 
@@ -39,13 +39,13 @@ function onPath(bin: string): boolean {
  */
 export interface SopsFixture {
   /** The throwaway project root (where `.sops.yaml` and `.keyshelf/` live). */
-  readonly dir: string
+  readonly dir: string;
   /** Absolute path to the generated age key file. */
-  readonly ageKeyFile: string
+  readonly ageKeyFile: string;
   /** The public age recipient the fixture encrypts to. */
-  readonly recipient: string
+  readonly recipient: string;
   /** Remove the temp directory. */
-  teardown(): Promise<void>
+  teardown(): Promise<void>;
 }
 
 /**
@@ -54,34 +54,36 @@ export interface SopsFixture {
  * setting `process.env.SOPS_AGE_KEY_FILE` if it spawns sops in a child process;
  * for in-process adapter use, set it from {@link SopsFixture.ageKeyFile}.
  */
-export async function makeSopsFixture(pathRegex = String.raw`.*\.secrets\.yaml$`): Promise<SopsFixture> {
-  const dir = await mkdtemp(path.join(os.tmpdir(), 'keyshelf-sops-'))
-  const ageKeyFile = path.join(dir, 'age-key.txt')
+export async function makeSopsFixture(
+  pathRegex = String.raw`.*\.secrets\.yaml$`
+): Promise<SopsFixture> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "keyshelf-sops-"));
+  const ageKeyFile = path.join(dir, "age-key.txt");
 
   // Generate a throwaway age keypair into the fixture directory.
-  const {stderr} = await execFileAsync('age-keygen', ['-o', ageKeyFile])
+  const { stderr } = await execFileAsync("age-keygen", ["-o", ageKeyFile]);
   // age-keygen prints `Public key: age1...` on stderr.
-  const match = /public key:\s*(age1[0-9a-z]+)/i.exec(stderr)
+  const match = /public key:\s*(age1[0-9a-z]+)/i.exec(stderr);
   if (match === null) {
-    throw new Error(`could not parse age public key from age-keygen output: ${stderr}`)
+    throw new Error(`could not parse age public key from age-keygen output: ${stderr}`);
   }
 
-  const recipient = match[1]
+  const recipient = match[1];
 
   // A fixture .sops.yaml the adapter never writes — recipients are the user's
   // concern; here the fixture plays that role with its own throwaway recipient.
   await writeFile(
-    path.join(dir, '.sops.yaml'),
+    path.join(dir, ".sops.yaml"),
     `creation_rules:\n  - path_regex: ${pathRegex}\n    age: ${recipient}\n`,
-    'utf8',
-  )
+    "utf8"
+  );
 
   return {
     dir,
     ageKeyFile,
     recipient,
     async teardown() {
-      await rm(dir, {recursive: true, force: true})
-    },
-  }
+      await rm(dir, { recursive: true, force: true });
+    }
+  };
 }

--- a/packages/cli/test/conformance/sops.contract.test.ts
+++ b/packages/cli/test/conformance/sops.contract.test.ts
@@ -1,8 +1,8 @@
-import path from 'node:path'
-import {describe, it} from 'vitest'
-import {SopsAdapter} from '../../src/adapters/sops.js'
-import {runAdapterContractSuite} from './adapter-contract.js'
-import {makeSopsFixture, sopsAvailable, type SopsFixture} from './sops-fixture.js'
+import path from "node:path";
+import { describe, it } from "vitest";
+import { SopsAdapter } from "../../src/adapters/sops.js";
+import { runAdapterContractSuite } from "./adapter-contract.js";
+import { makeSopsFixture, sopsAvailable, type SopsFixture } from "./sops-fixture.js";
 
 // The sops harness: the only sops-aware code wiring the shared contract suite to
 // the real `sops` binary. Each test gets a fresh hermetic backend — a throwaway
@@ -14,24 +14,24 @@ import {makeSopsFixture, sopsAvailable, type SopsFixture} from './sops-fixture.j
 // local `npm test` stays green; CI installs both and asserts their presence, so
 // the matrix genuinely runs there.
 if (sopsAvailable()) {
-  let fixture: SopsFixture
+  let fixture: SopsFixture;
 
   runAdapterContractSuite({
-    name: 'sops',
+    name: "sops",
     async setup() {
-      fixture = await makeSopsFixture()
+      fixture = await makeSopsFixture();
       // Decryption needs the fixture's throwaway age key in the environment.
-      process.env.SOPS_AGE_KEY_FILE = fixture.ageKeyFile
-      const storePath = path.join(fixture.dir, '.keyshelf', 'app', 'staging.secrets.yaml')
-      return {adapter: new SopsAdapter({storePath, cwd: fixture.dir})}
+      process.env.SOPS_AGE_KEY_FILE = fixture.ageKeyFile;
+      const storePath = path.join(fixture.dir, ".keyshelf", "app", "staging.secrets.yaml");
+      return { adapter: new SopsAdapter({ storePath, cwd: fixture.dir }) };
     },
     async teardown() {
-      delete process.env.SOPS_AGE_KEY_FILE
-      await fixture.teardown()
-    },
-  })
+      delete process.env.SOPS_AGE_KEY_FILE;
+      await fixture.teardown();
+    }
+  });
 } else {
-  describe('adapter contract: sops', () => {
-    it.skip('skipped: no sops/age binary resolvable on this host', () => {})
-  })
+  describe("adapter contract: sops", () => {
+    it.skip("skipped: no sops/age binary resolvable on this host", () => {});
+  });
 }

--- a/packages/cli/test/e2e/fake.secret-roundtrip.e2e.test.ts
+++ b/packages/cli/test/e2e/fake.secret-roundtrip.e2e.test.ts
@@ -1,26 +1,26 @@
-import {readFile} from 'node:fs/promises'
-import path from 'node:path'
-import {runSecretRoundtripSuite} from './secret-roundtrip.js'
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { runSecretRoundtripSuite } from "./secret-roundtrip.js";
 
 // The fake harness: no backend prerequisites, a plaintext JSON store. Running the
 // shared black-box suite against it keeps the fake faithful (ADR-0005) and is the
 // fast per-PR lane that does not need a sops binary.
 runSecretRoundtripSuite({
-  name: 'fake',
-  providerName: 'local',
+  name: "fake",
+  providerName: "local",
   providerConfig() {
-    return {local: {adapter: 'fake'}}
+    return { local: { adapter: "fake" } };
   },
   async setup() {
     // Nothing to provision.
   },
   runEnv() {
-    return {}
+    return {};
   },
   async inspectStore(dir) {
-    return readFile(path.join(dir, '.keyshelf', '.fake-store.json'), 'utf8')
+    return readFile(path.join(dir, ".keyshelf", ".fake-store.json"), "utf8");
   },
   async teardown() {
     // Nothing to tear down beyond the temp dir the suite removes.
-  },
-})
+  }
+});

--- a/packages/cli/test/e2e/helpers.ts
+++ b/packages/cli/test/e2e/helpers.ts
@@ -1,19 +1,19 @@
-import {execFile} from 'node:child_process'
-import {mkdtemp, rm} from 'node:fs/promises'
-import os from 'node:os'
-import path from 'node:path'
-import {fileURLToPath} from 'node:url'
-import {promisify} from 'node:util'
+import { execFile } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
 
-const execFileAsync = promisify(execFile)
+const execFileAsync = promisify(execFile);
 
-const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..')
-const BIN = path.join(repoRoot, 'bin', 'run.js')
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const BIN = path.join(repoRoot, "bin", "run.js");
 
 export interface RunResult {
-  code: number
-  stdout: string
-  stderr: string
+  code: number;
+  stdout: string;
+  stderr: string;
 }
 
 /** Run the real built `keyshelf` binary as a subprocess. Never throws on a
@@ -22,30 +22,30 @@ export interface RunResult {
  * sops adapter can decrypt in the spawned process). */
 export async function runKeyshelf(
   args: string[],
-  opts: {cwd: string; input?: string; env?: Record<string, string>} = {cwd: process.cwd()},
+  opts: { cwd: string; input?: string; env?: Record<string, string> } = { cwd: process.cwd() }
 ): Promise<RunResult> {
   try {
-    const child = execFileAsync('node', [BIN, ...args], {
+    const child = execFileAsync("node", [BIN, ...args], {
       cwd: opts.cwd,
-      env: opts.env === undefined ? process.env : {...process.env, ...opts.env},
-    })
+      env: opts.env === undefined ? process.env : { ...process.env, ...opts.env }
+    });
     if (opts.input !== undefined) {
-      child.child.stdin?.end(opts.input)
+      child.child.stdin?.end(opts.input);
     }
 
-    const {stdout, stderr} = await child
-    return {code: 0, stdout, stderr}
+    const { stdout, stderr } = await child;
+    return { code: 0, stdout, stderr };
   } catch (error) {
-    const e = error as {code?: number; stdout?: string; stderr?: string}
-    return {code: e.code ?? 1, stdout: e.stdout ?? '', stderr: e.stderr ?? ''}
+    const e = error as { code?: number; stdout?: string; stderr?: string };
+    return { code: e.code ?? 1, stdout: e.stdout ?? "", stderr: e.stderr ?? "" };
   }
 }
 
 /** Create an isolated empty temp directory to act as a project root. */
 export async function makeTmpDir(): Promise<string> {
-  return mkdtemp(path.join(os.tmpdir(), 'keyshelf-e2e-'))
+  return mkdtemp(path.join(os.tmpdir(), "keyshelf-e2e-"));
 }
 
 export async function removeDir(dir: string): Promise<void> {
-  await rm(dir, {recursive: true, force: true})
+  await rm(dir, { recursive: true, force: true });
 }

--- a/packages/cli/test/e2e/init.e2e.test.ts
+++ b/packages/cli/test/e2e/init.e2e.test.ts
@@ -1,82 +1,89 @@
-import {readFile} from 'node:fs/promises'
-import path from 'node:path'
-import {afterEach, beforeEach, describe, expect, it} from 'vitest'
-import {parse} from 'yaml'
-import {makeTmpDir, removeDir, runKeyshelf} from './helpers.js'
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { parse } from "yaml";
+import { makeTmpDir, removeDir, runKeyshelf } from "./helpers.js";
 
-async function readYaml(dir: string, ...segments: string[]): Promise<any> {
-  return parse(await readFile(path.join(dir, ...segments), 'utf8'))
+async function readYaml<T = Record<string, unknown>>(
+  dir: string,
+  ...segments: string[]
+): Promise<T> {
+  return parse(await readFile(path.join(dir, ...segments), "utf8")) as T;
 }
 
-describe('keyshelf init', () => {
-  let cwd: string
+describe("keyshelf init", () => {
+  let cwd: string;
 
   beforeEach(async () => {
-    cwd = await makeTmpDir()
-  })
+    cwd = await makeTmpDir();
+  });
 
   afterEach(async () => {
-    await removeDir(cwd)
-  })
+    await removeDir(cwd);
+  });
 
-  it('scaffolds config.yaml with the directory name and a default local sops provider', async () => {
-    const {code} = await runKeyshelf(['init'], {cwd})
-    expect(code).toBe(0)
+  it("scaffolds config.yaml with the directory name and a default local sops provider", async () => {
+    const { code } = await runKeyshelf(["init"], { cwd });
+    expect(code).toBe(0);
 
-    const config = await readYaml(cwd, '.keyshelf', 'config.yaml')
-    expect(config.project).toBe(path.basename(cwd))
-    expect(config.providers.local.adapter).toBe('sops')
-  })
+    const config = await readYaml<{ project: string; providers: { local: { adapter: string } } }>(
+      cwd,
+      ".keyshelf",
+      "config.yaml"
+    );
+    expect(config.project).toBe(path.basename(cwd));
+    expect(config.providers.local.adapter).toBe("sops");
+  });
 
   it('creates a default "app" shelf with an empty schema.yaml', async () => {
-    await runKeyshelf(['init'], {cwd})
+    await runKeyshelf(["init"], { cwd });
 
-    const schema = await readYaml(cwd, '.keyshelf', 'app', 'schema.yaml')
-    expect(schema).toEqual({keys: {}})
-  })
+    const schema = await readYaml(cwd, ".keyshelf", "app", "schema.yaml");
+    expect(schema).toEqual({ keys: {} });
+  });
 
-  it('honors --project and --shelf overrides', async () => {
-    const {code} = await runKeyshelf(['init', '--project', 'billing', '--shelf', 'web'], {cwd})
-    expect(code).toBe(0)
+  it("honors --project and --shelf overrides", async () => {
+    const { code } = await runKeyshelf(["init", "--project", "billing", "--shelf", "web"], { cwd });
+    expect(code).toBe(0);
 
-    const config = await readYaml(cwd, '.keyshelf', 'config.yaml')
-    expect(config.project).toBe('billing')
-    await expect(readYaml(cwd, '.keyshelf', 'web', 'schema.yaml')).resolves.toEqual({keys: {}})
-  })
+    const config = await readYaml(cwd, ".keyshelf", "config.yaml");
+    expect(config.project).toBe("billing");
+    await expect(readYaml(cwd, ".keyshelf", "web", "schema.yaml")).resolves.toEqual({ keys: {} });
+  });
 
-  it('emits a structured JSON result with --json', async () => {
-    const {code, stdout} = await runKeyshelf(['init', '--json'], {cwd})
-    expect(code).toBe(0)
+  it("emits a structured JSON result with --json", async () => {
+    const { code, stdout } = await runKeyshelf(["init", "--json"], { cwd });
+    expect(code).toBe(0);
 
-    const result = JSON.parse(stdout)
+    const result = JSON.parse(stdout);
     expect(result).toMatchObject({
       project: path.basename(cwd),
-      shelf: 'app',
-      created: ['config.yaml', 'app/schema.yaml'],
-    })
-  })
+      shelf: "app",
+      created: ["config.yaml", "app/schema.yaml"]
+    });
+  });
 
-  it('refuses to clobber an existing project with ALREADY_INITIALIZED', async () => {
-    await runKeyshelf(['init'], {cwd})
+  it("refuses to clobber an existing project with ALREADY_INITIALIZED", async () => {
+    await runKeyshelf(["init"], { cwd });
 
-    const {code, stdout} = await runKeyshelf(['init', '--json'], {cwd})
-    expect(code).not.toBe(0)
-    expect(JSON.parse(stdout).error.code).toBe('ALREADY_INITIALIZED')
-  })
+    const { code, stdout } = await runKeyshelf(["init", "--json"], { cwd });
+    expect(code).not.toBe(0);
+    expect(JSON.parse(stdout).error.code).toBe("ALREADY_INITIALIZED");
+  });
 
-  it('overwrites an existing project with --force', async () => {
-    await runKeyshelf(['init', '--project', 'first'], {cwd})
+  it("overwrites an existing project with --force", async () => {
+    await runKeyshelf(["init", "--project", "first"], { cwd });
 
-    const {code} = await runKeyshelf(['init', '--project', 'second', '--force'], {cwd})
-    expect(code).toBe(0)
+    const { code } = await runKeyshelf(["init", "--project", "second", "--force"], { cwd });
+    expect(code).toBe(0);
 
-    const config = await readYaml(cwd, '.keyshelf', 'config.yaml')
-    expect(config.project).toBe('second')
-  })
+    const config = await readYaml(cwd, ".keyshelf", "config.yaml");
+    expect(config.project).toBe("second");
+  });
 
-  it('exposes --help and exits zero', async () => {
-    const {code, stdout} = await runKeyshelf(['init', '--help'], {cwd})
-    expect(code).toBe(0)
-    expect(stdout).toContain('init')
-  })
-})
+  it("exposes --help and exits zero", async () => {
+    const { code, stdout } = await runKeyshelf(["init", "--help"], { cwd });
+    expect(code).toBe(0);
+    expect(stdout).toContain("init");
+  });
+});

--- a/packages/cli/test/e2e/run.e2e.test.ts
+++ b/packages/cli/test/e2e/run.e2e.test.ts
@@ -1,29 +1,29 @@
-import {execFile} from 'node:child_process'
-import {mkdir, writeFile} from 'node:fs/promises'
-import path from 'node:path'
-import {fileURLToPath} from 'node:url'
-import {promisify} from 'node:util'
-import {afterEach, beforeEach, describe, expect, it} from 'vitest'
-import {makeTmpDir, removeDir, runKeyshelf} from './helpers.js'
+import { execFile } from "node:child_process";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { makeTmpDir, removeDir, runKeyshelf } from "./helpers.js";
 
-const execFileAsync = promisify(execFile)
-const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..')
-const BIN = path.join(repoRoot, 'bin', 'run.js')
+const execFileAsync = promisify(execFile);
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const BIN = path.join(repoRoot, "bin", "run.js");
 
-let cwd: string
+let cwd: string;
 
 beforeEach(async () => {
-  cwd = await makeTmpDir()
-})
+  cwd = await makeTmpDir();
+});
 
 afterEach(async () => {
-  await removeDir(cwd)
-})
+  await removeDir(cwd);
+});
 
 async function write(rel: string, contents: string): Promise<void> {
-  const full = path.join(cwd, rel)
-  await mkdir(path.dirname(full), {recursive: true})
-  await writeFile(full, contents, 'utf8')
+  const full = path.join(cwd, rel);
+  await mkdir(path.dirname(full), { recursive: true });
+  await writeFile(full, contents, "utf8");
 }
 
 const CONFIG = `project: myapp
@@ -34,7 +34,7 @@ providers:
     adapter: fake
   bogus:
     adapter: no-such-adapter
-`
+`;
 
 const SCHEMA = `keys:
   LOG_LEVEL: info
@@ -42,24 +42,24 @@ const SCHEMA = `keys:
   FEATURE_X: !optional
   EXTRA_SECRET: !optional
   DATABASE_URL: !optional
-`
+`;
 
 // A config-only environment: REGION supplied, LOG_LEVEL overrides the default.
 const CONFIG_ENV = `provider: local
 keys:
   LOG_LEVEL: debug
   REGION: eu-west-1
-`
+`;
 
 async function scaffold(): Promise<void> {
-  await write('.keyshelf/config.yaml', CONFIG)
-  await write('.keyshelf/web/schema.yaml', SCHEMA)
-  await write('.keyshelf/web/staging.yaml', CONFIG_ENV)
+  await write(".keyshelf/config.yaml", CONFIG);
+  await write(".keyshelf/web/schema.yaml", SCHEMA);
+  await write(".keyshelf/web/staging.yaml", CONFIG_ENV);
 }
 
 /** Seed the file-backed fake store the `fake` adapter reads (storedName -> value). */
 async function seedFakeStore(entries: Record<string, string>): Promise<void> {
-  await write('.keyshelf/.fake-store.json', JSON.stringify(entries, null, 2))
+  await write(".keyshelf/.fake-store.json", JSON.stringify(entries, null, 2));
 }
 
 /**
@@ -69,225 +69,270 @@ async function seedFakeStore(entries: Record<string, string>): Promise<void> {
  */
 async function runWrapped(
   argv: string[],
-  opts: {env?: Record<string, string>} = {},
-): Promise<{code: number; stdout: string; stderr: string}> {
+  opts: { env?: Record<string, string> } = {}
+): Promise<{ code: number; stdout: string; stderr: string }> {
   try {
-    const {stdout, stderr} = await execFileAsync('node', [BIN, ...argv], {
+    const { stdout, stderr } = await execFileAsync("node", [BIN, ...argv], {
       cwd,
-      env: {...process.env, ...opts.env},
-    })
-    return {code: 0, stdout, stderr}
+      env: { ...process.env, ...opts.env }
+    });
+    return { code: 0, stdout, stderr };
   } catch (error) {
-    const e = error as {code?: number; stdout?: string; stderr?: string}
-    return {code: e.code ?? 1, stdout: e.stdout ?? '', stderr: e.stderr ?? ''}
+    const e = error as { code?: number; stdout?: string; stderr?: string };
+    return { code: e.code ?? 1, stdout: e.stdout ?? "", stderr: e.stderr ?? "" };
   }
 }
 
 // Print one env var via a wrapped node process so we read the CHILD's actual env.
 function printEnv(name: string): string[] {
-  return ['run', 'web/staging', '--', 'node', '-e', `process.stdout.write(String(process.env.${name}))`]
+  return [
+    "run",
+    "web/staging",
+    "--",
+    "node",
+    "-e",
+    `process.stdout.write(String(process.env.${name}))`
+  ];
 }
 
-describe('keyshelf run <shelf>/<env> -- <cmd>', () => {
-  it('injects all resolved config keys as env vars with verbatim names', async () => {
-    await scaffold()
-    const {code, stdout} = await runWrapped([
-      'run',
-      'web/staging',
-      '--',
-      'node',
-      '-e',
-      'process.stdout.write(JSON.stringify({REGION: process.env.REGION, LOG_LEVEL: process.env.LOG_LEVEL}))',
-    ])
-    expect(code).toBe(0)
-    expect(JSON.parse(stdout)).toEqual({REGION: 'eu-west-1', LOG_LEVEL: 'debug'})
-  })
+describe("keyshelf run <shelf>/<env> -- <cmd>", () => {
+  it("injects all resolved config keys as env vars with verbatim names", async () => {
+    await scaffold();
+    const { code, stdout } = await runWrapped([
+      "run",
+      "web/staging",
+      "--",
+      "node",
+      "-e",
+      "process.stdout.write(JSON.stringify({REGION: process.env.REGION, LOG_LEVEL: process.env.LOG_LEVEL}))"
+    ]);
+    expect(code).toBe(0);
+    expect(JSON.parse(stdout)).toEqual({ REGION: "eu-west-1", LOG_LEVEL: "debug" });
+  });
 
-  it('contributes a schema default for a key the environment omits', async () => {
-    await scaffold()
-    await write('.keyshelf/web/staging.yaml', 'provider: local\nkeys:\n  REGION: eu\n')
-    const {code, stdout} = await runWrapped(printEnv('LOG_LEVEL'))
-    expect(code).toBe(0)
-    expect(stdout).toBe('info')
-  })
+  it("contributes a schema default for a key the environment omits", async () => {
+    await scaffold();
+    await write(".keyshelf/web/staging.yaml", "provider: local\nkeys:\n  REGION: eu\n");
+    const { code, stdout } = await runWrapped(printEnv("LOG_LEVEL"));
+    expect(code).toBe(0);
+    expect(stdout).toBe("info");
+  });
 
-  it('passes through inherited ambient vars for keys keyshelf does not manage', async () => {
-    await scaffold()
-    const {code, stdout} = await runWrapped(printEnv('UNMANAGED'), {env: {UNMANAGED: 'passthrough'}})
-    expect(code).toBe(0)
-    expect(stdout).toBe('passthrough')
-  })
+  it("passes through inherited ambient vars for keys keyshelf does not manage", async () => {
+    await scaffold();
+    const { code, stdout } = await runWrapped(printEnv("UNMANAGED"), {
+      env: { UNMANAGED: "passthrough" }
+    });
+    expect(code).toBe(0);
+    expect(stdout).toBe("passthrough");
+  });
 
-  it('overrides a stale ambient var of a managed key (managed wins, not ambient)', async () => {
-    await scaffold()
-    const {code, stdout} = await runWrapped(printEnv('REGION'), {env: {REGION: 'STALE-AMBIENT'}})
-    expect(code).toBe(0)
-    expect(stdout).toBe('eu-west-1')
-  })
+  it("overrides a stale ambient var of a managed key (managed wins, not ambient)", async () => {
+    await scaffold();
+    const { code, stdout } = await runWrapped(printEnv("REGION"), {
+      env: { REGION: "STALE-AMBIENT" }
+    });
+    expect(code).toBe(0);
+    expect(stdout).toBe("eu-west-1");
+  });
 
-  it('lets --set override the resolved value (highest precedence)', async () => {
-    await scaffold()
-    const {code, stdout} = await runWrapped([
-      'run',
-      'web/staging',
-      '--set',
-      'REGION=from-set',
-      '--',
-      'node',
-      '-e',
-      'process.stdout.write(String(process.env.REGION))',
-    ])
-    expect(code).toBe(0)
-    expect(stdout).toBe('from-set')
-  })
+  it("lets --set override the resolved value (highest precedence)", async () => {
+    await scaffold();
+    const { code, stdout } = await runWrapped([
+      "run",
+      "web/staging",
+      "--set",
+      "REGION=from-set",
+      "--",
+      "node",
+      "-e",
+      "process.stdout.write(String(process.env.REGION))"
+    ]);
+    expect(code).toBe(0);
+    expect(stdout).toBe("from-set");
+  });
 
-  it('accepts repeated --set flags and beats both ambient and resolved', async () => {
-    await scaffold()
-    const {code, stdout} = await runWrapped(
+  it("accepts repeated --set flags and beats both ambient and resolved", async () => {
+    await scaffold();
+    const { code, stdout } = await runWrapped(
       [
-        'run',
-        'web/staging',
-        '--set',
-        'REGION=r2',
-        '--set',
-        'NEWKEY=n1',
-        '--',
-        'node',
-        '-e',
-        'process.stdout.write(JSON.stringify({REGION: process.env.REGION, NEWKEY: process.env.NEWKEY}))',
+        "run",
+        "web/staging",
+        "--set",
+        "REGION=r2",
+        "--set",
+        "NEWKEY=n1",
+        "--",
+        "node",
+        "-e",
+        "process.stdout.write(JSON.stringify({REGION: process.env.REGION, NEWKEY: process.env.NEWKEY}))"
       ],
-      {env: {REGION: 'STALE'}},
-    )
-    expect(code).toBe(0)
-    expect(JSON.parse(stdout)).toEqual({REGION: 'r2', NEWKEY: 'n1'})
-  })
+      { env: { REGION: "STALE" } }
+    );
+    expect(code).toBe(0);
+    expect(JSON.parse(stdout)).toEqual({ REGION: "r2", NEWKEY: "n1" });
+  });
 
   it("passes the wrapped command's own flags after -- through untouched", async () => {
-    await scaffold()
+    await scaffold();
     // The trailing `--set`/positional belong to the wrapped command, not to
     // keyshelf. `sh -c '...' sh "$@"` makes the child echo its own argv verbatim,
     // proving keyshelf neither consumed nor reinterpreted the flag.
-    const {code, stdout} = await runWrapped([
-      'run',
-      'web/staging',
-      '--',
-      'sh',
-      '-c',
+    const { code, stdout } = await runWrapped([
+      "run",
+      "web/staging",
+      "--",
+      "sh",
+      "-c",
       'printf "%s\\n" "$@"',
-      'sh',
-      '--set',
-      'NOT_FOR_KEYSHELF=1',
-      'positional',
-    ])
-    expect(code).toBe(0)
-    expect(stdout).toBe('--set\nNOT_FOR_KEYSHELF=1\npositional\n')
-  })
+      "sh",
+      "--set",
+      "NOT_FOR_KEYSHELF=1",
+      "positional"
+    ]);
+    expect(code).toBe(0);
+    expect(stdout).toBe("--set\nNOT_FOR_KEYSHELF=1\npositional\n");
+  });
 
   it("propagates the wrapped command's exit code", async () => {
-    await scaffold()
-    const {code} = await runWrapped(['run', 'web/staging', '--', 'node', '-e', 'process.exit(7)'])
-    expect(code).toBe(7)
-  })
+    await scaffold();
+    const { code } = await runWrapped([
+      "run",
+      "web/staging",
+      "--",
+      "node",
+      "-e",
+      "process.exit(7)"
+    ]);
+    expect(code).toBe(7);
+  });
 
-  it('exits zero when the wrapped command exits zero', async () => {
-    await scaffold()
-    const {code} = await runWrapped(['run', 'web/staging', '--', 'node', '-e', 'process.exit(0)'])
-    expect(code).toBe(0)
-  })
+  it("exits zero when the wrapped command exits zero", async () => {
+    await scaffold();
+    const { code } = await runWrapped([
+      "run",
+      "web/staging",
+      "--",
+      "node",
+      "-e",
+      "process.exit(0)"
+    ]);
+    expect(code).toBe(0);
+  });
 
-  it('aborts before exec on a validation failure (MISSING_REQUIRED), command never runs', async () => {
-    await scaffold()
-    await write('.keyshelf/web/staging.yaml', 'provider: local\nkeys:\n  LOG_LEVEL: debug\n') // REGION missing
-    const sentinel = path.join(cwd, 'ran.txt')
-    const {code, stdout} = await runWrapped([
-      'run',
-      'web/staging',
-      '--json',
-      '--',
-      'node',
-      '-e',
-      `require('fs').writeFileSync(${JSON.stringify(sentinel)}, 'x')`,
-    ])
-    expect(code).not.toBe(0)
-    expect(JSON.parse(stdout).error.code).toBe('MISSING_REQUIRED')
+  it("aborts before exec on a validation failure (MISSING_REQUIRED), command never runs", async () => {
+    await scaffold();
+    await write(".keyshelf/web/staging.yaml", "provider: local\nkeys:\n  LOG_LEVEL: debug\n"); // REGION missing
+    const sentinel = path.join(cwd, "ran.txt");
+    const { code, stdout } = await runWrapped([
+      "run",
+      "web/staging",
+      "--json",
+      "--",
+      "node",
+      "-e",
+      `require('fs').writeFileSync(${JSON.stringify(sentinel)}, 'x')`
+    ]);
+    expect(code).not.toBe(0);
+    expect(JSON.parse(stdout).error.code).toBe("MISSING_REQUIRED");
     // The wrapped command must never have run.
-    const {existsSync} = await import('node:fs')
-    expect(existsSync(sentinel)).toBe(false)
-  })
+    const { existsSync } = await import("node:fs");
+    expect(existsSync(sentinel)).toBe(false);
+  });
 
-  it('resolves a !secret through the provider adapter by convention and injects it', async () => {
-    await scaffold()
+  it("resolves a !secret through the provider adapter by convention and injects it", async () => {
+    await scaffold();
     // Namespace mirrors the registry convention {project}-{shelf}-{env}.
-    await seedFakeStore({'myapp-web-staging-EXTRA_SECRET': 's3cr3t-value'})
-    await write('.keyshelf/web/staging.yaml', 'provider: store\nkeys:\n  REGION: eu\n  EXTRA_SECRET: !secret\n')
-    const {code, stdout} = await runWrapped(printEnv('EXTRA_SECRET'))
-    expect(code).toBe(0)
-    expect(stdout).toBe('s3cr3t-value')
-  })
-
-  it('resolves a differently-named foreign value via an explicit { ref } override', async () => {
-    await scaffold()
-    await seedFakeStore({'shared-db-url': 'postgres://shared/db'})
+    await seedFakeStore({ "myapp-web-staging-EXTRA_SECRET": "s3cr3t-value" });
     await write(
-      '.keyshelf/web/staging.yaml',
-      'provider: store\nkeys:\n  REGION: eu\n  DATABASE_URL: !secret { ref: shared-db-url }\n',
-    )
-    const {code, stdout} = await runWrapped(printEnv('DATABASE_URL'))
-    expect(code).toBe(0)
-    expect(stdout).toBe('postgres://shared/db')
-  })
+      ".keyshelf/web/staging.yaml",
+      "provider: store\nkeys:\n  REGION: eu\n  EXTRA_SECRET: !secret\n"
+    );
+    const { code, stdout } = await runWrapped(printEnv("EXTRA_SECRET"));
+    expect(code).toBe(0);
+    expect(stdout).toBe("s3cr3t-value");
+  });
 
-  it('aborts with SECRET_NOT_FOUND when a !secret has no stored value', async () => {
-    await scaffold()
-    await write('.keyshelf/web/staging.yaml', 'provider: store\nkeys:\n  REGION: eu\n  EXTRA_SECRET: !secret\n')
-    const sentinel = path.join(cwd, 'ran.txt')
-    const {code, stdout} = await runWrapped([
-      'run',
-      'web/staging',
-      '--json',
-      '--',
-      'node',
-      '-e',
-      `require('fs').writeFileSync(${JSON.stringify(sentinel)}, 'x')`,
-    ])
-    expect(code).not.toBe(0)
-    expect(JSON.parse(stdout).error.code).toBe('SECRET_NOT_FOUND')
-    const {existsSync} = await import('node:fs')
-    expect(existsSync(sentinel)).toBe(false)
-  })
+  it("resolves a differently-named foreign value via an explicit { ref } override", async () => {
+    await scaffold();
+    await seedFakeStore({ "shared-db-url": "postgres://shared/db" });
+    await write(
+      ".keyshelf/web/staging.yaml",
+      "provider: store\nkeys:\n  REGION: eu\n  DATABASE_URL: !secret { ref: shared-db-url }\n"
+    );
+    const { code, stdout } = await runWrapped(printEnv("DATABASE_URL"));
+    expect(code).toBe(0);
+    expect(stdout).toBe("postgres://shared/db");
+  });
 
-  it('aborts with ADAPTER_UNAVAILABLE for a !secret on an unregistered adapter', async () => {
-    await scaffold()
+  it("aborts with SECRET_NOT_FOUND when a !secret has no stored value", async () => {
+    await scaffold();
+    await write(
+      ".keyshelf/web/staging.yaml",
+      "provider: store\nkeys:\n  REGION: eu\n  EXTRA_SECRET: !secret\n"
+    );
+    const sentinel = path.join(cwd, "ran.txt");
+    const { code, stdout } = await runWrapped([
+      "run",
+      "web/staging",
+      "--json",
+      "--",
+      "node",
+      "-e",
+      `require('fs').writeFileSync(${JSON.stringify(sentinel)}, 'x')`
+    ]);
+    expect(code).not.toBe(0);
+    expect(JSON.parse(stdout).error.code).toBe("SECRET_NOT_FOUND");
+    const { existsSync } = await import("node:fs");
+    expect(existsSync(sentinel)).toBe(false);
+  });
+
+  it("aborts with ADAPTER_UNAVAILABLE for a !secret on an unregistered adapter", async () => {
+    await scaffold();
     // The `bogus` provider names an adapter no branch in the registry handles.
-    await write('.keyshelf/web/staging.yaml', 'provider: bogus\nkeys:\n  REGION: eu\n  EXTRA_SECRET: !secret\n')
-    const {code, stdout} = await runWrapped(['run', 'web/staging', '--json', '--', 'node', '-e', 'process.exit(0)'])
-    expect(code).not.toBe(0)
-    expect(JSON.parse(stdout).error.code).toBe('ADAPTER_UNAVAILABLE')
-  })
+    await write(
+      ".keyshelf/web/staging.yaml",
+      "provider: bogus\nkeys:\n  REGION: eu\n  EXTRA_SECRET: !secret\n"
+    );
+    const { code, stdout } = await runWrapped([
+      "run",
+      "web/staging",
+      "--json",
+      "--",
+      "node",
+      "-e",
+      "process.exit(0)"
+    ]);
+    expect(code).not.toBe(0);
+    expect(JSON.parse(stdout).error.code).toBe("ADAPTER_UNAVAILABLE");
+  });
 
-  it('reports EXEC_FAILED when the wrapped command cannot be started', async () => {
-    await scaffold()
-    const {code, stdout} = await runWrapped([
-      'run',
-      'web/staging',
-      '--json',
-      '--',
-      'this-binary-does-not-exist-keyshelf',
-    ])
-    expect(code).not.toBe(0)
-    expect(JSON.parse(stdout).error.code).toBe('EXEC_FAILED')
-  })
+  it("reports EXEC_FAILED when the wrapped command cannot be started", async () => {
+    await scaffold();
+    const { code, stdout } = await runWrapped([
+      "run",
+      "web/staging",
+      "--json",
+      "--",
+      "this-binary-does-not-exist-keyshelf"
+    ]);
+    expect(code).not.toBe(0);
+    expect(JSON.parse(stdout).error.code).toBe("EXEC_FAILED");
+  });
 
-  it('rejects a malformed <shelf>/<env> argument with MALFORMED_FILE', async () => {
-    await scaffold()
-    const {code, stdout} = await runKeyshelf(['run', 'webstaging', '--json', '--', 'node', '-e', '0'], {cwd})
-    expect(code).not.toBe(0)
-    expect(JSON.parse(stdout).error.code).toBe('MALFORMED_FILE')
-  })
+  it("rejects a malformed <shelf>/<env> argument with MALFORMED_FILE", async () => {
+    await scaffold();
+    const { code, stdout } = await runKeyshelf(
+      ["run", "webstaging", "--json", "--", "node", "-e", "0"],
+      { cwd }
+    );
+    expect(code).not.toBe(0);
+    expect(JSON.parse(stdout).error.code).toBe("MALFORMED_FILE");
+  });
 
-  it('exposes --help and exits zero', async () => {
-    const {code, stdout} = await runKeyshelf(['run', '--help'], {cwd})
-    expect(code).toBe(0)
-    expect(stdout).toContain('run')
-  })
-})
+  it("exposes --help and exits zero", async () => {
+    const { code, stdout } = await runKeyshelf(["run", "--help"], { cwd });
+    expect(code).toBe(0);
+    expect(stdout).toContain("run");
+  });
+});

--- a/packages/cli/test/e2e/secret-roundtrip.ts
+++ b/packages/cli/test/e2e/secret-roundtrip.ts
@@ -1,7 +1,7 @@
-import {readFile} from 'node:fs/promises'
-import path from 'node:path'
-import {afterEach, beforeEach, describe, expect, it} from 'vitest'
-import {makeTmpDir, removeDir, runKeyshelf} from './helpers.js'
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { makeTmpDir, removeDir, runKeyshelf } from "./helpers.js";
 
 /**
  * A per-adapter harness for the shared black-box E2E suite (ADR-0005). It is the
@@ -13,29 +13,29 @@ import {makeTmpDir, removeDir, runKeyshelf} from './helpers.js'
  */
 export interface E2EHarness {
   /** A label for the test report (e.g. `'fake'`, `'sops'`). */
-  readonly name: string
+  readonly name: string;
   /** The provider name the scaffolded environment references. */
-  readonly providerName: string
+  readonly providerName: string;
   /** The `providers:` block written into `config.yaml`. */
-  providerConfig(): Record<string, unknown>
+  providerConfig(): Record<string, unknown>;
   /** Provision backend prerequisites in `dir` before the project runs. */
-  setup(dir: string): Promise<void>
+  setup(dir: string): Promise<void>;
   /** Env vars merged into each spawned `keyshelf` invocation. */
-  runEnv(dir: string): Record<string, string>
+  runEnv(dir: string): Record<string, string>;
   /**
    * Read the raw on-disk store so the suite can assert it is ciphertext, not
    * plaintext. Omit for a backend with no inspectable local store.
    */
-  inspectStore?(dir: string): Promise<string>
+  inspectStore?(dir: string): Promise<string>;
   /** When true, the store must additionally look sops-encrypted (`ENC[`/`sops:`). */
-  readonly expectEncrypted?: boolean
+  readonly expectEncrypted?: boolean;
   /** Tear down anything {@link setup} provisioned outside `dir`. */
-  teardown(): Promise<void>
+  teardown(): Promise<void>;
 }
 
 /** A secret value with embedded newlines, `=`, quotes and unicode — exercises
  * byte-exact fidelity through the real binary, not just the contract suite. */
-const ADVERSARIAL_SECRET = 'p@ss\nword="x=y"\ncafé 🔐'
+const ADVERSARIAL_SECRET = 'p@ss\nword="x=y"\ncafé 🔐';
 
 /**
  * The shared, adapter-agnostic black-box E2E suite. It drives the real `keyshelf`
@@ -47,98 +47,118 @@ const ADVERSARIAL_SECRET = 'p@ss\nword="x=y"\ncafé 🔐'
  */
 export function runSecretRoundtripSuite(harness: E2EHarness): void {
   describe(`secret round-trip E2E: ${harness.name}`, () => {
-    let cwd: string
+    let cwd: string;
 
     beforeEach(async () => {
-      cwd = await makeTmpDir()
-      await harness.setup(cwd)
-      await scaffold(cwd, harness)
-    })
+      cwd = await makeTmpDir();
+      await harness.setup(cwd);
+      await scaffold(cwd, harness);
+    });
 
     afterEach(async () => {
-      await removeDir(cwd)
-      await harness.teardown()
-    })
+      await removeDir(cwd);
+      await harness.teardown();
+    });
 
-    const env = () => harness.runEnv(cwd)
+    const env = () => harness.runEnv(cwd);
 
-    it('set --secret stores ciphertext, run injects the value, validate passes', async () => {
-      const set = await runKeyshelf(['set', 'DATABASE_PASSWORD', 'app/staging', '--secret', '--json'], {
-        cwd,
-        input: ADVERSARIAL_SECRET,
-        env: env(),
-      })
-      expect(set.code, set.stderr).toBe(0)
-      expect(JSON.parse(set.stdout)).toMatchObject({key: 'DATABASE_PASSWORD', environment: 'app/staging', secret: true})
+    it("set --secret stores ciphertext, run injects the value, validate passes", async () => {
+      const set = await runKeyshelf(
+        ["set", "DATABASE_PASSWORD", "app/staging", "--secret", "--json"],
+        {
+          cwd,
+          input: ADVERSARIAL_SECRET,
+          env: env()
+        }
+      );
+      expect(set.code, set.stderr).toBe(0);
+      expect(JSON.parse(set.stdout)).toMatchObject({
+        key: "DATABASE_PASSWORD",
+        environment: "app/staging",
+        secret: true
+      });
 
       // The env file records only a !secret reference — never the plaintext.
-      const envText = await readFile(path.join(cwd, '.keyshelf', 'app', 'staging.yaml'), 'utf8')
-      expect(envText).toContain('!secret')
-      expect(envText).not.toContain('café')
+      const envText = await readFile(path.join(cwd, ".keyshelf", "app", "staging.yaml"), "utf8");
+      expect(envText).toContain("!secret");
+      expect(envText).not.toContain("café");
 
       // Inspection hook: the on-disk store is ciphertext, not plaintext.
-      await expectStoreEncrypted(cwd, harness, ADVERSARIAL_SECRET)
+      await expectStoreEncrypted(cwd, harness, ADVERSARIAL_SECRET);
 
       // run injects the resolved secret; the child sees it byte-exact.
       const run = await runKeyshelf(
-        ['run', 'app/staging', '--', 'node', '-e', 'process.stdout.write(String(process.env.DATABASE_PASSWORD))'],
-        {cwd, env: env()},
-      )
-      expect(run.code, run.stderr).toBe(0)
-      expect(run.stdout).toBe(ADVERSARIAL_SECRET)
+        [
+          "run",
+          "app/staging",
+          "--",
+          "node",
+          "-e",
+          "process.stdout.write(String(process.env.DATABASE_PASSWORD))"
+        ],
+        { cwd, env: env() }
+      );
+      expect(run.code, run.stderr).toBe(0);
+      expect(run.stdout).toBe(ADVERSARIAL_SECRET);
 
       // validate passes once every required key is supplied.
-      const validate = await runKeyshelf(['validate', 'app/staging', '--json'], {cwd, env: env()})
-      expect(validate.code, validate.stderr).toBe(0)
-      expect(JSON.parse(validate.stdout)).toMatchObject({environment: 'app/staging', valid: true})
-    })
+      const validate = await runKeyshelf(["validate", "app/staging", "--json"], {
+        cwd,
+        env: env()
+      });
+      expect(validate.code, validate.stderr).toBe(0);
+      expect(JSON.parse(validate.stdout)).toMatchObject({
+        environment: "app/staging",
+        valid: true
+      });
+    });
 
-    it('run surfaces SECRET_NOT_FOUND when a !secret reference has no stored value', async () => {
+    it("run surfaces SECRET_NOT_FOUND when a !secret reference has no stored value", async () => {
       // Declare the env as referencing a secret that was never written.
       await writeEnv(
         cwd,
-        `provider: ${harness.providerName}\nkeys:\n  REGION: eu-west-1\n  DATABASE_PASSWORD: !secret\n`,
-      )
+        `provider: ${harness.providerName}\nkeys:\n  REGION: eu-west-1\n  DATABASE_PASSWORD: !secret\n`
+      );
       const run = await runKeyshelf(
-        ['run', 'app/staging', '--', 'node', '-e', 'process.stdout.write("ran")'],
-        {cwd, env: env()},
-      )
-      expect(run.code).not.toBe(0)
+        ["run", "app/staging", "--", "node", "-e", 'process.stdout.write("ran")'],
+        { cwd, env: env() }
+      );
+      expect(run.code).not.toBe(0);
       const json = await runKeyshelf(
-        ['run', 'app/staging', '--json', '--', 'node', '-e', 'process.stdout.write("ran")'],
-        {cwd, env: env()},
-      )
-      expect(JSON.parse(json.stdout).error.code).toBe('SECRET_NOT_FOUND')
+        ["run", "app/staging", "--json", "--", "node", "-e", 'process.stdout.write("ran")'],
+        { cwd, env: env() }
+      );
+      expect(JSON.parse(json.stdout).error.code).toBe("SECRET_NOT_FOUND");
       // Fail-fast: the wrapped command never ran.
-      expect(json.stdout).not.toContain('ran')
-    })
-  })
+      expect(json.stdout).not.toContain("ran");
+    });
+  });
 }
 
 const SCHEMA = `keys:
   REGION: !required
   DATABASE_PASSWORD: !required
-`
+`;
 
 /** Scaffold a `.keyshelf/` project referencing the harness's provider. */
 async function scaffold(cwd: string, harness: E2EHarness): Promise<void> {
-  const {writeFile, mkdir} = await import('node:fs/promises')
-  const root = path.join(cwd, '.keyshelf')
-  await mkdir(path.join(root, 'app'), {recursive: true})
+  const { writeFile, mkdir } = await import("node:fs/promises");
+  const root = path.join(cwd, ".keyshelf");
+  await mkdir(path.join(root, "app"), { recursive: true });
 
-  const {stringify} = await import('yaml')
+  const { stringify } = await import("yaml");
   await writeFile(
-    path.join(root, 'config.yaml'),
-    stringify({project: 'myapp', providers: harness.providerConfig()}),
-    'utf8',
-  )
-  await writeFile(path.join(root, 'app', 'schema.yaml'), SCHEMA, 'utf8')
-  await writeEnv(cwd, `provider: ${harness.providerName}\nkeys:\n  REGION: eu-west-1\n`)
+    path.join(root, "config.yaml"),
+    stringify({ project: "myapp", providers: harness.providerConfig() }),
+    "utf8"
+  );
+  await writeFile(path.join(root, "app", "schema.yaml"), SCHEMA, "utf8");
+  await writeEnv(cwd, `provider: ${harness.providerName}\nkeys:\n  REGION: eu-west-1\n`);
 }
 
 async function writeEnv(cwd: string, contents: string): Promise<void> {
-  const {writeFile} = await import('node:fs/promises')
-  await writeFile(path.join(cwd, '.keyshelf', 'app', 'staging.yaml'), contents, 'utf8')
+  const { writeFile } = await import("node:fs/promises");
+  await writeFile(path.join(cwd, ".keyshelf", "app", "staging.yaml"), contents, "utf8");
 }
 
 /**
@@ -147,13 +167,17 @@ async function writeEnv(cwd: string, contents: string): Promise<void> {
  * The fake store is plaintext JSON by design, so only the no-plaintext invariant
  * holds there — `expectEncrypted` lets each harness opt into the stronger check.
  */
-async function expectStoreEncrypted(cwd: string, harness: E2EHarness, secret: string): Promise<void> {
-  const inspect = harness.inspectStore
-  if (inspect === undefined) return
-  const contents = await inspect(cwd)
-  expect(contents).not.toContain(secret)
+async function expectStoreEncrypted(
+  cwd: string,
+  harness: E2EHarness,
+  secret: string
+): Promise<void> {
+  const inspect = harness.inspectStore;
+  if (inspect === undefined) return;
+  const contents = await inspect(cwd);
+  expect(contents).not.toContain(secret);
   if (harness.expectEncrypted) {
-    expect(contents).toMatch(/ENC\[/)
-    expect(contents).toContain('sops:')
+    expect(contents).toMatch(/ENC\[/);
+    expect(contents).toContain("sops:");
   }
 }

--- a/packages/cli/test/e2e/set.e2e.test.ts
+++ b/packages/cli/test/e2e/set.e2e.test.ts
@@ -1,26 +1,26 @@
-import {readFile, mkdir, writeFile} from 'node:fs/promises'
-import path from 'node:path'
-import {afterEach, beforeEach, describe, expect, it} from 'vitest'
-import {makeTmpDir, removeDir, runKeyshelf} from './helpers.js'
+import { readFile, mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { makeTmpDir, removeDir, runKeyshelf } from "./helpers.js";
 
-let cwd: string
+let cwd: string;
 
 beforeEach(async () => {
-  cwd = await makeTmpDir()
-})
+  cwd = await makeTmpDir();
+});
 
 afterEach(async () => {
-  await removeDir(cwd)
-})
+  await removeDir(cwd);
+});
 
 async function write(rel: string, contents: string): Promise<void> {
-  const full = path.join(cwd, rel)
-  await mkdir(path.dirname(full), {recursive: true})
-  await writeFile(full, contents, 'utf8')
+  const full = path.join(cwd, rel);
+  await mkdir(path.dirname(full), { recursive: true });
+  await writeFile(full, contents, "utf8");
 }
 
 async function read(rel: string): Promise<string> {
-  return readFile(path.join(cwd, rel), 'utf8')
+  return readFile(path.join(cwd, rel), "utf8");
 }
 
 const CONFIG = `project: myapp
@@ -31,166 +31,212 @@ providers:
     adapter: fake
   bogus:
     adapter: no-such-adapter
-`
+`;
 
 const SCHEMA = `keys:
   LOG_LEVEL: info
   REGION: !required
   DATABASE_PASSWORD: !required
   TRICKY: !optional
-`
+`;
 
 // Two keys + a provider line, so we can assert the in-place edit preserves the rest.
 const ENV = `provider: store
 keys:
   LOG_LEVEL: debug
   REGION: eu-west-1
-`
+`;
 
 async function scaffold(): Promise<void> {
-  await write('.keyshelf/config.yaml', CONFIG)
-  await write('.keyshelf/web/schema.yaml', SCHEMA)
-  await write('.keyshelf/web/staging.yaml', ENV)
+  await write(".keyshelf/config.yaml", CONFIG);
+  await write(".keyshelf/web/schema.yaml", SCHEMA);
+  await write(".keyshelf/web/staging.yaml", ENV);
 }
 
-describe('keyshelf set <KEY> <shelf>/<env>', () => {
-  it('reads a plaintext value from stdin and writes it under keys, preserving others', async () => {
-    await scaffold()
-    const {code, stdout} = await runKeyshelf(['set', 'DATABASE_PASSWORD', 'web/staging', '--json'], {
-      cwd,
-      input: 'plainpw',
-    })
-    expect(code).toBe(0)
-    expect(JSON.parse(stdout)).toMatchObject({key: 'DATABASE_PASSWORD', environment: 'web/staging', secret: false})
+describe("keyshelf set <KEY> <shelf>/<env>", () => {
+  it("reads a plaintext value from stdin and writes it under keys, preserving others", async () => {
+    await scaffold();
+    const { code, stdout } = await runKeyshelf(
+      ["set", "DATABASE_PASSWORD", "web/staging", "--json"],
+      {
+        cwd,
+        input: "plainpw"
+      }
+    );
+    expect(code).toBe(0);
+    expect(JSON.parse(stdout)).toMatchObject({
+      key: "DATABASE_PASSWORD",
+      environment: "web/staging",
+      secret: false
+    });
 
-    const envText = await read('.keyshelf/web/staging.yaml')
+    const envText = await read(".keyshelf/web/staging.yaml");
     // In-place edit preserves the other keys and the provider line.
-    expect(envText).toContain('provider: store')
-    expect(envText).toContain('LOG_LEVEL: debug')
-    expect(envText).toContain('REGION: eu-west-1')
-    expect(envText).toContain('DATABASE_PASSWORD: plainpw')
-  })
+    expect(envText).toContain("provider: store");
+    expect(envText).toContain("LOG_LEVEL: debug");
+    expect(envText).toContain("REGION: eu-west-1");
+    expect(envText).toContain("DATABASE_PASSWORD: plainpw");
+  });
 
-  it('round-trips an adversarial plaintext value with spaces, = and quotes', async () => {
-    await scaffold()
+  it("round-trips an adversarial plaintext value with spaces, = and quotes", async () => {
+    await scaffold();
     // An env that already satisfies the required keys, so run resolves cleanly.
     await write(
-      '.keyshelf/web/staging.yaml',
-      'provider: store\nkeys:\n  REGION: eu-west-1\n  DATABASE_PASSWORD: pw\n',
-    )
-    const value = 'a "quoted" = value with spaces'
-    const {code} = await runKeyshelf(['set', 'TRICKY', 'web/staging'], {cwd, input: value})
-    expect(code).toBe(0)
+      ".keyshelf/web/staging.yaml",
+      "provider: store\nkeys:\n  REGION: eu-west-1\n  DATABASE_PASSWORD: pw\n"
+    );
+    const value = 'a "quoted" = value with spaces';
+    const { code } = await runKeyshelf(["set", "TRICKY", "web/staging"], { cwd, input: value });
+    expect(code).toBe(0);
     // run injects the resolved value; the child must see it byte-exact.
-    const {stdout} = await runKeyshelf(
-      ['run', 'web/staging', '--', 'node', '-e', 'process.stdout.write(String(process.env.TRICKY))'],
-      {cwd},
-    )
-    expect(stdout).toBe(value)
-  })
+    const { stdout } = await runKeyshelf(
+      [
+        "run",
+        "web/staging",
+        "--",
+        "node",
+        "-e",
+        "process.stdout.write(String(process.env.TRICKY))"
+      ],
+      { cwd }
+    );
+    expect(stdout).toBe(value);
+  });
 
-  it('never modifies the schema and rejects a key not in the schema with UNKNOWN_KEY', async () => {
-    await scaffold()
-    const schemaBefore = await read('.keyshelf/web/schema.yaml')
-    const {code, stdout} = await runKeyshelf(['set', 'NOT_DECLARED', 'web/staging', '--json'], {
+  it("never modifies the schema and rejects a key not in the schema with UNKNOWN_KEY", async () => {
+    await scaffold();
+    const schemaBefore = await read(".keyshelf/web/schema.yaml");
+    const { code, stdout } = await runKeyshelf(["set", "NOT_DECLARED", "web/staging", "--json"], {
       cwd,
-      input: 'whatever',
-    })
-    expect(code).not.toBe(0)
-    expect(JSON.parse(stdout).error).toMatchObject({code: 'UNKNOWN_KEY', key: 'NOT_DECLARED'})
+      input: "whatever"
+    });
+    expect(code).not.toBe(0);
+    expect(JSON.parse(stdout).error).toMatchObject({ code: "UNKNOWN_KEY", key: "NOT_DECLARED" });
     // Schema file is byte-for-byte unchanged.
-    expect(await read('.keyshelf/web/schema.yaml')).toBe(schemaBefore)
+    expect(await read(".keyshelf/web/schema.yaml")).toBe(schemaBefore);
     // The env file is not given the rejected key either.
-    expect(await read('.keyshelf/web/staging.yaml')).not.toContain('NOT_DECLARED')
-  })
+    expect(await read(".keyshelf/web/staging.yaml")).not.toContain("NOT_DECLARED");
+  });
 
-  it('fails with NO_INPUT when stdin provides no value', async () => {
-    await scaffold()
-    const {code, stdout} = await runKeyshelf(['set', 'REGION', 'web/staging', '--json'], {cwd, input: ''})
-    expect(code).not.toBe(0)
-    expect(JSON.parse(stdout).error.code).toBe('NO_INPUT')
-  })
-
-  it('surfaces ENVIRONMENT_NOT_FOUND for a missing environment', async () => {
-    await scaffold()
-    const {code, stdout} = await runKeyshelf(['set', 'REGION', 'web/prod', '--json'], {cwd, input: 'x'})
-    expect(code).not.toBe(0)
-    expect(JSON.parse(stdout).error.code).toBe('ENVIRONMENT_NOT_FOUND')
-  })
-
-  it('rejects a malformed <shelf>/<env> argument with MALFORMED_FILE', async () => {
-    await scaffold()
-    const {code, stdout} = await runKeyshelf(['set', 'REGION', 'webstaging', '--json'], {cwd, input: 'x'})
-    expect(code).not.toBe(0)
-    expect(JSON.parse(stdout).error.code).toBe('MALFORMED_FILE')
-  })
-
-  it('exposes --help and exits zero', async () => {
-    const {code, stdout} = await runKeyshelf(['set', '--help'], {cwd})
-    expect(code).toBe(0)
-    expect(stdout).toContain('set')
-  })
-})
-
-describe('keyshelf set <KEY> <shelf>/<env> --secret', () => {
-  it('writes the value to the store and records only a bare !secret reference', async () => {
-    await scaffold()
-    const secret = 's3cr3t-value'
-    const {code, stdout} = await runKeyshelf(['set', 'DATABASE_PASSWORD', 'web/staging', '--secret', '--json'], {
+  it("fails with NO_INPUT when stdin provides no value", async () => {
+    await scaffold();
+    const { code, stdout } = await runKeyshelf(["set", "REGION", "web/staging", "--json"], {
       cwd,
-      input: secret,
-    })
-    expect(code).toBe(0)
-    expect(JSON.parse(stdout)).toMatchObject({key: 'DATABASE_PASSWORD', environment: 'web/staging', secret: true})
+      input: ""
+    });
+    expect(code).not.toBe(0);
+    expect(JSON.parse(stdout).error.code).toBe("NO_INPUT");
+  });
 
-    const envText = await read('.keyshelf/web/staging.yaml')
+  it("surfaces ENVIRONMENT_NOT_FOUND for a missing environment", async () => {
+    await scaffold();
+    const { code, stdout } = await runKeyshelf(["set", "REGION", "web/prod", "--json"], {
+      cwd,
+      input: "x"
+    });
+    expect(code).not.toBe(0);
+    expect(JSON.parse(stdout).error.code).toBe("ENVIRONMENT_NOT_FOUND");
+  });
+
+  it("rejects a malformed <shelf>/<env> argument with MALFORMED_FILE", async () => {
+    await scaffold();
+    const { code, stdout } = await runKeyshelf(["set", "REGION", "webstaging", "--json"], {
+      cwd,
+      input: "x"
+    });
+    expect(code).not.toBe(0);
+    expect(JSON.parse(stdout).error.code).toBe("MALFORMED_FILE");
+  });
+
+  it("exposes --help and exits zero", async () => {
+    const { code, stdout } = await runKeyshelf(["set", "--help"], { cwd });
+    expect(code).toBe(0);
+    expect(stdout).toContain("set");
+  });
+});
+
+describe("keyshelf set <KEY> <shelf>/<env> --secret", () => {
+  it("writes the value to the store and records only a bare !secret reference", async () => {
+    await scaffold();
+    const secret = "s3cr3t-value";
+    const { code, stdout } = await runKeyshelf(
+      ["set", "DATABASE_PASSWORD", "web/staging", "--secret", "--json"],
+      {
+        cwd,
+        input: secret
+      }
+    );
+    expect(code).toBe(0);
+    expect(JSON.parse(stdout)).toMatchObject({
+      key: "DATABASE_PASSWORD",
+      environment: "web/staging",
+      secret: true
+    });
+
+    const envText = await read(".keyshelf/web/staging.yaml");
     // The plaintext value never lands in the env file — only a !secret reference.
-    expect(envText).not.toContain(secret)
-    expect(envText).toContain('!secret')
-    expect(envText).toContain('DATABASE_PASSWORD')
+    expect(envText).not.toContain(secret);
+    expect(envText).toContain("!secret");
+    expect(envText).toContain("DATABASE_PASSWORD");
     // Other keys + provider survive.
-    expect(envText).toContain('provider: store')
-    expect(envText).toContain('LOG_LEVEL: debug')
+    expect(envText).toContain("provider: store");
+    expect(envText).toContain("LOG_LEVEL: debug");
 
     // The value lives in the fake store under the convention name.
-    const store = JSON.parse(await read('.keyshelf/.fake-store.json'))
-    expect(store['myapp-web-staging-DATABASE_PASSWORD']).toBe(secret)
-  })
+    const store = JSON.parse(await read(".keyshelf/.fake-store.json"));
+    expect(store["myapp-web-staging-DATABASE_PASSWORD"]).toBe(secret);
+  });
 
-  it('round-trips: set --secret then run resolves the stored value via fake', async () => {
-    await scaffold()
-    const secret = 'round-trip-secret'
-    const set = await runKeyshelf(['set', 'DATABASE_PASSWORD', 'web/staging', '--secret'], {cwd, input: secret})
-    expect(set.code).toBe(0)
-
-    const {code, stdout} = await runKeyshelf(
-      ['run', 'web/staging', '--', 'node', '-e', 'process.stdout.write(String(process.env.DATABASE_PASSWORD))'],
-      {cwd},
-    )
-    expect(code).toBe(0)
-    expect(stdout).toBe(secret)
-  })
-
-  it('round-trips: set --secret then validate passes', async () => {
-    await scaffold()
-    const set = await runKeyshelf(['set', 'DATABASE_PASSWORD', 'web/staging', '--secret'], {cwd, input: 'pw'})
-    expect(set.code).toBe(0)
-    const {code, stdout} = await runKeyshelf(['validate', 'web/staging', '--json'], {cwd})
-    expect(code).toBe(0)
-    expect(JSON.parse(stdout)).toMatchObject({environment: 'web/staging', valid: true})
-  })
-
-  it('rejects --secret on a provider whose adapter is unregistered with ADAPTER_UNAVAILABLE', async () => {
-    await scaffold()
-    // The `bogus` provider names an adapter no branch in the registry handles.
-    await write('.keyshelf/web/staging.yaml', 'provider: bogus\nkeys:\n  REGION: eu-west-1\n')
-    const {code, stdout} = await runKeyshelf(['set', 'DATABASE_PASSWORD', 'web/staging', '--secret', '--json'], {
+  it("round-trips: set --secret then run resolves the stored value via fake", async () => {
+    await scaffold();
+    const secret = "round-trip-secret";
+    const set = await runKeyshelf(["set", "DATABASE_PASSWORD", "web/staging", "--secret"], {
       cwd,
-      input: 'pw',
-    })
-    expect(code).not.toBe(0)
-    expect(JSON.parse(stdout).error.code).toBe('ADAPTER_UNAVAILABLE')
+      input: secret
+    });
+    expect(set.code).toBe(0);
+
+    const { code, stdout } = await runKeyshelf(
+      [
+        "run",
+        "web/staging",
+        "--",
+        "node",
+        "-e",
+        "process.stdout.write(String(process.env.DATABASE_PASSWORD))"
+      ],
+      { cwd }
+    );
+    expect(code).toBe(0);
+    expect(stdout).toBe(secret);
+  });
+
+  it("round-trips: set --secret then validate passes", async () => {
+    await scaffold();
+    const set = await runKeyshelf(["set", "DATABASE_PASSWORD", "web/staging", "--secret"], {
+      cwd,
+      input: "pw"
+    });
+    expect(set.code).toBe(0);
+    const { code, stdout } = await runKeyshelf(["validate", "web/staging", "--json"], { cwd });
+    expect(code).toBe(0);
+    expect(JSON.parse(stdout)).toMatchObject({ environment: "web/staging", valid: true });
+  });
+
+  it("rejects --secret on a provider whose adapter is unregistered with ADAPTER_UNAVAILABLE", async () => {
+    await scaffold();
+    // The `bogus` provider names an adapter no branch in the registry handles.
+    await write(".keyshelf/web/staging.yaml", "provider: bogus\nkeys:\n  REGION: eu-west-1\n");
+    const { code, stdout } = await runKeyshelf(
+      ["set", "DATABASE_PASSWORD", "web/staging", "--secret", "--json"],
+      {
+        cwd,
+        input: "pw"
+      }
+    );
+    expect(code).not.toBe(0);
+    expect(JSON.parse(stdout).error.code).toBe("ADAPTER_UNAVAILABLE");
     // Nothing recorded in the env file on a failed write.
-    expect(await read('.keyshelf/web/staging.yaml')).not.toContain('!secret')
-  })
-})
+    expect(await read(".keyshelf/web/staging.yaml")).not.toContain("!secret");
+  });
+});

--- a/packages/cli/test/e2e/sops.secret-roundtrip.e2e.test.ts
+++ b/packages/cli/test/e2e/sops.secret-roundtrip.e2e.test.ts
@@ -1,12 +1,12 @@
-import {execFile} from 'node:child_process'
-import {readFile, writeFile} from 'node:fs/promises'
-import path from 'node:path'
-import {promisify} from 'node:util'
-import {describe, it} from 'vitest'
-import {sopsAvailable} from '../conformance/sops-fixture.js'
-import {runSecretRoundtripSuite} from './secret-roundtrip.js'
+import { execFile } from "node:child_process";
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+import { describe, it } from "vitest";
+import { sopsAvailable } from "../conformance/sops-fixture.js";
+import { runSecretRoundtripSuite } from "./secret-roundtrip.js";
 
-const execFileAsync = promisify(execFile)
+const execFileAsync = promisify(execFile);
 
 // The sops harness: provisions a throwaway age key + fixture `.sops.yaml` in the
 // project directory so the real `keyshelf` binary, shelling out to sops, encrypts
@@ -17,42 +17,42 @@ const execFileAsync = promisify(execFile)
 // Skips when no sops/age is resolvable so local `npm test` stays green; CI
 // installs both and asserts their presence, so the matrix genuinely runs there.
 if (sopsAvailable()) {
-  let ageKeyFile = ''
+  let ageKeyFile = "";
 
   runSecretRoundtripSuite({
-    name: 'sops',
-    providerName: 'local',
+    name: "sops",
+    providerName: "local",
     providerConfig() {
-      return {local: {adapter: 'sops'}}
+      return { local: { adapter: "sops" } };
     },
     async setup(dir) {
-      ageKeyFile = path.join(dir, 'age-key.txt')
-      const {stderr} = await execFileAsync('age-keygen', ['-o', ageKeyFile])
-      const match = /public key:\s*(age1[0-9a-z]+)/i.exec(stderr)
-      if (match === null) throw new Error(`could not parse age public key: ${stderr}`)
+      ageKeyFile = path.join(dir, "age-key.txt");
+      const { stderr } = await execFileAsync("age-keygen", ["-o", ageKeyFile]);
+      const match = /public key:\s*(age1[0-9a-z]+)/i.exec(stderr);
+      if (match === null) throw new Error(`could not parse age public key: ${stderr}`);
 
       // The fixture .sops.yaml the adapter never mutates — recipients are the
       // user's concern; here a throwaway recipient plays that role. sops walks up
       // from the store path to find it at the project root.
       await writeFile(
-        path.join(dir, '.sops.yaml'),
+        path.join(dir, ".sops.yaml"),
         `creation_rules:\n  - path_regex: .*\\.secrets\\.yaml$\n    age: ${match[1]}\n`,
-        'utf8',
-      )
+        "utf8"
+      );
     },
     runEnv() {
-      return {SOPS_AGE_KEY_FILE: ageKeyFile}
+      return { SOPS_AGE_KEY_FILE: ageKeyFile };
     },
     async inspectStore(dir) {
-      return readFile(path.join(dir, '.keyshelf', 'app', 'staging.secrets.yaml'), 'utf8')
+      return readFile(path.join(dir, ".keyshelf", "app", "staging.secrets.yaml"), "utf8");
     },
     expectEncrypted: true,
     async teardown() {
       // The temp project dir (with the key) is removed by the suite.
-    },
-  })
+    }
+  });
 } else {
-  describe('secret round-trip E2E: sops', () => {
-    it.skip('skipped: no sops/age binary resolvable on this host', () => {})
-  })
+  describe("secret round-trip E2E: sops", () => {
+    it.skip("skipped: no sops/age binary resolvable on this host", () => {});
+  });
 }

--- a/packages/cli/test/e2e/validate.e2e.test.ts
+++ b/packages/cli/test/e2e/validate.e2e.test.ts
@@ -1,22 +1,22 @@
-import {mkdir, writeFile} from 'node:fs/promises'
-import path from 'node:path'
-import {afterEach, beforeEach, describe, expect, it} from 'vitest'
-import {makeTmpDir, removeDir, runKeyshelf} from './helpers.js'
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { makeTmpDir, removeDir, runKeyshelf } from "./helpers.js";
 
-let cwd: string
+let cwd: string;
 
 beforeEach(async () => {
-  cwd = await makeTmpDir()
-})
+  cwd = await makeTmpDir();
+});
 
 afterEach(async () => {
-  await removeDir(cwd)
-})
+  await removeDir(cwd);
+});
 
 async function write(rel: string, contents: string): Promise<void> {
-  const full = path.join(cwd, rel)
-  await mkdir(path.dirname(full), {recursive: true})
-  await writeFile(full, contents, 'utf8')
+  const full = path.join(cwd, rel);
+  await mkdir(path.dirname(full), { recursive: true });
+  await writeFile(full, contents, "utf8");
 }
 
 const CONFIG = `project: myapp
@@ -25,207 +25,217 @@ providers:
     adapter: sops
   store:
     adapter: fake
-`
+`;
 
 const SCHEMA = `keys:
   LOG_LEVEL: info
   REGION: !required
   FEATURE_X: !optional
   DATABASE_PASSWORD: !required
-`
+`;
 
 const GOOD_ENV = `provider: store
 keys:
   REGION: eu-west-1
   DATABASE_PASSWORD: !secret
-`
+`;
 
 async function scaffold(): Promise<void> {
-  await write('.keyshelf/config.yaml', CONFIG)
-  await write('.keyshelf/web/schema.yaml', SCHEMA)
-  await write('.keyshelf/web/staging.yaml', GOOD_ENV)
+  await write(".keyshelf/config.yaml", CONFIG);
+  await write(".keyshelf/web/schema.yaml", SCHEMA);
+  await write(".keyshelf/web/staging.yaml", GOOD_ENV);
   // "valid means would run": the declared secret must be resolvable.
   await seedFakeStore({
-    'myapp-web-staging-DATABASE_PASSWORD': 'pw',
-    'myapp-web-prod-DATABASE_PASSWORD': 'pw',
-    'myapp-api-dev-TOKEN': 'tok',
-  })
+    "myapp-web-staging-DATABASE_PASSWORD": "pw",
+    "myapp-web-prod-DATABASE_PASSWORD": "pw",
+    "myapp-api-dev-TOKEN": "tok"
+  });
 }
 
 /** Seed the file-backed fake store the `fake` adapter reads (storedName -> value). */
 async function seedFakeStore(entries: Record<string, string>): Promise<void> {
-  await write('.keyshelf/.fake-store.json', JSON.stringify(entries, null, 2))
+  await write(".keyshelf/.fake-store.json", JSON.stringify(entries, null, 2));
 }
 
-function errorOf(stdout: string): {code: string} & Record<string, unknown> {
-  return JSON.parse(stdout).error
+function errorOf(stdout: string): { code: string } & Record<string, unknown> {
+  return JSON.parse(stdout).error;
 }
 
-describe('keyshelf validate <shelf>/<env>', () => {
-  it('validates a well-formed environment successfully', async () => {
-    await scaffold()
-    const {code, stdout} = await runKeyshelf(['validate', 'web/staging', '--json'], {cwd})
-    expect(code).toBe(0)
-    const result = JSON.parse(stdout)
-    expect(result).toMatchObject({environment: 'web/staging', valid: true})
-  })
+describe("keyshelf validate <shelf>/<env>", () => {
+  it("validates a well-formed environment successfully", async () => {
+    await scaffold();
+    const { code, stdout } = await runKeyshelf(["validate", "web/staging", "--json"], { cwd });
+    expect(code).toBe(0);
+    const result = JSON.parse(stdout);
+    expect(result).toMatchObject({ environment: "web/staging", valid: true });
+  });
 
-  it('reports UNKNOWN_KEY for an undeclared key', async () => {
-    await scaffold()
-    await write('.keyshelf/web/staging.yaml', `${GOOD_ENV}  EXTRA: nope\n`)
-    const {code, stdout} = await runKeyshelf(['validate', 'web/staging', '--json'], {cwd})
-    expect(code).not.toBe(0)
-    expect(errorOf(stdout)).toMatchObject({code: 'UNKNOWN_KEY', key: 'EXTRA'})
-  })
+  it("reports UNKNOWN_KEY for an undeclared key", async () => {
+    await scaffold();
+    await write(".keyshelf/web/staging.yaml", `${GOOD_ENV}  EXTRA: nope\n`);
+    const { code, stdout } = await runKeyshelf(["validate", "web/staging", "--json"], { cwd });
+    expect(code).not.toBe(0);
+    expect(errorOf(stdout)).toMatchObject({ code: "UNKNOWN_KEY", key: "EXTRA" });
+  });
 
-  it('reports MISSING_REQUIRED for an absent required key', async () => {
-    await scaffold()
-    await write('.keyshelf/web/staging.yaml', 'provider: local\nkeys:\n  REGION: eu\n')
-    const {code, stdout} = await runKeyshelf(['validate', 'web/staging', '--json'], {cwd})
-    expect(code).not.toBe(0)
-    expect(errorOf(stdout)).toMatchObject({code: 'MISSING_REQUIRED', key: 'DATABASE_PASSWORD'})
-  })
+  it("reports MISSING_REQUIRED for an absent required key", async () => {
+    await scaffold();
+    await write(".keyshelf/web/staging.yaml", "provider: local\nkeys:\n  REGION: eu\n");
+    const { code, stdout } = await runKeyshelf(["validate", "web/staging", "--json"], { cwd });
+    expect(code).not.toBe(0);
+    expect(errorOf(stdout)).toMatchObject({ code: "MISSING_REQUIRED", key: "DATABASE_PASSWORD" });
+  });
 
-  it('reports INVALID_KEY_NAME for a non-identifier key', async () => {
-    await scaffold()
-    await write('.keyshelf/web/staging.yaml', `${GOOD_ENV}  "bad-key": x\n`)
-    const {code, stdout} = await runKeyshelf(['validate', 'web/staging', '--json'], {cwd})
-    expect(code).not.toBe(0)
-    expect(errorOf(stdout)).toMatchObject({code: 'INVALID_KEY_NAME', key: 'bad-key'})
-  })
+  it("reports INVALID_KEY_NAME for a non-identifier key", async () => {
+    await scaffold();
+    await write(".keyshelf/web/staging.yaml", `${GOOD_ENV}  "bad-key": x\n`);
+    const { code, stdout } = await runKeyshelf(["validate", "web/staging", "--json"], { cwd });
+    expect(code).not.toBe(0);
+    expect(errorOf(stdout)).toMatchObject({ code: "INVALID_KEY_NAME", key: "bad-key" });
+  });
 
-  it('reports PROVIDER_NOT_FOUND for an undefined provider', async () => {
-    await scaffold()
-    await write('.keyshelf/web/staging.yaml', GOOD_ENV.replace('provider: store', 'provider: ghost'))
-    const {code, stdout} = await runKeyshelf(['validate', 'web/staging', '--json'], {cwd})
-    expect(code).not.toBe(0)
-    expect(errorOf(stdout)).toMatchObject({code: 'PROVIDER_NOT_FOUND', provider: 'ghost'})
-  })
-
-  it('reports SHELF_NOT_FOUND for an unknown shelf', async () => {
-    await scaffold()
-    const {code, stdout} = await runKeyshelf(['validate', 'ghost/staging', '--json'], {cwd})
-    expect(code).not.toBe(0)
-    expect(errorOf(stdout)).toMatchObject({code: 'SHELF_NOT_FOUND', shelf: 'ghost'})
-  })
-
-  it('reports SCHEMA_NOT_FOUND for a shelf without a schema', async () => {
-    await scaffold()
-    await write('.keyshelf/noschema/dev.yaml', 'provider: local\nkeys: {}\n')
-    const {code, stdout} = await runKeyshelf(['validate', 'noschema/dev', '--json'], {cwd})
-    expect(code).not.toBe(0)
-    expect(errorOf(stdout)).toMatchObject({code: 'SCHEMA_NOT_FOUND', shelf: 'noschema'})
-  })
-
-  it('reports ENVIRONMENT_NOT_FOUND for an unknown environment', async () => {
-    await scaffold()
-    const {code, stdout} = await runKeyshelf(['validate', 'web/prod', '--json'], {cwd})
-    expect(code).not.toBe(0)
-    expect(errorOf(stdout)).toMatchObject({code: 'ENVIRONMENT_NOT_FOUND', environment: 'web/prod'})
-  })
-
-  it('reports MALFORMED_FILE with file + reason for an unparseable environment', async () => {
-    await scaffold()
-    await write('.keyshelf/web/staging.yaml', 'provider: local\nkeys: {bad\n')
-    const {code, stdout} = await runKeyshelf(['validate', 'web/staging', '--json'], {cwd})
-    expect(code).not.toBe(0)
-    const err = errorOf(stdout)
-    expect(err.code).toBe('MALFORMED_FILE')
-    expect(String(err.file)).toContain('staging.yaml')
-    expect(typeof err.reason).toBe('string')
-  })
-
-  it('reports NOT_INITIALIZED when no .keyshelf is present', async () => {
-    const {code, stdout} = await runKeyshelf(['validate', 'web/staging', '--json'], {cwd})
-    expect(code).not.toBe(0)
-    expect(errorOf(stdout).code).toBe('NOT_INITIALIZED')
-  })
-
-  it('rejects a malformed argument that is not shelf/env', async () => {
-    await scaffold()
-    const {code} = await runKeyshelf(['validate', 'webstaging', '--json'], {cwd})
-    expect(code).not.toBe(0)
-  })
-
-  it('reports SECRET_NOT_FOUND when a declared secret is unresolvable (valid means would run)', async () => {
-    await scaffold()
-    // Same env, but the store has no value for the declared secret.
-    await seedFakeStore({})
-    const {code, stdout} = await runKeyshelf(['validate', 'web/staging', '--json'], {cwd})
-    expect(code).not.toBe(0)
-    expect(errorOf(stdout)).toMatchObject({code: 'SECRET_NOT_FOUND', key: 'DATABASE_PASSWORD'})
-  })
-
-  it('validates a resolvable explicit { ref } override secret', async () => {
-    await scaffold()
+  it("reports PROVIDER_NOT_FOUND for an undefined provider", async () => {
+    await scaffold();
     await write(
-      '.keyshelf/web/staging.yaml',
-      'provider: store\nkeys:\n  REGION: eu\n  DATABASE_PASSWORD: !secret { ref: shared-pw }\n',
-    )
-    await seedFakeStore({'shared-pw': 'pw'})
-    const {code, stdout} = await runKeyshelf(['validate', 'web/staging', '--json'], {cwd})
-    expect(code).toBe(0)
-    expect(JSON.parse(stdout)).toMatchObject({environment: 'web/staging', valid: true})
-  })
-})
+      ".keyshelf/web/staging.yaml",
+      GOOD_ENV.replace("provider: store", "provider: ghost")
+    );
+    const { code, stdout } = await runKeyshelf(["validate", "web/staging", "--json"], { cwd });
+    expect(code).not.toBe(0);
+    expect(errorOf(stdout)).toMatchObject({ code: "PROVIDER_NOT_FOUND", provider: "ghost" });
+  });
 
-describe('keyshelf validate (whole project)', () => {
-  it('validates every environment and reports an all-valid aggregate', async () => {
-    await scaffold()
-    await write('.keyshelf/web/prod.yaml', GOOD_ENV)
-    await write('.keyshelf/api/schema.yaml', 'keys:\n  TOKEN: !required\n')
-    await write('.keyshelf/api/dev.yaml', 'provider: store\nkeys:\n  TOKEN: !secret\n')
+  it("reports SHELF_NOT_FOUND for an unknown shelf", async () => {
+    await scaffold();
+    const { code, stdout } = await runKeyshelf(["validate", "ghost/staging", "--json"], { cwd });
+    expect(code).not.toBe(0);
+    expect(errorOf(stdout)).toMatchObject({ code: "SHELF_NOT_FOUND", shelf: "ghost" });
+  });
 
-    const {code, stdout} = await runKeyshelf(['validate', '--json'], {cwd})
-    expect(code).toBe(0)
-    const result = JSON.parse(stdout)
-    expect(result.valid).toBe(true)
-    const ids = result.results.map((r: {environment: string}) => r.environment).sort()
-    expect(ids).toEqual(['api/dev', 'web/prod', 'web/staging'])
-    expect(result.results.every((r: {valid: boolean}) => r.valid)).toBe(true)
-  })
+  it("reports SCHEMA_NOT_FOUND for a shelf without a schema", async () => {
+    await scaffold();
+    await write(".keyshelf/noschema/dev.yaml", "provider: local\nkeys: {}\n");
+    const { code, stdout } = await runKeyshelf(["validate", "noschema/dev", "--json"], { cwd });
+    expect(code).not.toBe(0);
+    expect(errorOf(stdout)).toMatchObject({ code: "SCHEMA_NOT_FOUND", shelf: "noschema" });
+  });
 
-  it('aggregates per-environment failures and exits non-zero', async () => {
-    await scaffold()
-    await write('.keyshelf/web/prod.yaml', 'provider: local\nkeys:\n  REGION: eu\n') // missing required
-    await write('.keyshelf/api/schema.yaml', 'keys:\n  TOKEN: !required\n')
-    await write('.keyshelf/api/dev.yaml', 'provider: ghost\nkeys:\n  TOKEN: !secret\n') // bad provider
+  it("reports ENVIRONMENT_NOT_FOUND for an unknown environment", async () => {
+    await scaffold();
+    const { code, stdout } = await runKeyshelf(["validate", "web/prod", "--json"], { cwd });
+    expect(code).not.toBe(0);
+    expect(errorOf(stdout)).toMatchObject({
+      code: "ENVIRONMENT_NOT_FOUND",
+      environment: "web/prod"
+    });
+  });
 
-    const {code, stdout} = await runKeyshelf(['validate', '--json'], {cwd})
-    expect(code).not.toBe(0)
-    const result = JSON.parse(stdout)
-    expect(result.valid).toBe(false)
+  it("reports MALFORMED_FILE with file + reason for an unparseable environment", async () => {
+    await scaffold();
+    await write(".keyshelf/web/staging.yaml", "provider: local\nkeys: {bad\n");
+    const { code, stdout } = await runKeyshelf(["validate", "web/staging", "--json"], { cwd });
+    expect(code).not.toBe(0);
+    const err = errorOf(stdout);
+    expect(err.code).toBe("MALFORMED_FILE");
+    expect(String(err.file)).toContain("staging.yaml");
+    expect(typeof err.reason).toBe("string");
+  });
 
-    const byEnv = Object.fromEntries(result.results.map((r: {environment: string}) => [r.environment, r]))
-    expect(byEnv['web/staging'].valid).toBe(true)
-    expect(byEnv['web/prod']).toMatchObject({valid: false, error: {code: 'MISSING_REQUIRED'}})
-    expect(byEnv['api/dev']).toMatchObject({valid: false, error: {code: 'PROVIDER_NOT_FOUND'}})
-  })
+  it("reports NOT_INITIALIZED when no .keyshelf is present", async () => {
+    const { code, stdout } = await runKeyshelf(["validate", "web/staging", "--json"], { cwd });
+    expect(code).not.toBe(0);
+    expect(errorOf(stdout).code).toBe("NOT_INITIALIZED");
+  });
 
-  it('marks an environment invalid when its declared secret is unresolvable', async () => {
-    await scaffold()
-    await write('.keyshelf/api/schema.yaml', 'keys:\n  TOKEN: !required\n')
-    await write('.keyshelf/api/dev.yaml', 'provider: store\nkeys:\n  TOKEN: !secret\n')
+  it("rejects a malformed argument that is not shelf/env", async () => {
+    await scaffold();
+    const { code } = await runKeyshelf(["validate", "webstaging", "--json"], { cwd });
+    expect(code).not.toBe(0);
+  });
+
+  it("reports SECRET_NOT_FOUND when a declared secret is unresolvable (valid means would run)", async () => {
+    await scaffold();
+    // Same env, but the store has no value for the declared secret.
+    await seedFakeStore({});
+    const { code, stdout } = await runKeyshelf(["validate", "web/staging", "--json"], { cwd });
+    expect(code).not.toBe(0);
+    expect(errorOf(stdout)).toMatchObject({ code: "SECRET_NOT_FOUND", key: "DATABASE_PASSWORD" });
+  });
+
+  it("validates a resolvable explicit { ref } override secret", async () => {
+    await scaffold();
+    await write(
+      ".keyshelf/web/staging.yaml",
+      "provider: store\nkeys:\n  REGION: eu\n  DATABASE_PASSWORD: !secret { ref: shared-pw }\n"
+    );
+    await seedFakeStore({ "shared-pw": "pw" });
+    const { code, stdout } = await runKeyshelf(["validate", "web/staging", "--json"], { cwd });
+    expect(code).toBe(0);
+    expect(JSON.parse(stdout)).toMatchObject({ environment: "web/staging", valid: true });
+  });
+});
+
+describe("keyshelf validate (whole project)", () => {
+  it("validates every environment and reports an all-valid aggregate", async () => {
+    await scaffold();
+    await write(".keyshelf/web/prod.yaml", GOOD_ENV);
+    await write(".keyshelf/api/schema.yaml", "keys:\n  TOKEN: !required\n");
+    await write(".keyshelf/api/dev.yaml", "provider: store\nkeys:\n  TOKEN: !secret\n");
+
+    const { code, stdout } = await runKeyshelf(["validate", "--json"], { cwd });
+    expect(code).toBe(0);
+    const result = JSON.parse(stdout);
+    expect(result.valid).toBe(true);
+    const ids = result.results.map((r: { environment: string }) => r.environment).sort();
+    expect(ids).toEqual(["api/dev", "web/prod", "web/staging"]);
+    expect(result.results.every((r: { valid: boolean }) => r.valid)).toBe(true);
+  });
+
+  it("aggregates per-environment failures and exits non-zero", async () => {
+    await scaffold();
+    await write(".keyshelf/web/prod.yaml", "provider: local\nkeys:\n  REGION: eu\n"); // missing required
+    await write(".keyshelf/api/schema.yaml", "keys:\n  TOKEN: !required\n");
+    await write(".keyshelf/api/dev.yaml", "provider: ghost\nkeys:\n  TOKEN: !secret\n"); // bad provider
+
+    const { code, stdout } = await runKeyshelf(["validate", "--json"], { cwd });
+    expect(code).not.toBe(0);
+    const result = JSON.parse(stdout);
+    expect(result.valid).toBe(false);
+
+    const byEnv = Object.fromEntries(
+      result.results.map((r: { environment: string }) => [r.environment, r])
+    );
+    expect(byEnv["web/staging"].valid).toBe(true);
+    expect(byEnv["web/prod"]).toMatchObject({ valid: false, error: { code: "MISSING_REQUIRED" } });
+    expect(byEnv["api/dev"]).toMatchObject({ valid: false, error: { code: "PROVIDER_NOT_FOUND" } });
+  });
+
+  it("marks an environment invalid when its declared secret is unresolvable", async () => {
+    await scaffold();
+    await write(".keyshelf/api/schema.yaml", "keys:\n  TOKEN: !required\n");
+    await write(".keyshelf/api/dev.yaml", "provider: store\nkeys:\n  TOKEN: !secret\n");
     // Store seeds web/staging's secret but NOT api/dev's TOKEN.
-    await seedFakeStore({'myapp-web-staging-DATABASE_PASSWORD': 'pw'})
+    await seedFakeStore({ "myapp-web-staging-DATABASE_PASSWORD": "pw" });
 
-    const {code, stdout} = await runKeyshelf(['validate', '--json'], {cwd})
-    expect(code).not.toBe(0)
-    const result = JSON.parse(stdout)
-    const byEnv = Object.fromEntries(result.results.map((r: {environment: string}) => [r.environment, r]))
-    expect(byEnv['web/staging'].valid).toBe(true)
-    expect(byEnv['api/dev']).toMatchObject({valid: false, error: {code: 'SECRET_NOT_FOUND'}})
-  })
+    const { code, stdout } = await runKeyshelf(["validate", "--json"], { cwd });
+    expect(code).not.toBe(0);
+    const result = JSON.parse(stdout);
+    const byEnv = Object.fromEntries(
+      result.results.map((r: { environment: string }) => [r.environment, r])
+    );
+    expect(byEnv["web/staging"].valid).toBe(true);
+    expect(byEnv["api/dev"]).toMatchObject({ valid: false, error: { code: "SECRET_NOT_FOUND" } });
+  });
 
-  it('reports NOT_INITIALIZED for whole-project mode without a project', async () => {
-    const {code, stdout} = await runKeyshelf(['validate', '--json'], {cwd})
-    expect(code).not.toBe(0)
-    expect(errorOf(stdout).code).toBe('NOT_INITIALIZED')
-  })
+  it("reports NOT_INITIALIZED for whole-project mode without a project", async () => {
+    const { code, stdout } = await runKeyshelf(["validate", "--json"], { cwd });
+    expect(code).not.toBe(0);
+    expect(errorOf(stdout).code).toBe("NOT_INITIALIZED");
+  });
 
-  it('exposes --help and exits zero', async () => {
-    const {code, stdout} = await runKeyshelf(['validate', '--help'], {cwd})
-    expect(code).toBe(0)
-    expect(stdout).toContain('validate')
-  })
-})
+  it("exposes --help and exits zero", async () => {
+    const { code, stdout } = await runKeyshelf(["validate", "--help"], { cwd });
+    expect(code).toBe(0);
+    expect(stdout).toContain("validate");
+  });
+});

--- a/packages/cli/test/platforms/helpers.ts
+++ b/packages/cli/test/platforms/helpers.ts
@@ -1,13 +1,18 @@
-import {execFile, execFileSync} from 'node:child_process'
-import {existsSync} from 'node:fs'
-import {mkdtemp, rm, writeFile} from 'node:fs/promises'
-import os from 'node:os'
-import path from 'node:path'
-import {promisify} from 'node:util'
-import {packageDir} from '../../scripts/lib/build.js'
-import {hostPlatformKey, platforms, type PlatformKey, repoRoot} from '../../scripts/lib/platforms.js'
+import { execFile, execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { packageDir } from "../../scripts/lib/build.js";
+import {
+  hostPlatformKey,
+  platforms,
+  type PlatformKey,
+  repoRoot
+} from "../../scripts/lib/platforms.js";
 
-const execFileAsync = promisify(execFile)
+const execFileAsync = promisify(execFile);
 
 /**
  * Shared scaffolding for the no-publish verification tiers. Both tiers need: a
@@ -20,34 +25,36 @@ const execFileAsync = promisify(execFile)
 /** Whether age-keygen is resolvable (needed to build the hermetic sops fixture). */
 export function ageAvailable(): boolean {
   try {
-    execFileSync(process.platform === 'win32' ? 'where' : 'which', ['age-keygen'], {stdio: 'ignore'})
-    return true
+    execFileSync(process.platform === "win32" ? "where" : "which", ["age-keygen"], {
+      stdio: "ignore"
+    });
+    return true;
   } catch {
-    return false
+    return false;
   }
 }
 
 /** The host's platform key, asserting it is one we support (it always is in CI/dev). */
 export function requireHostKey(): PlatformKey {
-  const key = hostPlatformKey()
-  if (key === undefined) throw new Error(`Unsupported host ${process.platform}-${process.arch}`)
-  return key
+  const key = hostPlatformKey();
+  if (key === undefined) throw new Error(`Unsupported host ${process.platform}-${process.arch}`);
+  return key;
 }
 
 /** True once `npm run platforms:build` has produced the host package directory. */
 function hostPackageBuilt(): boolean {
-  return existsSync(path.join(packageDir(requireHostKey()), 'package.json'))
+  return existsSync(path.join(packageDir(requireHostKey()), "package.json"));
 }
 
 /** Ensure the host platform package is built (downloads + verifies once, cached). */
 export async function ensureHostPackageBuilt(): Promise<void> {
-  if (hostPackageBuilt()) return
-  await execFileAsync('npx', ['tsx', 'scripts/build-platforms.ts', '--host'], {cwd: repoRoot})
+  if (hostPackageBuilt()) return;
+  await execFileAsync("npx", ["tsx", "scripts/build-platforms.ts", "--host"], { cwd: repoRoot });
 }
 
 /** True once all five platform package directories have been generated. */
 function allPackagesBuilt(): boolean {
-  return platforms.every((key) => existsSync(path.join(packageDir(key), 'package.json')))
+  return platforms.every((key) => existsSync(path.join(packageDir(key), "package.json")));
 }
 
 /**
@@ -56,16 +63,19 @@ function allPackagesBuilt(): boolean {
  * this fetches each ~30-50MB binary once and reuses it across runs.
  */
 export async function ensureAllPackagesBuilt(): Promise<void> {
-  if (allPackagesBuilt()) return
-  await execFileAsync('npx', ['tsx', 'scripts/build-platforms.ts'], {cwd: repoRoot, maxBuffer: 64 * 1024 * 1024})
+  if (allPackagesBuilt()) return;
+  await execFileAsync("npx", ["tsx", "scripts/build-platforms.ts"], {
+    cwd: repoRoot,
+    maxBuffer: 64 * 1024 * 1024
+  });
 }
 
 /** Whether the verdaccio CLI is installed (the Tier 2 local registry). */
 export function verdaccioInstalled(): boolean {
   return (
-    existsSync(path.join(repoRoot, 'node_modules', '.bin', 'verdaccio')) ||
-    existsSync(path.join(repoRoot, 'node_modules', 'verdaccio', 'bin', 'verdaccio'))
-  )
+    existsSync(path.join(repoRoot, "node_modules", ".bin", "verdaccio")) ||
+    existsSync(path.join(repoRoot, "node_modules", "verdaccio", "bin", "verdaccio"))
+  );
 }
 
 /**
@@ -74,48 +84,55 @@ export function verdaccioInstalled(): boolean {
  * on `--json`; instead we read the single `.tgz` filename npm emits on stdout.
  */
 export async function npmPack(srcDir: string, destDir: string): Promise<string> {
-  const {stdout} = await execFileAsync('npm', ['pack', '--pack-destination', destDir, '--silent', srcDir], {
-    cwd: repoRoot,
-    maxBuffer: 64 * 1024 * 1024,
-    // keyshelf's `prepack` runs `oclif manifest`, which records *source*
-    // (`src/**.ts`) command paths under a non-production NODE_ENV (vitest sets
-    // NODE_ENV=test in this worker). The published tarball ships only `dist`, so
-    // a src-referencing manifest makes the installed CLI fail to load commands.
-    // Pin production so the manifest references the compiled `dist/**.js` — the
-    // shape a real publish produces.
-    env: productionEnv(),
-  })
+  const { stdout } = await execFileAsync(
+    "npm",
+    ["pack", "--pack-destination", destDir, "--silent", srcDir],
+    {
+      cwd: repoRoot,
+      maxBuffer: 64 * 1024 * 1024,
+      // keyshelf's `prepack` runs `oclif manifest`, which records *source*
+      // (`src/**.ts`) command paths under a non-production NODE_ENV (vitest sets
+      // NODE_ENV=test in this worker). The published tarball ships only `dist`, so
+      // a src-referencing manifest makes the installed CLI fail to load commands.
+      // Pin production so the manifest references the compiled `dist/**.js` — the
+      // shape a real publish produces.
+      env: productionEnv()
+    }
+  );
   const file = stdout
-    .split('\n')
+    .split("\n")
     .map((l) => l.trim())
     .reverse()
-    .find((l) => l.endsWith('.tgz'))
-  if (file === undefined) throw new Error(`npm pack of ${srcDir} produced no .tgz line:\n${stdout}`)
-  return path.join(destDir, file)
+    .find((l) => l.endsWith(".tgz"));
+  if (file === undefined)
+    throw new Error(`npm pack of ${srcDir} produced no .tgz line:\n${stdout}`);
+  return path.join(destDir, file);
 }
 
 /** List a tarball's file paths (relative to its `package/` root). */
 export function tarballEntries(tarball: string): string[] {
-  const out = execFileSync('tar', ['-tzf', tarball], {encoding: 'utf8'})
+  const out = execFileSync("tar", ["-tzf", tarball], { encoding: "utf8" });
   return out
-    .split('\n')
+    .split("\n")
     .map((l) => l.trim())
     .filter(Boolean)
-    .map((l) => l.replace(/^package\//, ''))
+    .map((l) => l.replace(/^package\//, ""));
 }
 
 /** Read a JSON file inside a tarball without extracting to disk. */
 export function tarballPackageJson(tarball: string): Record<string, unknown> {
-  const out = execFileSync('tar', ['-xzO', '-f', tarball, 'package/package.json'], {encoding: 'utf8'})
-  return JSON.parse(out) as Record<string, unknown>
+  const out = execFileSync("tar", ["-xzO", "-f", tarball, "package/package.json"], {
+    encoding: "utf8"
+  });
+  return JSON.parse(out) as Record<string, unknown>;
 }
 
-export async function makeTmpDir(prefix = 'keyshelf-platforms-'): Promise<string> {
-  return mkdtemp(path.join(os.tmpdir(), prefix))
+export async function makeTmpDir(prefix = "keyshelf-platforms-"): Promise<string> {
+  return mkdtemp(path.join(os.tmpdir(), prefix));
 }
 
 export async function removeDir(dir: string): Promise<void> {
-  await rm(dir, {recursive: true, force: true})
+  await rm(dir, { recursive: true, force: true });
 }
 
 /**
@@ -124,20 +141,20 @@ export async function removeDir(dir: string): Promise<void> {
  * environment). Returns the age key file path. The same scaffold both tiers use
  * to run a real `keyshelf run` that decrypts through the bundled binary.
  */
-export async function scaffoldSopsProject(dir: string): Promise<{ageKeyFile: string}> {
-  const ageKeyFile = path.join(dir, 'age-key.txt')
-  const {stderr} = await execFileAsync('age-keygen', ['-o', ageKeyFile])
-  const match = /public key:\s*(age1[0-9a-z]+)/i.exec(stderr)
-  if (match === null) throw new Error(`could not parse age public key: ${stderr}`)
-  const recipient = match[1]
+export async function scaffoldSopsProject(dir: string): Promise<{ ageKeyFile: string }> {
+  const ageKeyFile = path.join(dir, "age-key.txt");
+  const { stderr } = await execFileAsync("age-keygen", ["-o", ageKeyFile]);
+  const match = /public key:\s*(age1[0-9a-z]+)/i.exec(stderr);
+  if (match === null) throw new Error(`could not parse age public key: ${stderr}`);
+  const recipient = match[1];
 
   await writeFile(
-    path.join(dir, '.sops.yaml'),
+    path.join(dir, ".sops.yaml"),
     `creation_rules:\n  - path_regex: .*\\.secrets\\.yaml$\n    age: ${recipient}\n`,
-    'utf8',
-  )
+    "utf8"
+  );
 
-  return {ageKeyFile}
+  return { ageKeyFile };
 }
 
 /**
@@ -149,7 +166,7 @@ export async function scaffoldSopsProject(dir: string): Promise<{ageKeyFile: str
  * `npm i -g keyshelf` install, which is exactly what these tiers verify.
  */
 export function productionEnv(overrides: Record<string, string> = {}): NodeJS.ProcessEnv {
-  const env: NodeJS.ProcessEnv = {...process.env}
+  const env: NodeJS.ProcessEnv = { ...process.env };
   for (const k of Object.keys(env)) {
     // Vitest's `DEV`/`VITEST*` flip oclif into dev mode. The `npm_*` lifecycle
     // vars (leaked because the suite is launched via npm/npx from the keyshelf
@@ -157,9 +174,8 @@ export function productionEnv(overrides: Record<string, string> = {}): NodeJS.Pr
     // repo — which has a tsconfig.json + src/ — so the installed keyshelf
     // transpiles from `src` instead of `dist`. A genuine `npm i -g keyshelf`
     // user has none of these; strip them so the child behaves like one.
-    if (k === 'DEV' || k.startsWith('VITEST') || k.startsWith('npm_')) delete env[k]
+    if (k === "DEV" || k.startsWith("VITEST") || k.startsWith("npm_")) delete env[k];
   }
-  env.NODE_ENV = 'production'
-  return {...env, ...overrides}
+  env.NODE_ENV = "production";
+  return { ...env, ...overrides };
 }
-

--- a/packages/cli/test/platforms/tier1-no-registry.test.ts
+++ b/packages/cli/test/platforms/tier1-no-registry.test.ts
@@ -1,10 +1,11 @@
-import {execFile} from 'node:child_process'
-import {mkdir, writeFile} from 'node:fs/promises'
-import path from 'node:path'
-import {promisify} from 'node:util'
-import {afterAll, beforeAll, describe, expect, it} from 'vitest'
-import {packageDir} from '../../scripts/lib/build.js'
-import {osCpu, repoRoot} from '../../scripts/lib/platforms.js'
+import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { packageDir } from "../../scripts/lib/build.js";
+import { osCpu, repoRoot } from "../../scripts/lib/platforms.js";
 import {
   ageAvailable,
   ensureHostPackageBuilt,
@@ -15,10 +16,10 @@ import {
   requireHostKey,
   scaffoldSopsProject,
   tarballEntries,
-  tarballPackageJson,
-} from './helpers.js'
+  tarballPackageJson
+} from "./helpers.js";
 
-const execFileAsync = promisify(execFile)
+const execFileAsync = promisify(execFile);
 
 /**
  * Tier 1 — no registry at all. Build the host platform package, `npm pack` it,
@@ -32,187 +33,217 @@ const execFileAsync = promisify(execFile)
  * The resolver contract is unchanged. Zero publishing.
  */
 
-const hostKey = requireHostKey()
-const binFile = hostKey.startsWith('win32-') ? 'sops.exe' : 'sops'
+const hostKey = requireHostKey();
+const binFile = hostKey.startsWith("win32-") ? "sops.exe" : "sops";
 
-describe('Tier 1: npm pack tarball metadata', () => {
-  let tarball: string
-  let workDir: string
+describe("Tier 1: npm pack tarball metadata", () => {
+  let tarball: string;
+  let workDir: string;
 
   beforeAll(async () => {
-    await ensureHostPackageBuilt()
-    workDir = await makeTmpDir('keyshelf-tier1-pack-')
-    tarball = await npmPack(packageDir(hostKey), workDir)
-  }, 300_000)
+    await ensureHostPackageBuilt();
+    workDir = await makeTmpDir("keyshelf-tier1-pack-");
+    tarball = await npmPack(packageDir(hostKey), workDir);
+  }, 300_000);
 
   afterAll(async () => {
-    if (workDir) await removeDir(workDir)
-  })
+    if (workDir) await removeDir(workDir);
+  });
 
-  it('includes the platform binary at bin/sops[.exe]', () => {
-    expect(tarballEntries(tarball)).toContain(`bin/${binFile}`)
-  })
+  it("includes the platform binary at bin/sops[.exe]", () => {
+    expect(tarballEntries(tarball)).toContain(`bin/${binFile}`);
+  });
 
-  it('carries os/cpu matching the package name and the MPL-2.0 license', () => {
-    const pkg = tarballPackageJson(tarball)
-    const {os, cpu} = osCpu(hostKey)
-    expect(pkg.name).toBe(`@keyshelf/sops-${hostKey}`)
-    expect(pkg.os).toEqual([os])
-    expect(pkg.cpu).toEqual([cpu])
-    expect(pkg.license).toBe('MPL-2.0')
-  })
-})
+  it("carries os/cpu matching the package name and the MPL-2.0 license", () => {
+    const pkg = tarballPackageJson(tarball);
+    const { os, cpu } = osCpu(hostKey);
+    expect(pkg.name).toBe(`@keyshelf/sops-${hostKey}`);
+    expect(pkg.os).toEqual([os]);
+    expect(pkg.cpu).toEqual([cpu]);
+    expect(pkg.license).toBe("MPL-2.0");
+  });
+});
 
 // The end-to-end install+run leg needs age to build the hermetic .sops.yaml.
-const e2e = ageAvailable() ? describe : describe.skip
+const e2e = ageAvailable() ? describe : describe.skip;
 
-e2e('Tier 1: file:-installed bundled binary drives a real keyshelf run', () => {
-  let proj: string
-  let keyshelfTarball: string
-  let platformTarball: string
-  let packDir: string
+e2e("Tier 1: file:-installed bundled binary drives a real keyshelf run", () => {
+  let proj: string;
+  let keyshelfTarball: string;
+  let platformTarball: string;
+  let packDir: string;
 
   beforeAll(async () => {
-    await ensureHostPackageBuilt()
-    packDir = await makeTmpDir('keyshelf-tier1-tgz-')
+    await ensureHostPackageBuilt();
+    packDir = await makeTmpDir("keyshelf-tier1-tgz-");
     // Pack keyshelf (build runs via its prepack) and the host platform package.
-    keyshelfTarball = await npmPack(repoRoot, packDir)
-    platformTarball = await npmPack(packageDir(hostKey), packDir)
-  }, 300_000)
+    keyshelfTarball = await npmPack(repoRoot, packDir);
+    platformTarball = await npmPack(packageDir(hostKey), packDir);
+  }, 300_000);
 
   afterAll(async () => {
-    if (proj) await removeDir(proj)
-    if (packDir) await removeDir(packDir)
-  })
+    if (proj) await removeDir(proj);
+    if (packDir) await removeDir(packDir);
+  });
 
   async function installProject(deps: Record<string, string>): Promise<string> {
-    const dir = await makeTmpDir('keyshelf-tier1-proj-')
+    const dir = await makeTmpDir("keyshelf-tier1-proj-");
     await writeFile(
-      path.join(dir, 'package.json'),
-      JSON.stringify({name: 'tier1-fixture', version: '1.0.0', private: true, dependencies: deps}, null, 2),
-      'utf8',
-    )
+      path.join(dir, "package.json"),
+      JSON.stringify(
+        { name: "tier1-fixture", version: "1.0.0", private: true, dependencies: deps },
+        null,
+        2
+      ),
+      "utf8"
+    );
     // Install only the file: tarballs; never reach the public registry for these.
-    await execFileAsync('npm', ['install', '--no-audit', '--no-fund'], {cwd: dir, maxBuffer: 64 * 1024 * 1024})
-    return dir
+    await execFileAsync("npm", ["install", "--no-audit", "--no-fund"], {
+      cwd: dir,
+      maxBuffer: 64 * 1024 * 1024
+    });
+    return dir;
   }
 
   /** A keyshelf project with a !secret, runnable end to end. */
-  async function scaffoldKeyshelf(dir: string): Promise<{ageKeyFile: string}> {
-    const out = await scaffoldSopsProject(dir)
-    const root = path.join(dir, '.keyshelf')
-    await mkdir(path.join(root, 'app'), {recursive: true})
-    await writeFile(path.join(root, 'config.yaml'), 'project: tier1\nproviders:\n  local:\n    adapter: sops\n', 'utf8')
-    await writeFile(path.join(root, 'app', 'schema.yaml'), 'keys:\n  TOKEN: !required\n', 'utf8')
-    await writeFile(path.join(root, 'app', 'staging.yaml'), 'provider: local\nkeys:\n  TOKEN: !required\n', 'utf8')
-    return out
+  async function scaffoldKeyshelf(dir: string): Promise<{ ageKeyFile: string }> {
+    const out = await scaffoldSopsProject(dir);
+    const root = path.join(dir, ".keyshelf");
+    await mkdir(path.join(root, "app"), { recursive: true });
+    await writeFile(
+      path.join(root, "config.yaml"),
+      "project: tier1\nproviders:\n  local:\n    adapter: sops\n",
+      "utf8"
+    );
+    await writeFile(path.join(root, "app", "schema.yaml"), "keys:\n  TOKEN: !required\n", "utf8");
+    await writeFile(
+      path.join(root, "app", "staging.yaml"),
+      "provider: local\nkeys:\n  TOKEN: !required\n",
+      "utf8"
+    );
+    return out;
   }
 
   /** PATH with every dir containing a `sops` removed, so only the bundled binary can satisfy the resolver. */
   function pathWithoutSops(): string {
-    const sep = path.delimiter
-    return (process.env.PATH ?? '')
+    const sep = path.delimiter;
+    return (process.env.PATH ?? "")
       .split(sep)
       .filter((d) => {
         try {
-          return !require('node:fs').existsSync(path.join(d, 'sops'))
+          return !existsSync(path.join(d, "sops"));
         } catch {
-          return true
+          return true;
         }
       })
-      .join(sep)
+      .join(sep);
   }
 
   /** Run the installed keyshelf binary; never throws on non-zero exit. */
   async function runKeyshelf(
     bin: string,
     args: string[],
-    opts: {cwd: string; env: NodeJS.ProcessEnv; input?: string},
-  ): Promise<{code: number; stdout: string; stderr: string}> {
+    opts: { cwd: string; env: NodeJS.ProcessEnv; input?: string }
+  ): Promise<{ code: number; stdout: string; stderr: string }> {
     try {
-      const child = execFileAsync(bin, args, {cwd: opts.cwd, env: opts.env, maxBuffer: 64 * 1024 * 1024})
-      if (opts.input !== undefined) child.child.stdin?.end(opts.input)
-      const {stdout, stderr} = await child
-      return {code: 0, stdout, stderr}
+      const child = execFileAsync(bin, args, {
+        cwd: opts.cwd,
+        env: opts.env,
+        maxBuffer: 64 * 1024 * 1024
+      });
+      if (opts.input !== undefined) child.child.stdin?.end(opts.input);
+      const { stdout, stderr } = await child;
+      return { code: 0, stdout, stderr };
     } catch (error) {
-      const e = error as {code?: number; stdout?: string; stderr?: string}
-      return {code: e.code ?? 1, stdout: e.stdout ?? '', stderr: e.stderr ?? ''}
+      const e = error as { code?: number; stdout?: string; stderr?: string };
+      return { code: e.code ?? 1, stdout: e.stdout ?? "", stderr: e.stderr ?? "" };
     }
   }
 
-  it('resolves the bundled binary from the file: install and decrypts a secret (PATH sops scrubbed)', async () => {
+  it("resolves the bundled binary from the file: install and decrypts a secret (PATH sops scrubbed)", async () => {
     proj = await installProject({
       keyshelf: `file:${keyshelfTarball}`,
-      [`@keyshelf/sops-${hostKey}`]: `file:${platformTarball}`,
-    })
-    const {ageKeyFile} = await scaffoldKeyshelf(proj)
+      [`@keyshelf/sops-${hostKey}`]: `file:${platformTarball}`
+    });
+    const { ageKeyFile } = await scaffoldKeyshelf(proj);
 
-    const keyshelfBin = path.join(proj, 'node_modules', '.bin', 'keyshelf')
+    const keyshelfBin = path.join(proj, "node_modules", ".bin", "keyshelf");
     const env = productionEnv({
       SOPS_AGE_KEY_FILE: ageKeyFile,
       PATH: pathWithoutSops(),
       // Belt-and-braces: ensure no override short-circuits the bundled lookup.
-      KEYSHELF_SOPS_BIN: '',
-    })
+      KEYSHELF_SOPS_BIN: ""
+    });
 
     // The bundled binary must be the only resolvable sops (PATH scrubbed).
-    const bundled = path.join(proj, 'node_modules', '@keyshelf', `sops-${hostKey}`, 'bin', binFile)
-    expect(require('node:fs').existsSync(bundled)).toBe(true)
+    const bundled = path.join(proj, "node_modules", "@keyshelf", `sops-${hostKey}`, "bin", binFile);
+    expect(existsSync(bundled)).toBe(true);
 
     // Store a secret (write goes through the bundled sops; value via stdin), then
     // a real `keyshelf run` decrypts and exports it.
-    const set = await runKeyshelf(keyshelfBin, ['set', 'TOKEN', 'app/staging', '--secret'], {
+    const set = await runKeyshelf(keyshelfBin, ["set", "TOKEN", "app/staging", "--secret"], {
       cwd: proj,
       env,
-      input: 's3cr3t',
-    })
-    expect(set.code, set.stderr).toBe(0)
+      input: "s3cr3t"
+    });
+    expect(set.code, set.stderr).toBe(0);
 
-    const run = await runKeyshelf(keyshelfBin, ['run', 'app/staging', '--', 'printenv', 'TOKEN'], {cwd: proj, env})
-    expect(run.code, run.stderr).toBe(0)
-    expect(run.stdout.trim()).toBe('s3cr3t')
-  }, 300_000)
+    const run = await runKeyshelf(keyshelfBin, ["run", "app/staging", "--", "printenv", "TOKEN"], {
+      cwd: proj,
+      env
+    });
+    expect(run.code, run.stderr).toBe(0);
+    expect(run.stdout.trim()).toBe("s3cr3t");
+  }, 300_000);
 
-  it('falls back to a PATH sops when the platform package is not installed', async () => {
+  it("falls back to a PATH sops when the platform package is not installed", async () => {
     // No platform package; a real sops IS on PATH. The resolver must use it and
     // decrypt — proving the PATH fallback leg of the resolver contract.
-    const bare = await installProject({keyshelf: `file:${keyshelfTarball}`})
+    const bare = await installProject({ keyshelf: `file:${keyshelfTarball}` });
     try {
-      const {ageKeyFile} = await scaffoldKeyshelf(bare)
-      const keyshelfBin = path.join(bare, 'node_modules', '.bin', 'keyshelf')
+      const { ageKeyFile } = await scaffoldKeyshelf(bare);
+      const keyshelfBin = path.join(bare, "node_modules", ".bin", "keyshelf");
       // PATH retains sops; no bundled package present.
-      const env = productionEnv({SOPS_AGE_KEY_FILE: ageKeyFile, KEYSHELF_SOPS_BIN: ''})
-      const set = await runKeyshelf(keyshelfBin, ['set', 'TOKEN', 'app/staging', '--secret'], {
+      const env = productionEnv({ SOPS_AGE_KEY_FILE: ageKeyFile, KEYSHELF_SOPS_BIN: "" });
+      const set = await runKeyshelf(keyshelfBin, ["set", "TOKEN", "app/staging", "--secret"], {
         cwd: bare,
         env,
-        input: 'p4thfallback',
-      })
-      expect(set.code, set.stderr).toBe(0)
-      const run = await runKeyshelf(keyshelfBin, ['run', 'app/staging', '--', 'printenv', 'TOKEN'], {cwd: bare, env})
-      expect(run.code, run.stderr).toBe(0)
-      expect(run.stdout.trim()).toBe('p4thfallback')
+        input: "p4thfallback"
+      });
+      expect(set.code, set.stderr).toBe(0);
+      const run = await runKeyshelf(
+        keyshelfBin,
+        ["run", "app/staging", "--", "printenv", "TOKEN"],
+        { cwd: bare, env }
+      );
+      expect(run.code, run.stderr).toBe(0);
+      expect(run.stdout.trim()).toBe("p4thfallback");
     } finally {
-      await removeDir(bare)
+      await removeDir(bare);
     }
-  }, 300_000)
+  }, 300_000);
 
-  it('surfaces ADAPTER_UNAVAILABLE when neither bundled package nor PATH sops resolves', async () => {
+  it("surfaces ADAPTER_UNAVAILABLE when neither bundled package nor PATH sops resolves", async () => {
     // Install keyshelf WITHOUT the platform package, and scrub sops from PATH:
     // nothing is resolvable, so the structured error (never a raw spawn) fires.
-    const bare = await installProject({keyshelf: `file:${keyshelfTarball}`})
+    const bare = await installProject({ keyshelf: `file:${keyshelfTarball}` });
     try {
-      const {ageKeyFile} = await scaffoldKeyshelf(bare)
-      const keyshelfBin = path.join(bare, 'node_modules', '.bin', 'keyshelf')
-      const env = productionEnv({SOPS_AGE_KEY_FILE: ageKeyFile, PATH: pathWithoutSops(), KEYSHELF_SOPS_BIN: ''})
-      const set = await runKeyshelf(keyshelfBin, ['set', 'TOKEN', 'app/staging', '--secret'], {
+      const { ageKeyFile } = await scaffoldKeyshelf(bare);
+      const keyshelfBin = path.join(bare, "node_modules", ".bin", "keyshelf");
+      const env = productionEnv({
+        SOPS_AGE_KEY_FILE: ageKeyFile,
+        PATH: pathWithoutSops(),
+        KEYSHELF_SOPS_BIN: ""
+      });
+      const set = await runKeyshelf(keyshelfBin, ["set", "TOKEN", "app/staging", "--secret"], {
         cwd: bare,
         env,
-        input: 's3cr3t',
-      })
-      expect(set.code).not.toBe(0)
-      expect(set.stderr).toMatch(/ADAPTER_UNAVAILABLE|No usable 'sops' binary/)
+        input: "s3cr3t"
+      });
+      expect(set.code).not.toBe(0);
+      expect(set.stderr).toMatch(/ADAPTER_UNAVAILABLE|No usable 'sops' binary/);
     } finally {
-      await removeDir(bare)
+      await removeDir(bare);
     }
-  }, 300_000)
-})
+  }, 300_000);
+});

--- a/packages/cli/test/platforms/tier2-verdaccio.test.ts
+++ b/packages/cli/test/platforms/tier2-verdaccio.test.ts
@@ -1,21 +1,25 @@
-import {execFile} from 'node:child_process'
-import {existsSync} from 'node:fs'
-import {readdir, writeFile} from 'node:fs/promises'
-import path from 'node:path'
-import {promisify} from 'node:util'
-import {afterAll, beforeAll, describe, expect, it} from 'vitest'
-import {packageDir} from '../../scripts/lib/build.js'
-import {osCpu, platforms, repoRoot} from '../../scripts/lib/platforms.js'
-import {publishToRegistry, startVerdaccio, type VerdaccioRegistry} from '../../scripts/lib/verdaccio.js'
+import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import { readdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { packageDir } from "../../scripts/lib/build.js";
+import { osCpu, platforms, repoRoot } from "../../scripts/lib/platforms.js";
+import {
+  publishToRegistry,
+  startVerdaccio,
+  type VerdaccioRegistry
+} from "../../scripts/lib/verdaccio.js";
 import {
   ensureAllPackagesBuilt,
   makeTmpDir,
   removeDir,
   requireHostKey,
-  verdaccioInstalled,
-} from './helpers.js'
+  verdaccioInstalled
+} from "./helpers.js";
 
-const execFileAsync = promisify(execFile)
+const execFileAsync = promisify(execFile);
 
 /**
  * Tier 2 — a *local* Verdaccio registry (still nothing public). Publish all five
@@ -29,74 +33,85 @@ const execFileAsync = promisify(execFile)
  * CI installs it and runs this for real.
  */
 
-const hostKey = requireHostKey()
-const run = verdaccioInstalled() ? describe : describe.skip
+const hostKey = requireHostKey();
+const run = verdaccioInstalled() ? describe : describe.skip;
 
-run('Tier 2: local Verdaccio os/cpu selection', () => {
-  let registry: VerdaccioRegistry
+run("Tier 2: local Verdaccio os/cpu selection", () => {
+  let registry: VerdaccioRegistry;
 
   beforeAll(async () => {
-    await ensureAllPackagesBuilt()
-    registry = await startVerdaccio()
+    await ensureAllPackagesBuilt();
+    registry = await startVerdaccio();
     // Publish all five platform packages, then keyshelf itself.
     for (const key of platforms) {
-      await publishToRegistry(packageDir(key), registry)
+      await publishToRegistry(packageDir(key), registry);
     }
 
-    await publishToRegistry(repoRoot, registry)
-  }, 900_000)
+    await publishToRegistry(repoRoot, registry);
+  }, 900_000);
 
   afterAll(async () => {
-    if (registry) await registry.teardown()
-  })
+    if (registry) await registry.teardown();
+  });
 
-  it('publishes only to the local registry (never npmjs.com)', () => {
-    expect(registry.url).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/)
-  })
+  it("publishes only to the local registry (never npmjs.com)", () => {
+    expect(registry.url).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+  });
 
-  it('installs keyshelf and lands ONLY the host platform package (others skipped via os/cpu)', async () => {
-    const proj = await makeTmpDir('keyshelf-tier2-proj-')
+  it("installs keyshelf and lands ONLY the host platform package (others skipped via os/cpu)", async () => {
+    const proj = await makeTmpDir("keyshelf-tier2-proj-");
     try {
       await writeFile(
-        path.join(proj, 'package.json'),
-        JSON.stringify({name: 'tier2-fixture', version: '1.0.0', private: true}, null, 2),
-        'utf8',
-      )
+        path.join(proj, "package.json"),
+        JSON.stringify({ name: "tier2-fixture", version: "1.0.0", private: true }, null, 2),
+        "utf8"
+      );
       // Explicit local registry on the command line AND via the pinned userconfig.
       await execFileAsync(
-        'npm',
-        ['install', 'keyshelf', '--registry', `${registry.url}/`, '--userconfig', registry.userconfig, '--no-audit', '--no-fund'],
-        {cwd: proj, env: registry.npmEnv(), maxBuffer: 64 * 1024 * 1024},
-      )
+        "npm",
+        [
+          "install",
+          "keyshelf",
+          "--registry",
+          `${registry.url}/`,
+          "--userconfig",
+          registry.userconfig,
+          "--no-audit",
+          "--no-fund"
+        ],
+        { cwd: proj, env: registry.npmEnv(), maxBuffer: 64 * 1024 * 1024 }
+      );
 
       // keyshelf itself is present and resolvable.
-      expect(existsSync(path.join(proj, 'node_modules', 'keyshelf', 'package.json'))).toBe(true)
+      expect(existsSync(path.join(proj, "node_modules", "keyshelf", "package.json"))).toBe(true);
 
       // Exactly the host's @keyshelf/sops-* package is installed; the other four
       // were skipped by npm because their os/cpu do not match this host.
-      const scopeDir = path.join(proj, 'node_modules', '@keyshelf')
-      const present = existsSync(scopeDir) ? (await readdir(scopeDir)).filter((d) => d.startsWith('sops-')) : []
-      expect(present).toEqual([`sops-${hostKey}`])
+      const scopeDir = path.join(proj, "node_modules", "@keyshelf");
+      const present = existsSync(scopeDir)
+        ? (await readdir(scopeDir)).filter((d) => d.startsWith("sops-"))
+        : [];
+      expect(present).toEqual([`sops-${hostKey}`]);
 
       // The other four platform names are genuinely absent.
       for (const key of platforms) {
-        const installed = existsSync(path.join(scopeDir, `sops-${key}`))
-        expect(installed, key).toBe(key === hostKey)
+        const installed = existsSync(path.join(scopeDir, `sops-${key}`));
+        expect(installed, key).toBe(key === hostKey);
       }
 
       // The one that landed carries the host's os/cpu and its bundled binary.
       const hostPkg = JSON.parse(
-        await import('node:fs/promises').then((m) =>
-          m.readFile(path.join(scopeDir, `sops-${hostKey}`, 'package.json'), 'utf8'),
-        ),
-      )
-      const {os, cpu} = osCpu(hostKey)
-      expect(hostPkg.os).toEqual([os])
-      expect(hostPkg.cpu).toEqual([cpu])
-      const binFile = hostKey.startsWith('win32-') ? 'sops.exe' : 'sops'
-      expect(existsSync(path.join(scopeDir, `sops-${hostKey}`, 'bin', binFile))).toBe(true)
+        await import("node:fs/promises").then((m) =>
+          m.readFile(path.join(scopeDir, `sops-${hostKey}`, "package.json"), "utf8")
+        )
+      );
+      const { os, cpu } = osCpu(hostKey);
+      expect(hostPkg.os).toEqual([os]);
+      expect(hostPkg.cpu).toEqual([cpu]);
+      const binFile = hostKey.startsWith("win32-") ? "sops.exe" : "sops";
+      expect(existsSync(path.join(scopeDir, `sops-${hostKey}`, "bin", binFile))).toBe(true);
     } finally {
-      await removeDir(proj)
+      await removeDir(proj);
     }
-  }, 300_000)
-})
+  }, 300_000);
+});

--- a/packages/cli/test/support/capture-error.ts
+++ b/packages/cli/test/support/capture-error.ts
@@ -1,0 +1,18 @@
+import { KeyshelfError } from "../../src/errors.js";
+
+/**
+ * Run `fn` expecting it to reject with a {@link KeyshelfError}, and return that
+ * error for assertions on its `code`/`fields`. Anything else — a non-Keyshelf
+ * rejection, or no rejection at all — fails the test loudly. Shared by the
+ * adapter conformance suite and the per-adapter unit tests.
+ */
+export async function captureError(fn: () => Promise<unknown>): Promise<KeyshelfError> {
+  try {
+    await fn();
+  } catch (error) {
+    if (error instanceof KeyshelfError) return error;
+    throw new Error(`expected a KeyshelfError, got: ${String(error)}`, { cause: error });
+  }
+
+  throw new Error("expected a KeyshelfError, but nothing was thrown");
+}

--- a/packages/cli/test/unit/build.test.ts
+++ b/packages/cli/test/unit/build.test.ts
@@ -1,90 +1,98 @@
-import {mkdtemp, readFile, rm, stat, writeFile} from 'node:fs/promises'
-import os from 'node:os'
-import path from 'node:path'
-import {afterEach, beforeEach, describe, expect, it} from 'vitest'
-import {assemblePackage, sha256, smokeTest, verifySha256} from '../../scripts/lib/build.js'
-import {loadSopsManifest, platformPackageJson, repoRoot} from '../../scripts/lib/platforms.js'
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { assemblePackage, sha256, smokeTest, verifySha256 } from "../../scripts/lib/build.js";
+import { loadSopsManifest, platformPackageJson, repoRoot } from "../../scripts/lib/platforms.js";
 
-describe('sha256 integrity', () => {
-  it('hashes bytes to the expected lowercase hex digest', () => {
+describe("sha256 integrity", () => {
+  it("hashes bytes to the expected lowercase hex digest", () => {
     // echo -n hello | sha256sum
-    expect(sha256(Buffer.from('hello'))).toBe(
-      '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824',
-    )
-  })
+    expect(sha256(Buffer.from("hello"))).toBe(
+      "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+    );
+  });
 
-  it('passes when the digest matches', () => {
-    expect(() => verifySha256(Buffer.from('hello'), sha256(Buffer.from('hello')), 'x')).not.toThrow()
-  })
+  it("passes when the digest matches", () => {
+    expect(() =>
+      verifySha256(Buffer.from("hello"), sha256(Buffer.from("hello")), "x")
+    ).not.toThrow();
+  });
 
-  it('throws a build-failing error when a byte is tampered', () => {
-    const good = sha256(Buffer.from('hello'))
-    expect(() => verifySha256(Buffer.from('hell0'), good, 'sops-linux-x64')).toThrow(/checksum mismatch/i)
-  })
-})
+  it("throws a build-failing error when a byte is tampered", () => {
+    const good = sha256(Buffer.from("hello"));
+    expect(() => verifySha256(Buffer.from("hell0"), good, "sops-linux-x64")).toThrow(
+      /checksum mismatch/i
+    );
+  });
+});
 
-describe('assemblePackage', () => {
-  let tmp: string
-  const manifest = loadSopsManifest()
+describe("assemblePackage", () => {
+  let tmp: string;
+  const manifest = loadSopsManifest();
 
   beforeEach(async () => {
-    tmp = await mkdtemp(path.join(os.tmpdir(), 'keyshelf-build-'))
-  })
+    tmp = await mkdtemp(path.join(os.tmpdir(), "keyshelf-build-"));
+  });
   afterEach(async () => {
-    await rm(tmp, {recursive: true, force: true})
-  })
+    await rm(tmp, { recursive: true, force: true });
+  });
 
-  it('writes bin/sops (mode 0755) and the derived package.json for a unix target', async () => {
-    const binary = Buffer.from('#!/bin/sh\necho fake sops\n')
-    const outDir = path.join(tmp, 'linux-x64')
-    await assemblePackage('linux-x64', manifest, binary, outDir)
+  it("writes bin/sops (mode 0755) and the derived package.json for a unix target", async () => {
+    const binary = Buffer.from("#!/bin/sh\necho fake sops\n");
+    const outDir = path.join(tmp, "linux-x64");
+    await assemblePackage("linux-x64", manifest, binary, outDir);
 
-    const binPath = path.join(outDir, 'bin', 'sops')
-    expect(await readFile(binPath)).toEqual(binary)
-    const mode = (await stat(binPath)).mode & 0o777
-    expect(mode & 0o111).not.toBe(0) // executable bit set
+    const binPath = path.join(outDir, "bin", "sops");
+    expect(await readFile(binPath)).toEqual(binary);
+    const mode = (await stat(binPath)).mode & 0o777;
+    expect(mode & 0o111).not.toBe(0); // executable bit set
 
-    const pkg = JSON.parse(await readFile(path.join(outDir, 'package.json'), 'utf8'))
-    expect(pkg).toMatchObject(platformPackageJson('linux-x64', manifest))
-  })
+    const pkg = JSON.parse(await readFile(path.join(outDir, "package.json"), "utf8"));
+    expect(pkg).toMatchObject(platformPackageJson("linux-x64", manifest));
+  });
 
-  it('names the binary sops.exe for win32', async () => {
-    const outDir = path.join(tmp, 'win32-x64')
-    await assemblePackage('win32-x64', manifest, Buffer.from('MZ'), outDir)
-    expect(await readFile(path.join(outDir, 'bin', 'sops.exe'), 'utf8')).toBe('MZ')
-  })
+  it("names the binary sops.exe for win32", async () => {
+    const outDir = path.join(tmp, "win32-x64");
+    await assemblePackage("win32-x64", manifest, Buffer.from("MZ"), outDir);
+    expect(await readFile(path.join(outDir, "bin", "sops.exe"), "utf8")).toBe("MZ");
+  });
 
-  it('copies the sops LICENSE/notice so the redistribution carries MPL-2.0', async () => {
-    const outDir = path.join(tmp, 'linux-x64')
-    await assemblePackage('linux-x64', manifest, Buffer.from('x'), outDir)
-    const license = await readFile(path.join(outDir, 'LICENSE'), 'utf8')
-    expect(license).toMatch(/Mozilla Public License/i)
-  })
-})
+  it("copies the sops LICENSE/notice so the redistribution carries MPL-2.0", async () => {
+    const outDir = path.join(tmp, "linux-x64");
+    await assemblePackage("linux-x64", manifest, Buffer.from("x"), outDir);
+    const license = await readFile(path.join(outDir, "LICENSE"), "utf8");
+    expect(license).toMatch(/Mozilla Public License/i);
+  });
+});
 
-describe('host smoke-test against the real bundled binary', () => {
-  it('runs sops --version on the assembled host binary when present', async () => {
+describe("host smoke-test against the real bundled binary", () => {
+  it("runs sops --version on the assembled host binary when present", async () => {
     // Only meaningful once the host package has been generated; otherwise skip.
     const hostPkgJson = path.join(
       repoRoot,
-      'platforms',
+      "platforms",
       `sops-${process.platform}-${process.arch}`,
-      'package.json',
-    )
-    let exists = true
+      "package.json"
+    );
+    let exists = true;
     try {
-      await stat(hostPkgJson)
+      await stat(hostPkgJson);
     } catch {
-      exists = false
+      exists = false;
     }
 
     if (!exists) {
-      expect(true).toBe(true)
-      return
+      expect(true).toBe(true);
+      return;
     }
 
-    const bin = path.join(path.dirname(hostPkgJson), 'bin', process.platform === 'win32' ? 'sops.exe' : 'sops')
-    const version = smokeTest(bin)
-    expect(version).toContain(loadSopsManifest().sopsVersion)
-  })
-})
+    const bin = path.join(
+      path.dirname(hostPkgJson),
+      "bin",
+      process.platform === "win32" ? "sops.exe" : "sops"
+    );
+    const version = smokeTest(bin);
+    expect(version).toContain(loadSopsManifest().sopsVersion);
+  });
+});

--- a/packages/cli/test/unit/errors.test.ts
+++ b/packages/cli/test/unit/errors.test.ts
@@ -1,27 +1,27 @@
-import {describe, expect, it} from 'vitest'
-import {ERROR_CODES, KeyshelfError} from '../../src/errors.js'
+import { describe, expect, it } from "vitest";
+import { ERROR_CODES, KeyshelfError } from "../../src/errors.js";
 
-describe('KeyshelfError', () => {
-  it('serializes to { code, message, ...fields }', () => {
-    const err = new KeyshelfError('ALREADY_INITIALIZED', 'already there', {path: '/x/.keyshelf'})
+describe("KeyshelfError", () => {
+  it("serializes to { code, message, ...fields }", () => {
+    const err = new KeyshelfError("ALREADY_INITIALIZED", "already there", { path: "/x/.keyshelf" });
     expect(err.toJSON()).toEqual({
-      code: 'ALREADY_INITIALIZED',
-      message: 'already there',
-      path: '/x/.keyshelf',
-    })
-  })
+      code: "ALREADY_INITIALIZED",
+      message: "already there",
+      path: "/x/.keyshelf"
+    });
+  });
 
-  it('is an Error with a stable code', () => {
-    const err = new KeyshelfError('NOT_INITIALIZED', 'nope')
-    expect(err).toBeInstanceOf(Error)
-    expect(err.code).toBe('NOT_INITIALIZED')
-  })
+  it("is an Error with a stable code", () => {
+    const err = new KeyshelfError("NOT_INITIALIZED", "nope");
+    expect(err).toBeInstanceOf(Error);
+    expect(err.code).toBe("NOT_INITIALIZED");
+  });
 
-  it('exposes the full closed code set', () => {
-    expect(ERROR_CODES).toContain('ALREADY_INITIALIZED')
-    expect(ERROR_CODES).toContain('SECRET_NOT_FOUND')
-    expect(ERROR_CODES).toContain('MALFORMED_FILE')
+  it("exposes the full closed code set", () => {
+    expect(ERROR_CODES).toContain("ALREADY_INITIALIZED");
+    expect(ERROR_CODES).toContain("SECRET_NOT_FOUND");
+    expect(ERROR_CODES).toContain("MALFORMED_FILE");
     // The committed enum size — bump deliberately when adding a code.
-    expect(ERROR_CODES).toHaveLength(16)
-  })
-})
+    expect(ERROR_CODES).toHaveLength(16);
+  });
+});

--- a/packages/cli/test/unit/gcp.test.ts
+++ b/packages/cli/test/unit/gcp.test.ts
@@ -1,6 +1,6 @@
-import {describe, expect, it} from 'vitest'
-import {GcpAdapter, type SecretsClient} from '../../src/adapters/gcp.js'
-import {KeyshelfError} from '../../src/errors.js'
+import { describe, expect, it } from "vitest";
+import { GcpAdapter, type SecretsClient } from "../../src/adapters/gcp.js";
+import { captureError } from "../support/capture-error.js";
 
 /**
  * A faithful in-memory {@link SecretsClient}: one container per secret id, an
@@ -10,196 +10,192 @@ import {KeyshelfError} from '../../src/errors.js'
  * exercised by the gated conformance suite (ADR-0005).
  */
 function fakeClient() {
-  const secrets = new Map<string, {replication: unknown; versions: Buffer[]}>()
-  const createCalls: Array<{secretId: string; replication: unknown}> = []
+  const secrets = new Map<string, { replication: unknown; versions: Buffer[] }>();
+  const createCalls: Array<{ secretId: string; replication: unknown }> = [];
 
-  function idOf(resource: string, kind: 'secret' | 'version'): string {
+  function idOf(resource: string, kind: "secret" | "version"): string {
     // projects/P/secrets/ID  or  projects/P/secrets/ID/versions/latest
-    const match = resource.match(/secrets\/([^/]+)/)
-    if (!match) throw Object.assign(new Error(`bad ${kind} resource: ${resource}`), {code: 3})
-    return match[1]
+    const match = resource.match(/secrets\/([^/]+)/);
+    if (!match) throw Object.assign(new Error(`bad ${kind} resource: ${resource}`), { code: 3 });
+    return match[1];
   }
 
   const client: SecretsClient = {
     async createSecret(request) {
-      createCalls.push({secretId: request.secretId, replication: request.secret.replication})
+      createCalls.push({ secretId: request.secretId, replication: request.secret.replication });
       if (secrets.has(request.secretId)) {
-        throw Object.assign(new Error('already exists'), {code: 6})
+        throw Object.assign(new Error("already exists"), { code: 6 });
       }
 
-      secrets.set(request.secretId, {replication: request.secret.replication, versions: []})
-      return [{}]
+      secrets.set(request.secretId, { replication: request.secret.replication, versions: [] });
+      return [{}];
     },
     async addSecretVersion(request) {
-      const id = idOf(request.parent, 'secret')
-      const secret = secrets.get(id)
-      if (!secret) throw Object.assign(new Error('no such secret'), {code: 5})
-      secret.versions.push(request.payload.data)
-      return [{}]
+      const id = idOf(request.parent, "secret");
+      const secret = secrets.get(id);
+      if (!secret) throw Object.assign(new Error("no such secret"), { code: 5 });
+      secret.versions.push(request.payload.data);
+      return [{}];
     },
     async accessSecretVersion(request) {
-      const id = idOf(request.name, 'version')
-      const secret = secrets.get(id)
+      const id = idOf(request.name, "version");
+      const secret = secrets.get(id);
       if (!secret || secret.versions.length === 0) {
-        throw Object.assign(new Error('not found'), {code: 5})
+        throw Object.assign(new Error("not found"), { code: 5 });
       }
 
-      return [{payload: {data: secret.versions[secret.versions.length - 1]}}]
-    },
-  }
+      return [{ payload: { data: secret.versions[secret.versions.length - 1] } }];
+    }
+  };
 
-  return {client, createCalls}
+  return { client, createCalls };
 }
 
 /** A client whose every call rejects with the given error — for error mapping. */
 function throwingClient(error: unknown): SecretsClient {
   const reject = async (): Promise<never> => {
-    throw error
-  }
+    throw error;
+  };
 
-  return {createSecret: reject, addSecretVersion: reject, accessSecretVersion: reject}
+  return { createSecret: reject, addSecretVersion: reject, accessSecretVersion: reject };
 }
 
-function adapter(client: SecretsClient, opts?: {location?: string; namespace?: string}): GcpAdapter {
+function adapter(
+  client: SecretsClient,
+  opts?: { location?: string; namespace?: string }
+): GcpAdapter {
   return new GcpAdapter({
-    projectId: 'test-proj',
-    namespace: opts?.namespace ?? 'myapp-web-staging',
+    projectId: "test-proj",
+    namespace: opts?.namespace ?? "myapp-web-staging",
     location: opts?.location,
-    client,
-  })
+    client
+  });
 }
 
-async function captureError(fn: () => Promise<unknown>): Promise<KeyshelfError> {
-  try {
-    await fn()
-  } catch (error) {
-    if (error instanceof KeyshelfError) return error
-    throw new Error(`expected a KeyshelfError, got: ${String(error)}`)
-  }
+describe("GcpAdapter", () => {
+  describe("naming convention", () => {
+    it("stores under {namespace}-{key} and returns that id from write", async () => {
+      const { client } = fakeClient();
+      const ref = await adapter(client).write("DATABASE_PASSWORD", "sekret");
+      expect(ref).toBe("myapp-web-staging-DATABASE_PASSWORD");
+    });
 
-  throw new Error('expected a KeyshelfError, but nothing was thrown')
-}
+    it("resolves a value written by convention", async () => {
+      const { client } = fakeClient();
+      const a = adapter(client);
+      await a.write("TOKEN", "value-1");
+      expect(await a.resolve("TOKEN")).toBe("value-1");
+    });
 
-describe('GcpAdapter', () => {
-  describe('naming convention', () => {
-    it('stores under {namespace}-{key} and returns that id from write', async () => {
-      const {client} = fakeClient()
-      const ref = await adapter(client).write('DATABASE_PASSWORD', 'sekret')
-      expect(ref).toBe('myapp-web-staging-DATABASE_PASSWORD')
-    })
+    it("keeps the same key in different namespaces distinct", async () => {
+      const { client } = fakeClient();
+      const staging = adapter(client, { namespace: "myapp-web-staging" });
+      const prod = adapter(client, { namespace: "myapp-web-prod" });
+      await staging.write("TOKEN", "staging-token");
+      await prod.write("TOKEN", "prod-token");
+      expect(await staging.resolve("TOKEN")).toBe("staging-token");
+      expect(await prod.resolve("TOKEN")).toBe("prod-token");
+    });
 
-    it('resolves a value written by convention', async () => {
-      const {client} = fakeClient()
-      const a = adapter(client)
-      await a.write('TOKEN', 'value-1')
-      expect(await a.resolve('TOKEN')).toBe('value-1')
-    })
+    it("resolves a foreign value through an explicit ref", async () => {
+      const { client } = fakeClient();
+      const a = adapter(client);
+      const ref = await a.write("CANONICAL_KEY", "foreign-value");
+      expect(await a.resolve("A_DIFFERENT_KEY", ref)).toBe("foreign-value");
+    });
 
-    it('keeps the same key in different namespaces distinct', async () => {
-      const {client} = fakeClient()
-      const staging = adapter(client, {namespace: 'myapp-web-staging'})
-      const prod = adapter(client, {namespace: 'myapp-web-prod'})
-      await staging.write('TOKEN', 'staging-token')
-      await prod.write('TOKEN', 'prod-token')
-      expect(await staging.resolve('TOKEN')).toBe('staging-token')
-      expect(await prod.resolve('TOKEN')).toBe('prod-token')
-    })
+    it("overwrites with the latest version on a repeated write", async () => {
+      const { client } = fakeClient();
+      const a = adapter(client);
+      await a.write("KEY", "first");
+      await a.write("KEY", "second");
+      expect(await a.resolve("KEY")).toBe("second");
+    });
+  });
 
-    it('resolves a foreign value through an explicit ref', async () => {
-      const {client} = fakeClient()
-      const a = adapter(client)
-      const ref = await a.write('CANONICAL_KEY', 'foreign-value')
-      expect(await a.resolve('A_DIFFERENT_KEY', ref)).toBe('foreign-value')
-    })
-
-    it('overwrites with the latest version on a repeated write', async () => {
-      const {client} = fakeClient()
-      const a = adapter(client)
-      await a.write('KEY', 'first')
-      await a.write('KEY', 'second')
-      expect(await a.resolve('KEY')).toBe('second')
-    })
-  })
-
-  describe('value fidelity (byte-exact round-trip)', () => {
+  describe("value fidelity (byte-exact round-trip)", () => {
     const cases: ReadonlyArray<readonly [string, string]> = [
-      ['embedded newlines', 'line1\nline2\nline3'],
-      ['trailing/leading whitespace', '  padded value \t'],
-      ['equals signs', 'postgres://h?a=b=c&d=e'],
-      ['quotes', `it's a "quoted" 'value'`],
-      ['unicode', 'café — 日本語 — 🔐 — Ω'],
-      ['multi-KB blob', 'x'.repeat(8192)],
-      ['empty string', ''],
-    ]
+      ["embedded newlines", "line1\nline2\nline3"],
+      ["trailing/leading whitespace", "  padded value \t"],
+      ["equals signs", "postgres://h?a=b=c&d=e"],
+      ["quotes", `it's a "quoted" 'value'`],
+      ["unicode", "café — 日本語 — 🔐 — Ω"],
+      ["multi-KB blob", "x".repeat(8192)],
+      ["empty string", ""]
+    ];
 
     for (const [label, value] of cases) {
       it(`round-trips ${label}`, async () => {
-        const {client} = fakeClient()
-        const a = adapter(client)
-        await a.write('FIDELITY_KEY', value)
-        expect(await a.resolve('FIDELITY_KEY')).toBe(value)
-      })
+        const { client } = fakeClient();
+        const a = adapter(client);
+        await a.write("FIDELITY_KEY", value);
+        expect(await a.resolve("FIDELITY_KEY")).toBe(value);
+      });
     }
 
-    it('stores an empty string as a non-empty payload (Secret Manager rejects empty)', async () => {
-      const {client} = fakeClient()
+    it("stores an empty string as a non-empty payload (Secret Manager rejects empty)", async () => {
+      const { client } = fakeClient();
       // The fake captures the raw bytes; JSON.stringify('') is `""`, two bytes.
-      const a = adapter(client)
-      await a.write('EMPTY', '')
+      const a = adapter(client);
+      await a.write("EMPTY", "");
       // Resolving proves the bytes were a valid non-empty JSON-encoded empty string.
-      expect(await a.resolve('EMPTY')).toBe('')
-    })
-  })
+      expect(await a.resolve("EMPTY")).toBe("");
+    });
+  });
 
-  describe('replication policy from location', () => {
-    it('uses automatic replication when location is absent', async () => {
-      const {client, createCalls} = fakeClient()
-      await adapter(client).write('KEY', 'v')
-      expect(createCalls[0].replication).toEqual({automatic: {}})
-    })
+  describe("replication policy from location", () => {
+    it("uses automatic replication when location is absent", async () => {
+      const { client, createCalls } = fakeClient();
+      await adapter(client).write("KEY", "v");
+      expect(createCalls[0].replication).toEqual({ automatic: {} });
+    });
 
     it('uses automatic replication when location is "global"', async () => {
-      const {client, createCalls} = fakeClient()
-      await adapter(client, {location: 'global'}).write('KEY', 'v')
-      expect(createCalls[0].replication).toEqual({automatic: {}})
-    })
+      const { client, createCalls } = fakeClient();
+      await adapter(client, { location: "global" }).write("KEY", "v");
+      expect(createCalls[0].replication).toEqual({ automatic: {} });
+    });
 
-    it('pins user-managed replication to a region when location is set', async () => {
-      const {client, createCalls} = fakeClient()
-      await adapter(client, {location: 'europe-west1'}).write('KEY', 'v')
-      expect(createCalls[0].replication).toEqual({userManaged: {replicas: [{location: 'europe-west1'}]}})
-    })
-  })
+    it("pins user-managed replication to a region when location is set", async () => {
+      const { client, createCalls } = fakeClient();
+      await adapter(client, { location: "europe-west1" }).write("KEY", "v");
+      expect(createCalls[0].replication).toEqual({
+        userManaged: { replicas: [{ location: "europe-west1" }] }
+      });
+    });
+  });
 
-  describe('error-code mapping', () => {
-    it('maps a missing secret to SECRET_NOT_FOUND', async () => {
-      const {client} = fakeClient()
-      const error = await captureError(() => adapter(client).resolve('ABSENT_KEY'))
-      expect(error.code).toBe('SECRET_NOT_FOUND')
-    })
+  describe("error-code mapping", () => {
+    it("maps a missing secret to SECRET_NOT_FOUND", async () => {
+      const { client } = fakeClient();
+      const error = await captureError(() => adapter(client).resolve("ABSENT_KEY"));
+      expect(error.code).toBe("SECRET_NOT_FOUND");
+    });
 
-    it('maps gRPC PERMISSION_DENIED to PROVIDER_AUTH', async () => {
-      const client = throwingClient(Object.assign(new Error('permission denied'), {code: 7}))
-      const error = await captureError(() => adapter(client).resolve('KEY'))
-      expect(error.code).toBe('PROVIDER_AUTH')
-    })
+    it("maps gRPC PERMISSION_DENIED to PROVIDER_AUTH", async () => {
+      const client = throwingClient(Object.assign(new Error("permission denied"), { code: 7 }));
+      const error = await captureError(() => adapter(client).resolve("KEY"));
+      expect(error.code).toBe("PROVIDER_AUTH");
+    });
 
-    it('maps gRPC UNAUTHENTICATED to PROVIDER_AUTH', async () => {
-      const client = throwingClient(Object.assign(new Error('unauthenticated'), {code: 16}))
-      const error = await captureError(() => adapter(client).resolve('KEY'))
-      expect(error.code).toBe('PROVIDER_AUTH')
-    })
+    it("maps gRPC UNAUTHENTICATED to PROVIDER_AUTH", async () => {
+      const client = throwingClient(Object.assign(new Error("unauthenticated"), { code: 16 }));
+      const error = await captureError(() => adapter(client).resolve("KEY"));
+      expect(error.code).toBe("PROVIDER_AUTH");
+    });
 
-    it('maps an ADC credential-load failure (no gRPC code) to PROVIDER_AUTH', async () => {
-      const client = throwingClient(new Error('Could not load the default credentials. Browse to https://...'))
-      const error = await captureError(() => adapter(client).resolve('KEY'))
-      expect(error.code).toBe('PROVIDER_AUTH')
-    })
+    it("maps an ADC credential-load failure (no gRPC code) to PROVIDER_AUTH", async () => {
+      const client = throwingClient(
+        new Error("Could not load the default credentials. Browse to https://...")
+      );
+      const error = await captureError(() => adapter(client).resolve("KEY"));
+      expect(error.code).toBe("PROVIDER_AUTH");
+    });
 
-    it('maps any other backend failure to ADAPTER_ERROR', async () => {
-      const client = throwingClient(Object.assign(new Error('internal'), {code: 13}))
-      const error = await captureError(() => adapter(client).resolve('KEY'))
-      expect(error.code).toBe('ADAPTER_ERROR')
-    })
-  })
-})
+    it("maps any other backend failure to ADAPTER_ERROR", async () => {
+      const client = throwingClient(Object.assign(new Error("internal"), { code: 13 }));
+      const error = await captureError(() => adapter(client).resolve("KEY"));
+      expect(error.code).toBe("ADAPTER_ERROR");
+    });
+  });
+});

--- a/packages/cli/test/unit/loader.test.ts
+++ b/packages/cli/test/unit/loader.test.ts
@@ -1,152 +1,158 @@
-import {mkdir, mkdtemp, rm, writeFile} from 'node:fs/promises'
-import os from 'node:os'
-import path from 'node:path'
-import {afterEach, beforeEach, describe, expect, it} from 'vitest'
-import {KeyshelfError} from '../../src/errors.js'
-import {listEnvironments, loadEnvironment} from '../../src/loader.js'
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { KeyshelfError } from "../../src/errors.js";
+import { listEnvironments, loadEnvironment } from "../../src/loader.js";
 
-let root: string
+let root: string;
 
 beforeEach(async () => {
-  root = await mkdtemp(path.join(os.tmpdir(), 'keyshelf-loader-'))
-})
+  root = await mkdtemp(path.join(os.tmpdir(), "keyshelf-loader-"));
+});
 
 afterEach(async () => {
-  await rm(root, {recursive: true, force: true})
-})
+  await rm(root, { recursive: true, force: true });
+});
 
 async function write(rel: string, contents: string): Promise<void> {
-  const full = path.join(root, rel)
-  await mkdir(path.dirname(full), {recursive: true})
-  await writeFile(full, contents, 'utf8')
+  const full = path.join(root, rel);
+  await mkdir(path.dirname(full), { recursive: true });
+  await writeFile(full, contents, "utf8");
 }
 
 const CONFIG = `project: myapp
 providers:
   local:
     adapter: sops
-`
+`;
 
 const SCHEMA = `keys:
   LOG_LEVEL: info
   REGION: !required
   FEATURE_X: !optional
   DATABASE_PASSWORD: !required
-`
+`;
 
 async function scaffold(): Promise<void> {
-  await write('.keyshelf/config.yaml', CONFIG)
-  await write('.keyshelf/web/schema.yaml', SCHEMA)
+  await write(".keyshelf/config.yaml", CONFIG);
+  await write(".keyshelf/web/schema.yaml", SCHEMA);
   await write(
-    '.keyshelf/web/staging.yaml',
+    ".keyshelf/web/staging.yaml",
     `provider: local
 keys:
   REGION: eu-west-1
   DATABASE_PASSWORD: !secret
-`,
-  )
+`
+  );
 }
 
 function expectCode(p: Promise<unknown>, code: string, fields?: Record<string, unknown>) {
   return p.then(
     () => {
-      throw new Error(`expected KeyshelfError ${code} but resolved`)
+      throw new Error(`expected KeyshelfError ${code} but resolved`);
     },
     (error: unknown) => {
-      expect(error).toBeInstanceOf(KeyshelfError)
-      const err = error as KeyshelfError
-      expect(err.code).toBe(code)
-      if (fields) expect(err.fields).toMatchObject(fields)
-    },
-  )
+      expect(error).toBeInstanceOf(KeyshelfError);
+      const err = error as KeyshelfError;
+      expect(err.code).toBe(code);
+      if (fields) expect(err.fields).toMatchObject(fields);
+    }
+  );
 }
 
-describe('loadEnvironment', () => {
-  it('loads config, schema, and environment into a model with filesystem-derived identity', async () => {
-    await scaffold()
-    const loaded = await loadEnvironment(root, 'web', 'staging')
+describe("loadEnvironment", () => {
+  it("loads config, schema, and environment into a model with filesystem-derived identity", async () => {
+    await scaffold();
+    const loaded = await loadEnvironment(root, "web", "staging");
 
-    expect(loaded.config.project).toBe('myapp')
-    expect(loaded.config.providers.local.adapter).toBe('sops')
+    expect(loaded.config.project).toBe("myapp");
+    expect(loaded.config.providers.local.adapter).toBe("sops");
 
-    expect(loaded.schema.keys.LOG_LEVEL).toEqual({kind: 'config', default: 'info'})
-    expect(loaded.schema.keys.REGION).toEqual({kind: 'required'})
-    expect(loaded.schema.keys.FEATURE_X).toEqual({kind: 'optional'})
+    expect(loaded.schema.keys.LOG_LEVEL).toEqual({ kind: "config", default: "info" });
+    expect(loaded.schema.keys.REGION).toEqual({ kind: "required" });
+    expect(loaded.schema.keys.FEATURE_X).toEqual({ kind: "optional" });
 
-    expect(loaded.environment.shelf).toBe('web')
-    expect(loaded.environment.name).toBe('staging')
-    expect(loaded.environment.provider).toBe('local')
-    expect(loaded.environment.keys.REGION).toEqual({kind: 'config', value: 'eu-west-1'})
-    expect(loaded.environment.keys.DATABASE_PASSWORD).toMatchObject({kind: 'secret'})
-  })
+    expect(loaded.environment.shelf).toBe("web");
+    expect(loaded.environment.name).toBe("staging");
+    expect(loaded.environment.provider).toBe("local");
+    expect(loaded.environment.keys.REGION).toEqual({ kind: "config", value: "eu-west-1" });
+    expect(loaded.environment.keys.DATABASE_PASSWORD).toMatchObject({ kind: "secret" });
+  });
 
-  it('throws NOT_INITIALIZED when no .keyshelf exists', async () => {
-    await expectCode(loadEnvironment(root, 'web', 'staging'), 'NOT_INITIALIZED')
-  })
+  it("throws NOT_INITIALIZED when no .keyshelf exists", async () => {
+    await expectCode(loadEnvironment(root, "web", "staging"), "NOT_INITIALIZED");
+  });
 
-  it('throws SHELF_NOT_FOUND for an unknown shelf', async () => {
-    await scaffold()
-    await expectCode(loadEnvironment(root, 'ghost', 'staging'), 'SHELF_NOT_FOUND', {shelf: 'ghost'})
-  })
+  it("throws SHELF_NOT_FOUND for an unknown shelf", async () => {
+    await scaffold();
+    await expectCode(loadEnvironment(root, "ghost", "staging"), "SHELF_NOT_FOUND", {
+      shelf: "ghost"
+    });
+  });
 
-  it('throws SCHEMA_NOT_FOUND when the shelf has no schema.yaml', async () => {
-    await scaffold()
-    await mkdir(path.join(root, '.keyshelf', 'noschema'), {recursive: true})
-    await write('.keyshelf/noschema/dev.yaml', 'provider: local\nkeys: {}\n')
-    await expectCode(loadEnvironment(root, 'noschema', 'dev'), 'SCHEMA_NOT_FOUND', {shelf: 'noschema'})
-  })
+  it("throws SCHEMA_NOT_FOUND when the shelf has no schema.yaml", async () => {
+    await scaffold();
+    await mkdir(path.join(root, ".keyshelf", "noschema"), { recursive: true });
+    await write(".keyshelf/noschema/dev.yaml", "provider: local\nkeys: {}\n");
+    await expectCode(loadEnvironment(root, "noschema", "dev"), "SCHEMA_NOT_FOUND", {
+      shelf: "noschema"
+    });
+  });
 
-  it('throws ENVIRONMENT_NOT_FOUND for a missing environment file', async () => {
-    await scaffold()
-    await expectCode(loadEnvironment(root, 'web', 'prod'), 'ENVIRONMENT_NOT_FOUND', {environment: 'web/prod'})
-  })
+  it("throws ENVIRONMENT_NOT_FOUND for a missing environment file", async () => {
+    await scaffold();
+    await expectCode(loadEnvironment(root, "web", "prod"), "ENVIRONMENT_NOT_FOUND", {
+      environment: "web/prod"
+    });
+  });
 
-  it('throws MALFORMED_FILE with file + reason for unparseable config', async () => {
-    await scaffold()
-    await write('.keyshelf/config.yaml', 'project: [unterminated\n')
-    let err: KeyshelfError | undefined
-    await loadEnvironment(root, 'web', 'staging').catch((e: KeyshelfError) => {
-      err = e
-    })
-    expect(err).toBeInstanceOf(KeyshelfError)
-    expect(err!.code).toBe('MALFORMED_FILE')
-    expect(err!.fields.file).toContain('config.yaml')
-    expect(typeof err!.fields.reason).toBe('string')
-  })
+  it("throws MALFORMED_FILE with file + reason for unparseable config", async () => {
+    await scaffold();
+    await write(".keyshelf/config.yaml", "project: [unterminated\n");
+    let err: KeyshelfError | undefined;
+    await loadEnvironment(root, "web", "staging").catch((e: KeyshelfError) => {
+      err = e;
+    });
+    expect(err).toBeInstanceOf(KeyshelfError);
+    expect(err!.code).toBe("MALFORMED_FILE");
+    expect(err!.fields.file).toContain("config.yaml");
+    expect(typeof err!.fields.reason).toBe("string");
+  });
 
-  it('throws MALFORMED_FILE for an unparseable environment file', async () => {
-    await scaffold()
-    await write('.keyshelf/web/staging.yaml', 'provider: local\nkeys: {bad\n')
-    await expectCode(loadEnvironment(root, 'web', 'staging'), 'MALFORMED_FILE', {})
-  })
+  it("throws MALFORMED_FILE for an unparseable environment file", async () => {
+    await scaffold();
+    await write(".keyshelf/web/staging.yaml", "provider: local\nkeys: {bad\n");
+    await expectCode(loadEnvironment(root, "web", "staging"), "MALFORMED_FILE", {});
+  });
 
-  it('throws MALFORMED_FILE for an environment missing the provider field', async () => {
-    await scaffold()
-    await write('.keyshelf/web/staging.yaml', 'keys:\n  REGION: eu\n')
-    await expectCode(loadEnvironment(root, 'web', 'staging'), 'MALFORMED_FILE', {})
-  })
+  it("throws MALFORMED_FILE for an environment missing the provider field", async () => {
+    await scaffold();
+    await write(".keyshelf/web/staging.yaml", "keys:\n  REGION: eu\n");
+    await expectCode(loadEnvironment(root, "web", "staging"), "MALFORMED_FILE", {});
+  });
 
-  it('throws MALFORMED_FILE for config missing the required project field', async () => {
-    await scaffold()
-    await write('.keyshelf/config.yaml', 'providers:\n  local:\n    adapter: sops\n')
-    await expectCode(loadEnvironment(root, 'web', 'staging'), 'MALFORMED_FILE', {})
-  })
-})
+  it("throws MALFORMED_FILE for config missing the required project field", async () => {
+    await scaffold();
+    await write(".keyshelf/config.yaml", "providers:\n  local:\n    adapter: sops\n");
+    await expectCode(loadEnvironment(root, "web", "staging"), "MALFORMED_FILE", {});
+  });
+});
 
-describe('listEnvironments', () => {
-  it('throws NOT_INITIALIZED when no .keyshelf exists', async () => {
-    await expectCode(listEnvironments(root), 'NOT_INITIALIZED')
-  })
+describe("listEnvironments", () => {
+  it("throws NOT_INITIALIZED when no .keyshelf exists", async () => {
+    await expectCode(listEnvironments(root), "NOT_INITIALIZED");
+  });
 
-  it('lists every {shelf}/{env} across all shelves, ignoring schema and secrets files', async () => {
-    await scaffold()
-    await write('.keyshelf/web/prod.yaml', 'provider: local\nkeys: {}\n')
-    await write('.keyshelf/web/staging.secrets.yaml', 'enc: stuff\n')
-    await write('.keyshelf/api/schema.yaml', 'keys: {}\n')
-    await write('.keyshelf/api/dev.yaml', 'provider: local\nkeys: {}\n')
+  it("lists every {shelf}/{env} across all shelves, ignoring schema and secrets files", async () => {
+    await scaffold();
+    await write(".keyshelf/web/prod.yaml", "provider: local\nkeys: {}\n");
+    await write(".keyshelf/web/staging.secrets.yaml", "enc: stuff\n");
+    await write(".keyshelf/api/schema.yaml", "keys: {}\n");
+    await write(".keyshelf/api/dev.yaml", "provider: local\nkeys: {}\n");
 
-    const envs = await listEnvironments(root)
-    const ids = envs.map((e) => `${e.shelf}/${e.env}`).sort()
-    expect(ids).toEqual(['api/dev', 'web/prod', 'web/staging'])
-  })
-})
+    const envs = await listEnvironments(root);
+    const ids = envs.map((e) => `${e.shelf}/${e.env}`).sort();
+    expect(ids).toEqual(["api/dev", "web/prod", "web/staging"]);
+  });
+});

--- a/packages/cli/test/unit/platforms.test.ts
+++ b/packages/cli/test/unit/platforms.test.ts
@@ -1,97 +1,97 @@
-import {createRequire} from 'node:module'
-import {describe, expect, it} from 'vitest'
+import { createRequire } from "node:module";
+import { describe, expect, it } from "vitest";
 import {
   loadSopsManifest,
   platformPackageJson,
   platforms,
-  type PlatformKey,
-} from '../../scripts/lib/platforms.js'
+  type PlatformKey
+} from "../../scripts/lib/platforms.js";
 
-const require = createRequire(import.meta.url)
-const mainPkg = require('../../package.json') as {
-  optionalDependencies: Record<string, string>
-}
+const require = createRequire(import.meta.url);
+const mainPkg = require("../../package.json") as {
+  optionalDependencies: Record<string, string>;
+};
 
-describe('sops platform manifest', () => {
-  it('lists exactly the five supported {platform}-{arch} targets', () => {
+describe("sops platform manifest", () => {
+  it("lists exactly the five supported {platform}-{arch} targets", () => {
     expect([...platforms].sort()).toEqual(
-      ['darwin-arm64', 'darwin-x64', 'linux-arm64', 'linux-x64', 'win32-x64'].sort(),
-    )
-  })
+      ["darwin-arm64", "darwin-x64", "linux-arm64", "linux-x64", "win32-x64"].sort()
+    );
+  });
 
-  it('has a sha256 and asset name for every platform', () => {
-    const manifest = loadSopsManifest()
+  it("has a sha256 and asset name for every platform", () => {
+    const manifest = loadSopsManifest();
     for (const key of platforms) {
-      const entry = manifest.binaries[key]
-      expect(entry, key).toBeDefined()
-      expect(entry.asset, key).toMatch(/^sops-v/)
-      expect(entry.sha256, key).toMatch(/^[0-9a-f]{64}$/)
+      const entry = manifest.binaries[key];
+      expect(entry, key).toBeDefined();
+      expect(entry.asset, key).toMatch(/^sops-v/);
+      expect(entry.sha256, key).toMatch(/^[0-9a-f]{64}$/);
     }
-  })
+  });
 
-  it('pins a single sops version that the tag agrees with', () => {
-    const manifest = loadSopsManifest()
-    expect(manifest.tag).toBe(`v${manifest.sopsVersion}`)
-  })
-})
+  it("pins a single sops version that the tag agrees with", () => {
+    const manifest = loadSopsManifest();
+    expect(manifest.tag).toBe(`v${manifest.sopsVersion}`);
+  });
+});
 
-describe('platformPackageJson', () => {
-  const manifest = loadSopsManifest()
+describe("platformPackageJson", () => {
+  const manifest = loadSopsManifest();
 
-  it('derives the package version from the pinned sops version (clef-sh style)', () => {
-    const pkg = platformPackageJson('linux-x64', manifest)
-    expect(pkg.version).toBe(manifest.sopsVersion)
-  })
+  it("derives the package version from the pinned sops version (clef-sh style)", () => {
+    const pkg = platformPackageJson("linux-x64", manifest);
+    expect(pkg.version).toBe(manifest.sopsVersion);
+  });
 
-  it('declares os/cpu matching the package name (load-bearing for npm selection)', () => {
+  it("declares os/cpu matching the package name (load-bearing for npm selection)", () => {
     const cases: Array<[PlatformKey, string, string]> = [
-      ['linux-x64', 'linux', 'x64'],
-      ['linux-arm64', 'linux', 'arm64'],
-      ['darwin-x64', 'darwin', 'x64'],
-      ['darwin-arm64', 'darwin', 'arm64'],
-      ['win32-x64', 'win32', 'x64'],
-    ]
+      ["linux-x64", "linux", "x64"],
+      ["linux-arm64", "linux", "arm64"],
+      ["darwin-x64", "darwin", "x64"],
+      ["darwin-arm64", "darwin", "arm64"],
+      ["win32-x64", "win32", "x64"]
+    ];
     for (const [key, os, cpu] of cases) {
-      const pkg = platformPackageJson(key, manifest)
-      expect(pkg.name, key).toBe(`@keyshelf/sops-${key}`)
-      expect(pkg.os, key).toEqual([os])
-      expect(pkg.cpu, key).toEqual([cpu])
+      const pkg = platformPackageJson(key, manifest);
+      expect(pkg.name, key).toBe(`@keyshelf/sops-${key}`);
+      expect(pkg.os, key).toEqual([os]);
+      expect(pkg.cpu, key).toEqual([cpu]);
     }
-  })
+  });
 
-  it('redistributes sops, so its license is MPL-2.0 (not keyshelf MIT)', () => {
+  it("redistributes sops, so its license is MPL-2.0 (not keyshelf MIT)", () => {
     for (const key of platforms) {
-      expect(platformPackageJson(key, manifest).license, key).toBe('MPL-2.0')
+      expect(platformPackageJson(key, manifest).license, key).toBe("MPL-2.0");
     }
-  })
+  });
 
-  it('has no runtime dependencies (deps: none)', () => {
+  it("has no runtime dependencies (deps: none)", () => {
     for (const key of platforms) {
-      const pkg = platformPackageJson(key, manifest)
-      expect(pkg.dependencies, key).toBeUndefined()
-      expect(pkg.optionalDependencies, key).toBeUndefined()
+      const pkg = platformPackageJson(key, manifest);
+      expect(pkg.dependencies, key).toBeUndefined();
+      expect(pkg.optionalDependencies, key).toBeUndefined();
     }
-  })
+  });
 
-  it('ships only the bin directory and declares no npm bin command', () => {
+  it("ships only the bin directory and declares no npm bin command", () => {
     // These packages are binary *carriers* the resolver locates by path
     // (require.resolve + bin/sops[.exe]); they intentionally expose no `bin`
     // command, matching esbuild's @esbuild/* platform packages.
     for (const key of platforms) {
-      const pkg = platformPackageJson(key, manifest)
-      expect(pkg.files, key).toEqual(['bin'])
-      expect((pkg as Record<string, unknown>).bin, key).toBeUndefined()
+      const pkg = platformPackageJson(key, manifest);
+      expect(pkg.files, key).toEqual(["bin"]);
+      expect((pkg as Record<string, unknown>).bin, key).toBeUndefined();
     }
-  })
-})
+  });
+});
 
-describe('main package.json agreement', () => {
-  const manifest = loadSopsManifest()
+describe("main package.json agreement", () => {
+  const manifest = loadSopsManifest();
 
-  it('pins every @keyshelf/sops-* optionalDependency to the bundled sops version', () => {
+  it("pins every @keyshelf/sops-* optionalDependency to the bundled sops version", () => {
     for (const key of platforms) {
-      const name = `@keyshelf/sops-${key}`
-      expect(mainPkg.optionalDependencies[name], name).toBe(manifest.sopsVersion)
+      const name = `@keyshelf/sops-${key}`;
+      expect(mainPkg.optionalDependencies[name], name).toBe(manifest.sopsVersion);
     }
-  })
-})
+  });
+});

--- a/packages/cli/test/unit/registry.test.ts
+++ b/packages/cli/test/unit/registry.test.ts
@@ -1,50 +1,59 @@
-import {mkdtempSync, rmSync} from 'node:fs'
-import os from 'node:os'
-import path from 'node:path'
-import {afterEach, beforeEach, describe, expect, it} from 'vitest'
-import {createAdapter} from '../../src/adapters/registry.js'
-import {KeyshelfError} from '../../src/errors.js'
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createAdapter } from "../../src/adapters/registry.js";
+import { KeyshelfError } from "../../src/errors.js";
 
-let dir: string
+let dir: string;
 
 beforeEach(() => {
-  dir = mkdtempSync(path.join(os.tmpdir(), 'keyshelf-registry-'))
-})
+  dir = mkdtempSync(path.join(os.tmpdir(), "keyshelf-registry-"));
+});
 
 afterEach(() => {
-  rmSync(dir, {recursive: true, force: true})
-})
+  rmSync(dir, { recursive: true, force: true });
+});
 
-describe('createAdapter', () => {
-  it('builds a fake adapter that round-trips through a persisted store', async () => {
-    const ctx = {projectDir: dir, project: 'myapp', shelf: 'web', env: 'staging'}
-    const a = createAdapter({adapter: 'fake'}, ctx)
-    await a.write('DATABASE_PASSWORD', 'sekret')
+describe("createAdapter", () => {
+  it("builds a fake adapter that round-trips through a persisted store", async () => {
+    const ctx = { projectDir: dir, project: "myapp", shelf: "web", env: "staging" };
+    const a = createAdapter({ adapter: "fake" }, ctx);
+    await a.write("DATABASE_PASSWORD", "sekret");
 
     // A second adapter instance (as a separate CLI process would build) sees it.
-    const b = createAdapter({adapter: 'fake'}, ctx)
-    expect(await b.resolve('DATABASE_PASSWORD')).toBe('sekret')
-  })
+    const b = createAdapter({ adapter: "fake" }, ctx);
+    expect(await b.resolve("DATABASE_PASSWORD")).toBe("sekret");
+  });
 
-  it('namespaces by project+env so the same key in two environments is distinct', async () => {
-    const staging = createAdapter({adapter: 'fake'}, {projectDir: dir, project: 'myapp', shelf: 'web', env: 'staging'})
-    const prod = createAdapter({adapter: 'fake'}, {projectDir: dir, project: 'myapp', shelf: 'web', env: 'prod'})
-    await staging.write('TOKEN', 'staging-token')
-    await prod.write('TOKEN', 'prod-token')
-    expect(await staging.resolve('TOKEN')).toBe('staging-token')
-    expect(await prod.resolve('TOKEN')).toBe('prod-token')
-  })
+  it("namespaces by project+env so the same key in two environments is distinct", async () => {
+    const staging = createAdapter(
+      { adapter: "fake" },
+      { projectDir: dir, project: "myapp", shelf: "web", env: "staging" }
+    );
+    const prod = createAdapter(
+      { adapter: "fake" },
+      { projectDir: dir, project: "myapp", shelf: "web", env: "prod" }
+    );
+    await staging.write("TOKEN", "staging-token");
+    await prod.write("TOKEN", "prod-token");
+    expect(await staging.resolve("TOKEN")).toBe("staging-token");
+    expect(await prod.resolve("TOKEN")).toBe("prod-token");
+  });
 
-  it('rejects an unknown adapter name with a structured ADAPTER_UNAVAILABLE error', () => {
-    let thrown: unknown
+  it("rejects an unknown adapter name with a structured ADAPTER_UNAVAILABLE error", () => {
+    let thrown: unknown;
     try {
-      createAdapter({adapter: 'no-such-adapter'}, {projectDir: dir, project: 'myapp', shelf: 'web', env: 'staging'})
+      createAdapter(
+        { adapter: "no-such-adapter" },
+        { projectDir: dir, project: "myapp", shelf: "web", env: "staging" }
+      );
     } catch (error) {
-      thrown = error
+      thrown = error;
     }
 
-    expect(thrown).toBeInstanceOf(KeyshelfError)
-    expect((thrown as KeyshelfError).code).toBe('ADAPTER_UNAVAILABLE')
-    expect((thrown as KeyshelfError).fields).toMatchObject({adapter: 'no-such-adapter'})
-  })
-})
+    expect(thrown).toBeInstanceOf(KeyshelfError);
+    expect((thrown as KeyshelfError).code).toBe("ADAPTER_UNAVAILABLE");
+    expect((thrown as KeyshelfError).fields).toMatchObject({ adapter: "no-such-adapter" });
+  });
+});

--- a/packages/cli/test/unit/resolve.test.ts
+++ b/packages/cli/test/unit/resolve.test.ts
@@ -1,171 +1,188 @@
-import {describe, expect, it} from 'vitest'
-import {FakeAdapter, inMemoryStore} from '../../src/adapters/fake.js'
-import {KeyshelfError} from '../../src/errors.js'
-import type {Config, Environment, LoadedEnvironment, Schema} from '../../src/model.js'
-import {buildChildEnv, parseSet, resolveEnvironment} from '../../src/resolve.js'
+import { describe, expect, it } from "vitest";
+import { FakeAdapter, inMemoryStore } from "../../src/adapters/fake.js";
+import { KeyshelfError } from "../../src/errors.js";
+import type { Config, Environment, LoadedEnvironment, Schema } from "../../src/model.js";
+import { buildChildEnv, parseSet, resolveEnvironment } from "../../src/resolve.js";
 
 /** A factory yielding an empty adapter for config-only cases (never invoked). */
-const noSecrets = () => new FakeAdapter(inMemoryStore())
+const noSecrets = () => new FakeAdapter(inMemoryStore());
 
 /** Wrap a concrete adapter as the lazy factory resolveEnvironment expects. */
-const using = (a: FakeAdapter) => () => a
+const using = (a: FakeAdapter) => () => a;
 
 const config: Config = {
-  project: 'myapp',
-  providers: {local: {adapter: 'sops'}},
-}
+  project: "myapp",
+  providers: { local: { adapter: "sops" } }
+};
 
 const schema: Schema = {
   keys: {
-    LOG_LEVEL: {kind: 'config', default: 'info'},
-    REGION: {kind: 'required'},
-    FEATURE_X: {kind: 'optional'},
-    DATABASE_PASSWORD: {kind: 'required'},
-  },
+    LOG_LEVEL: { kind: "config", default: "info" },
+    REGION: { kind: "required" },
+    FEATURE_X: { kind: "optional" },
+    DATABASE_PASSWORD: { kind: "required" }
+  }
+};
+
+function env(keys: Environment["keys"]): LoadedEnvironment {
+  return {
+    config,
+    schema,
+    environment: { shelf: "web", name: "staging", provider: "local", keys }
+  };
 }
 
-function env(keys: Environment['keys']): LoadedEnvironment {
-  return {config, schema, environment: {shelf: 'web', name: 'staging', provider: 'local', keys}}
-}
-
-describe('resolveEnvironment (config-only)', () => {
-  it('merges schema defaults with environment values, environment wins', async () => {
+describe("resolveEnvironment (config-only)", () => {
+  it("merges schema defaults with environment values, environment wins", async () => {
     const map = await resolveEnvironment(
       env({
-        REGION: {kind: 'config', value: 'eu-west-1'},
-        DATABASE_PASSWORD: {kind: 'config', value: 'pw'},
-        LOG_LEVEL: {kind: 'config', value: 'debug'},
+        REGION: { kind: "config", value: "eu-west-1" },
+        DATABASE_PASSWORD: { kind: "config", value: "pw" },
+        LOG_LEVEL: { kind: "config", value: "debug" }
       }),
-      noSecrets,
-    )
-    expect(map).toEqual({LOG_LEVEL: 'debug', REGION: 'eu-west-1', DATABASE_PASSWORD: 'pw'})
-  })
+      noSecrets
+    );
+    expect(map).toEqual({ LOG_LEVEL: "debug", REGION: "eu-west-1", DATABASE_PASSWORD: "pw" });
+  });
 
-  it('contributes a schema config default when the environment omits the key', async () => {
-    const map = await resolveEnvironment(
-      env({REGION: {kind: 'config', value: 'eu'}, DATABASE_PASSWORD: {kind: 'config', value: 'pw'}}),
-      noSecrets,
-    )
-    expect(map.LOG_LEVEL).toBe('info')
-  })
-
-  it('omits optional and absent keys that have no default', async () => {
-    const map = await resolveEnvironment(
-      env({REGION: {kind: 'config', value: 'eu'}, DATABASE_PASSWORD: {kind: 'config', value: 'pw'}}),
-      noSecrets,
-    )
-    expect(Object.prototype.hasOwnProperty.call(map, 'FEATURE_X')).toBe(false)
-  })
-
-  it('preserves byte-exact values including whitespace and empty strings', async () => {
+  it("contributes a schema config default when the environment omits the key", async () => {
     const map = await resolveEnvironment(
       env({
-        REGION: {kind: 'config', value: ' eu = west \n'},
-        DATABASE_PASSWORD: {kind: 'config', value: ''},
+        REGION: { kind: "config", value: "eu" },
+        DATABASE_PASSWORD: { kind: "config", value: "pw" }
       }),
-      noSecrets,
-    )
-    expect(map.REGION).toBe(' eu = west \n')
-    expect(map.DATABASE_PASSWORD).toBe('')
-  })
-})
+      noSecrets
+    );
+    expect(map.LOG_LEVEL).toBe("info");
+  });
 
-describe('resolveEnvironment (secret resolution)', () => {
-  it('resolves a !secret through the adapter by convention (key name)', async () => {
-    const adapter = new FakeAdapter(inMemoryStore())
-    await adapter.write('DATABASE_PASSWORD', 's3cr3t')
+  it("omits optional and absent keys that have no default", async () => {
     const map = await resolveEnvironment(
-      env({REGION: {kind: 'config', value: 'eu'}, DATABASE_PASSWORD: {kind: 'secret'}}),
-      using(adapter),
-    )
-    expect(map.DATABASE_PASSWORD).toBe('s3cr3t')
-    expect(map.REGION).toBe('eu')
-  })
+      env({
+        REGION: { kind: "config", value: "eu" },
+        DATABASE_PASSWORD: { kind: "config", value: "pw" }
+      }),
+      noSecrets
+    );
+    expect(Object.prototype.hasOwnProperty.call(map, "FEATURE_X")).toBe(false);
+  });
 
-  it('resolves a differently-named foreign value via an explicit { ref }', async () => {
-    const adapter = new FakeAdapter(inMemoryStore({'shared-db-url': 'postgres://x'}))
+  it("preserves byte-exact values including whitespace and empty strings", async () => {
     const map = await resolveEnvironment(
-      env({REGION: {kind: 'config', value: 'eu'}, DATABASE_PASSWORD: {kind: 'secret', ref: {ref: 'shared-db-url'}}}),
-      using(adapter),
-    )
-    expect(map.DATABASE_PASSWORD).toBe('postgres://x')
-  })
+      env({
+        REGION: { kind: "config", value: " eu = west \n" },
+        DATABASE_PASSWORD: { kind: "config", value: "" }
+      }),
+      noSecrets
+    );
+    expect(map.REGION).toBe(" eu = west \n");
+    expect(map.DATABASE_PASSWORD).toBe("");
+  });
+});
 
-  it('fails with SECRET_NOT_FOUND when no value is stored for a !secret', async () => {
-    const adapter = new FakeAdapter(inMemoryStore())
-    let thrown: unknown
+describe("resolveEnvironment (secret resolution)", () => {
+  it("resolves a !secret through the adapter by convention (key name)", async () => {
+    const adapter = new FakeAdapter(inMemoryStore());
+    await adapter.write("DATABASE_PASSWORD", "s3cr3t");
+    const map = await resolveEnvironment(
+      env({ REGION: { kind: "config", value: "eu" }, DATABASE_PASSWORD: { kind: "secret" } }),
+      using(adapter)
+    );
+    expect(map.DATABASE_PASSWORD).toBe("s3cr3t");
+    expect(map.REGION).toBe("eu");
+  });
+
+  it("resolves a differently-named foreign value via an explicit { ref }", async () => {
+    const adapter = new FakeAdapter(inMemoryStore({ "shared-db-url": "postgres://x" }));
+    const map = await resolveEnvironment(
+      env({
+        REGION: { kind: "config", value: "eu" },
+        DATABASE_PASSWORD: { kind: "secret", ref: { ref: "shared-db-url" } }
+      }),
+      using(adapter)
+    );
+    expect(map.DATABASE_PASSWORD).toBe("postgres://x");
+  });
+
+  it("fails with SECRET_NOT_FOUND when no value is stored for a !secret", async () => {
+    const adapter = new FakeAdapter(inMemoryStore());
+    let thrown: unknown;
     try {
       await resolveEnvironment(
-        env({REGION: {kind: 'config', value: 'eu'}, DATABASE_PASSWORD: {kind: 'secret'}}),
-        using(adapter),
-      )
+        env({ REGION: { kind: "config", value: "eu" }, DATABASE_PASSWORD: { kind: "secret" } }),
+        using(adapter)
+      );
     } catch (error) {
-      thrown = error
+      thrown = error;
     }
 
-    expect(thrown).toBeInstanceOf(KeyshelfError)
-    expect((thrown as KeyshelfError).code).toBe('SECRET_NOT_FOUND')
-    expect((thrown as KeyshelfError).fields).toMatchObject({key: 'DATABASE_PASSWORD'})
-  })
-})
+    expect(thrown).toBeInstanceOf(KeyshelfError);
+    expect((thrown as KeyshelfError).code).toBe("SECRET_NOT_FOUND");
+    expect((thrown as KeyshelfError).fields).toMatchObject({ key: "DATABASE_PASSWORD" });
+  });
+});
 
-describe('parseSet', () => {
-  it('splits KEY=VALUE on the first =', () => {
-    expect(parseSet('FOO=bar')).toEqual({key: 'FOO', value: 'bar'})
-  })
+describe("parseSet", () => {
+  it("splits KEY=VALUE on the first =", () => {
+    expect(parseSet("FOO=bar")).toEqual({ key: "FOO", value: "bar" });
+  });
 
-  it('keeps later = signs in the value verbatim', () => {
-    expect(parseSet('URL=postgres://h?a=b=c')).toEqual({key: 'URL', value: 'postgres://h?a=b=c'})
-  })
+  it("keeps later = signs in the value verbatim", () => {
+    expect(parseSet("URL=postgres://h?a=b=c")).toEqual({ key: "URL", value: "postgres://h?a=b=c" });
+  });
 
-  it('allows an empty value', () => {
-    expect(parseSet('EMPTY=')).toEqual({key: 'EMPTY', value: ''})
-  })
+  it("allows an empty value", () => {
+    expect(parseSet("EMPTY=")).toEqual({ key: "EMPTY", value: "" });
+  });
 
-  it('rejects a --set without = with MALFORMED_FILE', () => {
-    let thrown: unknown
+  it("rejects a --set without = with MALFORMED_FILE", () => {
+    let thrown: unknown;
     try {
-      parseSet('NOEQUALS')
+      parseSet("NOEQUALS");
     } catch (error) {
-      thrown = error
+      thrown = error;
     }
 
-    expect((thrown as KeyshelfError).code).toBe('MALFORMED_FILE')
-  })
+    expect((thrown as KeyshelfError).code).toBe("MALFORMED_FILE");
+  });
 
-  it('rejects an invalid key name with INVALID_KEY_NAME', () => {
-    let thrown: unknown
+  it("rejects an invalid key name with INVALID_KEY_NAME", () => {
+    let thrown: unknown;
     try {
-      parseSet('bad-key=x')
+      parseSet("bad-key=x");
     } catch (error) {
-      thrown = error
+      thrown = error;
     }
 
-    expect((thrown as KeyshelfError).code).toBe('INVALID_KEY_NAME')
-  })
-})
+    expect((thrown as KeyshelfError).code).toBe("INVALID_KEY_NAME");
+  });
+});
 
-describe('buildChildEnv precedence', () => {
-  const managed = {LOG_LEVEL: 'debug', REGION: 'eu'}
+describe("buildChildEnv precedence", () => {
+  const managed = { LOG_LEVEL: "debug", REGION: "eu" };
 
-  it('overlays managed values onto the inherited ambient environment', () => {
-    const out = buildChildEnv({ambient: {PATH: '/bin', HOME: '/root'}, managed, sets: {}})
-    expect(out).toMatchObject({PATH: '/bin', HOME: '/root', LOG_LEVEL: 'debug', REGION: 'eu'})
-  })
+  it("overlays managed values onto the inherited ambient environment", () => {
+    const out = buildChildEnv({ ambient: { PATH: "/bin", HOME: "/root" }, managed, sets: {} });
+    expect(out).toMatchObject({ PATH: "/bin", HOME: "/root", LOG_LEVEL: "debug", REGION: "eu" });
+  });
 
-  it('overrides a stale ambient value for a managed key (managed wins)', () => {
-    const out = buildChildEnv({ambient: {REGION: 'STALE', PATH: '/bin'}, managed, sets: {}})
-    expect(out.REGION).toBe('eu')
-    expect(out.PATH).toBe('/bin')
-  })
+  it("overrides a stale ambient value for a managed key (managed wins)", () => {
+    const out = buildChildEnv({ ambient: { REGION: "STALE", PATH: "/bin" }, managed, sets: {} });
+    expect(out.REGION).toBe("eu");
+    expect(out.PATH).toBe("/bin");
+  });
 
-  it('lets --set win over the resolved managed value and over ambient', () => {
-    const out = buildChildEnv({ambient: {REGION: 'STALE'}, managed, sets: {REGION: 'override'}})
-    expect(out.REGION).toBe('override')
-  })
+  it("lets --set win over the resolved managed value and over ambient", () => {
+    const out = buildChildEnv({
+      ambient: { REGION: "STALE" },
+      managed,
+      sets: { REGION: "override" }
+    });
+    expect(out.REGION).toBe("override");
+  });
 
-  it('lets --set introduce a key keyshelf does not manage', () => {
-    const out = buildChildEnv({ambient: {}, managed, sets: {EXTRA: 'x'}})
-    expect(out.EXTRA).toBe('x')
-  })
-})
+  it("lets --set introduce a key keyshelf does not manage", () => {
+    const out = buildChildEnv({ ambient: {}, managed, sets: { EXTRA: "x" } });
+    expect(out.EXTRA).toBe("x");
+  });
+});

--- a/packages/cli/test/unit/set.test.ts
+++ b/packages/cli/test/unit/set.test.ts
@@ -1,132 +1,140 @@
-import {mkdir, mkdtemp, rm, writeFile} from 'node:fs/promises'
-import os from 'node:os'
-import path from 'node:path'
-import {parseDocument} from 'yaml'
-import {afterEach, beforeEach, describe, expect, it} from 'vitest'
-import {loadEnvironment} from '../../src/loader.js'
-import {secretRefForm, setConfigValue, setSecretRef} from '../../src/set.js'
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { parseDocument } from "yaml";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { loadEnvironment } from "../../src/loader.js";
+import { secretRefForm, setConfigValue, setSecretRef } from "../../src/set.js";
 
-describe('secretRefForm', () => {
-  it('is bare when the adapter ref equals the convention name', () => {
-    expect(secretRefForm('myapp-web-staging-DB', 'myapp-web-staging-DB')).toEqual({bare: true})
-  })
+describe("secretRefForm", () => {
+  it("is bare when the adapter ref equals the convention name", () => {
+    expect(secretRefForm("myapp-web-staging-DB", "myapp-web-staging-DB")).toEqual({ bare: true });
+  });
 
-  it('is bare when the adapter returns undefined (convention-resolvable)', () => {
-    expect(secretRefForm(undefined, 'myapp-web-staging-DB')).toEqual({bare: true})
-  })
+  it("is bare when the adapter returns undefined (convention-resolvable)", () => {
+    expect(secretRefForm(undefined, "myapp-web-staging-DB")).toEqual({ bare: true });
+  });
 
-  it('carries an explicit { ref } when the adapter ref is foreign', () => {
-    expect(secretRefForm('shared-db-url', 'myapp-web-staging-DB')).toEqual({bare: false, ref: 'shared-db-url'})
-  })
+  it("carries an explicit { ref } when the adapter ref is foreign", () => {
+    expect(secretRefForm("shared-db-url", "myapp-web-staging-DB")).toEqual({
+      bare: false,
+      ref: "shared-db-url"
+    });
+  });
 
-  it('carries an explicit { ref } when the adapter returns a non-string payload', () => {
-    expect(secretRefForm({name: 'x'}, 'myapp-web-staging-DB')).toEqual({bare: false, ref: {name: 'x'}})
-  })
-})
+  it("carries an explicit { ref } when the adapter returns a non-string payload", () => {
+    expect(secretRefForm({ name: "x" }, "myapp-web-staging-DB")).toEqual({
+      bare: false,
+      ref: { name: "x" }
+    });
+  });
+});
 
-describe('setConfigValue', () => {
-  it('sets a plaintext value under keys, creating keys when absent', () => {
-    const doc = parseDocument('provider: local\n')
-    setConfigValue(doc, 'REGION', 'eu-west-1')
-    expect(doc.toString()).toContain('REGION: eu-west-1')
-    expect(doc.toString()).toContain('provider: local')
-  })
+describe("setConfigValue", () => {
+  it("sets a plaintext value under keys, creating keys when absent", () => {
+    const doc = parseDocument("provider: local\n");
+    setConfigValue(doc, "REGION", "eu-west-1");
+    expect(doc.toString()).toContain("REGION: eu-west-1");
+    expect(doc.toString()).toContain("provider: local");
+  });
 
-  it('overwrites an existing key and preserves the other keys and provider', () => {
-    const doc = parseDocument('provider: local\nkeys:\n  LOG_LEVEL: info\n  REGION: us\n')
-    setConfigValue(doc, 'REGION', 'eu')
-    const text = doc.toString()
-    expect(text).toContain('LOG_LEVEL: info')
-    expect(text).toContain('REGION: eu')
-    expect(text).toContain('provider: local')
-    expect(text).not.toContain('REGION: us')
-  })
+  it("overwrites an existing key and preserves the other keys and provider", () => {
+    const doc = parseDocument("provider: local\nkeys:\n  LOG_LEVEL: info\n  REGION: us\n");
+    setConfigValue(doc, "REGION", "eu");
+    const text = doc.toString();
+    expect(text).toContain("LOG_LEVEL: info");
+    expect(text).toContain("REGION: eu");
+    expect(text).toContain("provider: local");
+    expect(text).not.toContain("REGION: us");
+  });
 
-  it('round-trips an adversarial value with spaces, = and quotes', () => {
-    const value = 'a "quoted" = value with spaces'
-    const doc = parseDocument('provider: local\nkeys:\n  OTHER: keep\n')
-    setConfigValue(doc, 'TRICKY', value)
-    const reparsed = parseDocument(doc.toString()).toJS() as {keys: Record<string, string>}
-    expect(reparsed.keys.TRICKY).toBe(value)
-    expect(reparsed.keys.OTHER).toBe('keep')
-  })
+  it("round-trips an adversarial value with spaces, = and quotes", () => {
+    const value = 'a "quoted" = value with spaces';
+    const doc = parseDocument("provider: local\nkeys:\n  OTHER: keep\n");
+    setConfigValue(doc, "TRICKY", value);
+    const reparsed = parseDocument(doc.toString()).toJS() as { keys: Record<string, string> };
+    expect(reparsed.keys.TRICKY).toBe(value);
+    expect(reparsed.keys.OTHER).toBe("keep");
+  });
 
-  it('clears any prior !secret tag when re-setting a key as plaintext', () => {
-    const doc = parseDocument('provider: local\nkeys:\n  DB: !secret\n')
-    setConfigValue(doc, 'DB', 'plain')
-    const reparsed = parseDocument(doc.toString())
-    expect(reparsed.toString()).not.toContain('!secret')
-    expect((reparsed.toJS() as {keys: Record<string, string>}).keys.DB).toBe('plain')
-  })
-})
+  it("clears any prior !secret tag when re-setting a key as plaintext", () => {
+    const doc = parseDocument("provider: local\nkeys:\n  DB: !secret\n");
+    setConfigValue(doc, "DB", "plain");
+    const reparsed = parseDocument(doc.toString());
+    expect(reparsed.toString()).not.toContain("!secret");
+    expect((reparsed.toJS() as { keys: Record<string, string> }).keys.DB).toBe("plain");
+  });
+});
 
-describe('setSecretRef', () => {
-  it('writes a bare !secret tag, never the value, preserving other keys', () => {
-    const doc = parseDocument('provider: local\nkeys:\n  REGION: eu\n')
-    setSecretRef(doc, 'DB', {bare: true})
-    const text = doc.toString()
-    expect(text).toContain('REGION: eu')
-    expect(text).toContain('!secret')
-    expect(text).not.toContain('s3cr3t')
-  })
+describe("setSecretRef", () => {
+  it("writes a bare !secret tag, never the value, preserving other keys", () => {
+    const doc = parseDocument("provider: local\nkeys:\n  REGION: eu\n");
+    setSecretRef(doc, "DB", { bare: true });
+    const text = doc.toString();
+    expect(text).toContain("REGION: eu");
+    expect(text).toContain("!secret");
+    expect(text).not.toContain("s3cr3t");
+  });
 
-  it('writes !secret { ref: ... } for a foreign reference', () => {
-    const doc = parseDocument('provider: local\nkeys:\n  REGION: eu\n')
-    setSecretRef(doc, 'DB', {bare: false, ref: 'shared-db-url'})
-    const reparsed = parseDocument(doc.toString())
+  it("writes !secret { ref: ... } for a foreign reference", () => {
+    const doc = parseDocument("provider: local\nkeys:\n  REGION: eu\n");
+    setSecretRef(doc, "DB", { bare: false, ref: "shared-db-url" });
+    const reparsed = parseDocument(doc.toString());
     // The written form must round-trip back through the loader's !secret parsing.
-    expect(reparsed.toString()).toContain('!secret')
-    expect(reparsed.toString()).toContain('shared-db-url')
-  })
-})
+    expect(reparsed.toString()).toContain("!secret");
+    expect(reparsed.toString()).toContain("shared-db-url");
+  });
+});
 
 // The written environment file must read back through the real loader into the
 // expected EnvironmentValue: plaintext config, bare secret, and explicit ref.
-describe('set output round-trips through loadEnvironment', () => {
-  let root: string
+describe("set output round-trips through loadEnvironment", () => {
+  let root: string;
 
   beforeEach(async () => {
-    root = await mkdtemp(path.join(os.tmpdir(), 'keyshelf-set-loader-'))
-    await mkdir(path.join(root, '.keyshelf', 'web'), {recursive: true})
+    root = await mkdtemp(path.join(os.tmpdir(), "keyshelf-set-loader-"));
+    await mkdir(path.join(root, ".keyshelf", "web"), { recursive: true });
     await writeFile(
-      path.join(root, '.keyshelf', 'config.yaml'),
-      'project: myapp\nproviders:\n  store:\n    adapter: fake\n',
-      'utf8',
-    )
+      path.join(root, ".keyshelf", "config.yaml"),
+      "project: myapp\nproviders:\n  store:\n    adapter: fake\n",
+      "utf8"
+    );
     await writeFile(
-      path.join(root, '.keyshelf', 'web', 'schema.yaml'),
-      'keys:\n  REGION: !optional\n  DB: !optional\n',
-      'utf8',
-    )
-  })
+      path.join(root, ".keyshelf", "web", "schema.yaml"),
+      "keys:\n  REGION: !optional\n  DB: !optional\n",
+      "utf8"
+    );
+  });
 
   afterEach(async () => {
-    await rm(root, {recursive: true, force: true})
-  })
+    await rm(root, { recursive: true, force: true });
+  });
 
-  async function writeEnvVia(mutate: (doc: ReturnType<typeof parseDocument>) => void): Promise<void> {
-    const doc = parseDocument('provider: store\nkeys:\n  REGION: eu\n')
-    mutate(doc)
-    await writeFile(path.join(root, '.keyshelf', 'web', 'staging.yaml'), doc.toString(), 'utf8')
+  async function writeEnvVia(
+    mutate: (doc: ReturnType<typeof parseDocument>) => void
+  ): Promise<void> {
+    const doc = parseDocument("provider: store\nkeys:\n  REGION: eu\n");
+    mutate(doc);
+    await writeFile(path.join(root, ".keyshelf", "web", "staging.yaml"), doc.toString(), "utf8");
   }
 
-  it('yields a config EnvironmentValue for a plaintext set', async () => {
-    await writeEnvVia((doc) => setConfigValue(doc, 'DB', 'plainval'))
-    const loaded = await loadEnvironment(root, 'web', 'staging')
-    expect(loaded.environment.keys.DB).toEqual({kind: 'config', value: 'plainval'})
-  })
+  it("yields a config EnvironmentValue for a plaintext set", async () => {
+    await writeEnvVia((doc) => setConfigValue(doc, "DB", "plainval"));
+    const loaded = await loadEnvironment(root, "web", "staging");
+    expect(loaded.environment.keys.DB).toEqual({ kind: "config", value: "plainval" });
+  });
 
-  it('yields a bare secret EnvironmentValue for set --secret (no ref)', async () => {
-    await writeEnvVia((doc) => setSecretRef(doc, 'DB', {bare: true}))
-    const loaded = await loadEnvironment(root, 'web', 'staging')
-    expect(loaded.environment.keys.DB.kind).toBe('secret')
-    expect(loaded.environment.keys.DB.ref).toBeUndefined()
-  })
+  it("yields a bare secret EnvironmentValue for set --secret (no ref)", async () => {
+    await writeEnvVia((doc) => setSecretRef(doc, "DB", { bare: true }));
+    const loaded = await loadEnvironment(root, "web", "staging");
+    expect(loaded.environment.keys.DB.kind).toBe("secret");
+    expect(loaded.environment.keys.DB.ref).toBeUndefined();
+  });
 
-  it('yields a secret EnvironmentValue carrying the explicit ref', async () => {
-    await writeEnvVia((doc) => setSecretRef(doc, 'DB', {bare: false, ref: 'shared-db-url'}))
-    const loaded = await loadEnvironment(root, 'web', 'staging')
-    expect(loaded.environment.keys.DB.kind).toBe('secret')
-    expect(loaded.environment.keys.DB.ref).toMatchObject({ref: 'shared-db-url'})
-  })
-})
+  it("yields a secret EnvironmentValue carrying the explicit ref", async () => {
+    await writeEnvVia((doc) => setSecretRef(doc, "DB", { bare: false, ref: "shared-db-url" }));
+    const loaded = await loadEnvironment(root, "web", "staging");
+    expect(loaded.environment.keys.DB.kind).toBe("secret");
+    expect(loaded.environment.keys.DB.ref).toMatchObject({ ref: "shared-db-url" });
+  });
+});

--- a/packages/cli/test/unit/sops-binary.test.ts
+++ b/packages/cli/test/unit/sops-binary.test.ts
@@ -1,59 +1,62 @@
-import path from 'node:path'
-import {afterEach, describe, expect, it} from 'vitest'
-import {createAdapter} from '../../src/adapters/registry.js'
-import {SopsAdapter} from '../../src/adapters/sops.js'
-import {platformPackage, resolveSopsBinary} from '../../src/adapters/sops-binary.js'
-import {KeyshelfError} from '../../src/errors.js'
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createAdapter } from "../../src/adapters/registry.js";
+import { SopsAdapter } from "../../src/adapters/sops.js";
+import { platformPackage, resolveSopsBinary } from "../../src/adapters/sops-binary.js";
+import { KeyshelfError } from "../../src/errors.js";
 
-const ORIGINAL = process.env.KEYSHELF_SOPS_BIN
+const ORIGINAL = process.env.KEYSHELF_SOPS_BIN;
 
 afterEach(() => {
-  if (ORIGINAL === undefined) delete process.env.KEYSHELF_SOPS_BIN
-  else process.env.KEYSHELF_SOPS_BIN = ORIGINAL
-})
+  if (ORIGINAL === undefined) delete process.env.KEYSHELF_SOPS_BIN;
+  else process.env.KEYSHELF_SOPS_BIN = ORIGINAL;
+});
 
-describe('resolveSopsBinary', () => {
-  it('surfaces ADAPTER_UNAVAILABLE when the override points at a nonexistent binary', () => {
-    process.env.KEYSHELF_SOPS_BIN = '/definitely/not/a/real/sops/binary'
-    let thrown: unknown
+describe("resolveSopsBinary", () => {
+  it("surfaces ADAPTER_UNAVAILABLE when the override points at a nonexistent binary", () => {
+    process.env.KEYSHELF_SOPS_BIN = "/definitely/not/a/real/sops/binary";
+    let thrown: unknown;
     try {
-      resolveSopsBinary()
+      resolveSopsBinary();
     } catch (error) {
-      thrown = error
+      thrown = error;
     }
 
-    expect(thrown).toBeInstanceOf(KeyshelfError)
-    expect((thrown as KeyshelfError).code).toBe('ADAPTER_UNAVAILABLE')
+    expect(thrown).toBeInstanceOf(KeyshelfError);
+    expect((thrown as KeyshelfError).code).toBe("ADAPTER_UNAVAILABLE");
     // Never a raw spawn error — a clear, structured message (ADR-0003).
-    expect((thrown as KeyshelfError).message).toContain('does not exist')
-  })
+    expect((thrown as KeyshelfError).message).toContain("does not exist");
+  });
 
-  it('names the per-platform optional-dependency package for this host', () => {
-    expect(platformPackage()).toBe(`@keyshelf/sops-${process.platform}-${process.arch}`)
-  })
-})
+  it("names the per-platform optional-dependency package for this host", () => {
+    expect(platformPackage()).toBe(`@keyshelf/sops-${process.platform}-${process.arch}`);
+  });
+});
 
-describe('sops adapter binary resolution', () => {
-  it('maps a missing/unusable sops binary to ADAPTER_UNAVAILABLE at write time', async () => {
-    process.env.KEYSHELF_SOPS_BIN = '/definitely/not/a/real/sops/binary'
-    const adapter = new SopsAdapter({storePath: path.join('/tmp', 'x', 'app', 'staging.secrets.yaml'), cwd: '/tmp/x'})
-    let thrown: unknown
+describe("sops adapter binary resolution", () => {
+  it("maps a missing/unusable sops binary to ADAPTER_UNAVAILABLE at write time", async () => {
+    process.env.KEYSHELF_SOPS_BIN = "/definitely/not/a/real/sops/binary";
+    const adapter = new SopsAdapter({
+      storePath: path.join("/tmp", "x", "app", "staging.secrets.yaml"),
+      cwd: "/tmp/x"
+    });
+    let thrown: unknown;
     try {
-      await adapter.write('KEY', 'value')
+      await adapter.write("KEY", "value");
     } catch (error) {
-      thrown = error
+      thrown = error;
     }
 
-    expect((thrown as KeyshelfError).code).toBe('ADAPTER_UNAVAILABLE')
-  })
-})
+    expect((thrown as KeyshelfError).code).toBe("ADAPTER_UNAVAILABLE");
+  });
+});
 
-describe('createAdapter sops branch', () => {
-  it('builds a SopsAdapter with the per-environment store path', () => {
+describe("createAdapter sops branch", () => {
+  it("builds a SopsAdapter with the per-environment store path", () => {
     const adapter = createAdapter(
-      {adapter: 'sops'},
-      {projectDir: '/proj', project: 'myapp', shelf: 'web', env: 'staging'},
-    )
-    expect(adapter).toBeInstanceOf(SopsAdapter)
-  })
-})
+      { adapter: "sops" },
+      { projectDir: "/proj", project: "myapp", shelf: "web", env: "staging" }
+    );
+    expect(adapter).toBeInstanceOf(SopsAdapter);
+  });
+});

--- a/packages/cli/test/unit/validate.test.ts
+++ b/packages/cli/test/unit/validate.test.ts
@@ -1,100 +1,110 @@
-import {describe, expect, it} from 'vitest'
-import {KeyshelfError} from '../../src/errors.js'
-import type {Config, Environment, LoadedEnvironment, Schema} from '../../src/model.js'
-import {validateEnvironment} from '../../src/validate.js'
+import { describe, expect, it } from "vitest";
+import { KeyshelfError } from "../../src/errors.js";
+import type { Config, Environment, LoadedEnvironment, Schema } from "../../src/model.js";
+import { validateEnvironment } from "../../src/validate.js";
 
 const config: Config = {
-  project: 'myapp',
-  providers: {local: {adapter: 'sops'}, 'gcp-staging': {adapter: 'gcp', projectId: 'p'}},
-}
+  project: "myapp",
+  providers: { local: { adapter: "sops" }, "gcp-staging": { adapter: "gcp", projectId: "p" } }
+};
 
 const schema: Schema = {
   keys: {
-    LOG_LEVEL: {kind: 'config', default: 'info'},
-    REGION: {kind: 'required'},
-    FEATURE_X: {kind: 'optional'},
-    DATABASE_PASSWORD: {kind: 'required'},
-  },
-}
+    LOG_LEVEL: { kind: "config", default: "info" },
+    REGION: { kind: "required" },
+    FEATURE_X: { kind: "optional" },
+    DATABASE_PASSWORD: { kind: "required" }
+  }
+};
 
 function env(overrides: Partial<Environment> = {}): Environment {
   return {
-    shelf: 'web',
-    name: 'staging',
-    provider: 'local',
+    shelf: "web",
+    name: "staging",
+    provider: "local",
     keys: {
-      REGION: {kind: 'config', value: 'eu-west-1'},
-      DATABASE_PASSWORD: {kind: 'secret'},
+      REGION: { kind: "config", value: "eu-west-1" },
+      DATABASE_PASSWORD: { kind: "secret" }
     },
-    ...overrides,
-  }
+    ...overrides
+  };
 }
 
 function loaded(environment: Environment): LoadedEnvironment {
-  return {config, schema, environment}
+  return { config, schema, environment };
 }
 
-describe('validateEnvironment', () => {
-  it('passes a well-formed environment (returns no errors)', () => {
-    expect(() => validateEnvironment(loaded(env()))).not.toThrow()
-  })
+describe("validateEnvironment", () => {
+  it("passes a well-formed environment (returns no errors)", () => {
+    expect(() => validateEnvironment(loaded(env()))).not.toThrow();
+  });
 
-  it('does not require restating defaulted config keys', () => {
+  it("does not require restating defaulted config keys", () => {
     // LOG_LEVEL has a default and FEATURE_X is optional; both omitted is fine.
-    expect(() => validateEnvironment(loaded(env()))).not.toThrow()
-  })
+    expect(() => validateEnvironment(loaded(env()))).not.toThrow();
+  });
 
-  it('allows an optional key to be absent', () => {
+  it("allows an optional key to be absent", () => {
     // FEATURE_X is !optional and not supplied — still valid.
-    expect(() => validateEnvironment(loaded(env()))).not.toThrow()
-  })
+    expect(() => validateEnvironment(loaded(env()))).not.toThrow();
+  });
 
-  it('accepts a !secret value structurally without resolving it', () => {
-    const e = env({keys: {REGION: {kind: 'config', value: 'eu'}, DATABASE_PASSWORD: {kind: 'secret', ref: {ref: 'x'}}}})
-    expect(() => validateEnvironment(loaded(e))).not.toThrow()
-  })
+  it("accepts a !secret value structurally without resolving it", () => {
+    const e = env({
+      keys: {
+        REGION: { kind: "config", value: "eu" },
+        DATABASE_PASSWORD: { kind: "secret", ref: { ref: "x" } }
+      }
+    });
+    expect(() => validateEnvironment(loaded(e))).not.toThrow();
+  });
 
   function expectCode(fn: () => void, code: string, fields?: Record<string, unknown>): void {
-    let thrown: unknown
+    let thrown: unknown;
     try {
-      fn()
+      fn();
     } catch (error) {
-      thrown = error
+      thrown = error;
     }
 
-    expect(thrown).toBeInstanceOf(KeyshelfError)
-    const err = thrown as KeyshelfError
-    expect(err.code).toBe(code)
-    if (fields) expect(err.fields).toMatchObject(fields)
+    expect(thrown).toBeInstanceOf(KeyshelfError);
+    const err = thrown as KeyshelfError;
+    expect(err.code).toBe(code);
+    if (fields) expect(err.fields).toMatchObject(fields);
   }
 
-  it('rejects a key not declared in the schema with UNKNOWN_KEY', () => {
-    const e = env({keys: {...env().keys, EXTRA: {kind: 'config', value: 'x'}}})
-    expectCode(() => validateEnvironment(loaded(e)), 'UNKNOWN_KEY', {key: 'EXTRA', environment: 'web/staging'})
-  })
+  it("rejects a key not declared in the schema with UNKNOWN_KEY", () => {
+    const e = env({ keys: { ...env().keys, EXTRA: { kind: "config", value: "x" } } });
+    expectCode(() => validateEnvironment(loaded(e)), "UNKNOWN_KEY", {
+      key: "EXTRA",
+      environment: "web/staging"
+    });
+  });
 
-  it('rejects a missing !required key with MISSING_REQUIRED', () => {
-    const e = env({keys: {REGION: {kind: 'config', value: 'eu'}}}) // DATABASE_PASSWORD missing
-    expectCode(() => validateEnvironment(loaded(e)), 'MISSING_REQUIRED', {key: 'DATABASE_PASSWORD'})
-  })
+  it("rejects a missing !required key with MISSING_REQUIRED", () => {
+    const e = env({ keys: { REGION: { kind: "config", value: "eu" } } }); // DATABASE_PASSWORD missing
+    expectCode(() => validateEnvironment(loaded(e)), "MISSING_REQUIRED", {
+      key: "DATABASE_PASSWORD"
+    });
+  });
 
-  it('rejects an invalid env-var key name with INVALID_KEY_NAME', () => {
-    const e = env({keys: {...env().keys, 'bad-key': {kind: 'config', value: 'x'}}})
-    expectCode(() => validateEnvironment(loaded(e)), 'INVALID_KEY_NAME', {key: 'bad-key'})
-  })
+  it("rejects an invalid env-var key name with INVALID_KEY_NAME", () => {
+    const e = env({ keys: { ...env().keys, "bad-key": { kind: "config", value: "x" } } });
+    expectCode(() => validateEnvironment(loaded(e)), "INVALID_KEY_NAME", { key: "bad-key" });
+  });
 
-  it('rejects a lowercase-leading key name with INVALID_KEY_NAME', () => {
-    const e = env({keys: {...env().keys, region: {kind: 'config', value: 'x'}}})
-    expectCode(() => validateEnvironment(loaded(e)), 'INVALID_KEY_NAME', {key: 'region'})
-  })
+  it("rejects a lowercase-leading key name with INVALID_KEY_NAME", () => {
+    const e = env({ keys: { ...env().keys, region: { kind: "config", value: "x" } } });
+    expectCode(() => validateEnvironment(loaded(e)), "INVALID_KEY_NAME", { key: "region" });
+  });
 
-  it('rejects a digit-leading key name with INVALID_KEY_NAME', () => {
-    const e = env({keys: {...env().keys, '1ST': {kind: 'config', value: 'x'}}})
-    expectCode(() => validateEnvironment(loaded(e)), 'INVALID_KEY_NAME', {key: '1ST'})
-  })
+  it("rejects a digit-leading key name with INVALID_KEY_NAME", () => {
+    const e = env({ keys: { ...env().keys, "1ST": { kind: "config", value: "x" } } });
+    expectCode(() => validateEnvironment(loaded(e)), "INVALID_KEY_NAME", { key: "1ST" });
+  });
 
-  it('rejects an undefined provider reference with PROVIDER_NOT_FOUND', () => {
-    const e = env({provider: 'nope'})
-    expectCode(() => validateEnvironment(loaded(e)), 'PROVIDER_NOT_FOUND', {provider: 'nope'})
-  })
-})
+  it("rejects an undefined provider reference with PROVIDER_NOT_FOUND", () => {
+    const e = env({ provider: "nope" });
+    expectCode(() => validateEnvironment(loaded(e)), "PROVIDER_NOT_FOUND", { provider: "nope" });
+  });
+});

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,8 +1,8 @@
-import {defineConfig} from 'vitest/config'
+import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    include: ['test/**/*.test.ts'],
-    testTimeout: 30_000,
-  },
-})
+    include: ["test/**/*.test.ts"],
+    testTimeout: 30_000
+  }
+});


### PR DESCRIPTION
Closes #176

The v6 MVP under `packages/cli` (oclif CLI, YAML config, fake/sops/gcp adapters) was developed without the repo's eslint / prettier / fallow / Codacy gates, so they failed on the imported source after the structural cutover. This reconciles all of them and re-arms `lint` + `format:check` in CI.

## eslint (`npm run lint` — was 7 errors)
- Dropped two dead `no-await-in-loop` disable directives (the rule isn't enabled in `eslint.config.js`).
- Attached the caught error as `cause` in the two `captureError` test helpers (`preserve-caught-error`).
- Replaced `any` with a typed generic in the `init` e2e `readYaml` helper.
- Dropped an unused `writeFile` import; converted two `require('node:fs')` calls to a top-level `existsSync` import.
- Kept the TSDoc-only `KeyshelfError` import in `adapter.ts` behind a justified `eslint-disable` (it resolves `{@link}`/`@throws` references).

## prettier (`npm run format:check`)
- `prettier --write .` brings the tree into line with the root `.prettierrc` (double quotes + semicolons). This is the bulk of the diff.
- Added generated artifacts (`oclif.manifest.json`, `platforms/`, `.cache/`) to `.prettierignore` so the check is stable whether or not someone built locally.

## fallow (CRAP 110 complexity + clone groups)
- **Complexity:** refactored the hotspot `main` entrypoints without behavior change — extracted `resolveTargets` / `buildPlatform` / `smokeTestHost` from `scripts/build-platforms.ts` and `publishAll` / `verifyHostOnlyInstall` / `installedSopsPackages` from `scripts/verdaccio-verify.ts`, shrinking each `main`'s branch count.
- **Clones:** deduped the byte-identical `captureError` helper into `test/support/capture-error.ts`. The two `runKeyshelf` helpers were left as-is — their semantics genuinely differ (hermetic installed-bin run vs. repo-bin run) and both live under fallow's already-ignored `**/test/**` duplicates glob; merging would harm clarity.
- Repointed `.fallowrc.json` `entry` at the v6 roots (oclif `bin/run.js`, the dynamically-loaded `src/commands/*.ts`, and the npm-invoked `scripts/*.ts`) and removed the dead `packages/action` / `packages/migrate` references.

## Codacy
- Excluded generated artifacts and the stale `examples/` (rewritten under #179) so they don't gate this change.

## Tooling drift
- `.editorconfig`: `indent_size` set to 2 to match Prettier (was 4) — removes editor/formatter churn.
- `.gitignore`: removed the dead `!packages/action/dist` and `packages/migrate/...` exception lines. The v6 build/sops artifacts are already covered by `packages/cli/.gitignore`.
- `package.json`: dropped the broken `typecheck:examples` script (pointed at the removed v5 TS-config examples). **Depends on #179**, which rewrites the examples; the script can be reintroduced there if still wanted.

## CI
- Added a dedicated, sops-free `quality` job to `ci.yml` running `lint` + `format:check`, so they gate every PR again (runs in parallel with the heavier `test` job for fast feedback).

## Local verification
`npm run lint`, `npm run format:check`, `npm run typecheck`, `npm run build`, and `npm test` (183 passed / 3 skipped) all pass in the worktree. fallow runs only in CI (Rust binary, no local cargo), so its resolution is verified by the `fallow` check on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnKDVDBMEALW2aaoNT5Xgm