### PR TITLE
chore: reseed release-please for single keyshelf package at 6.0.0

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,3 @@
 {
-  "packages/cli": "5.4.0",
-  "packages/action": "1.4.0",
-  "packages/migrate": "1.2.1"
+  "packages/cli": "6.0.0"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,18 +2,9 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
   "include-component-in-tag": true,
-  "separate-pull-requests": true,
-  "plugins": ["node-workspace"],
   "packages": {
     "packages/cli": {
       "package-name": "keyshelf"
-    },
-    "packages/action": {
-      "package-name": "keyshelf-action"
-    },
-    "packages/migrate": {
-      "package-name": "@keyshelf/migrate",
-      "component": "migrate"
     }
   }
 }


### PR DESCRIPTION
Reconfigures the release-please machinery for the post-cutover single-package layout so the next release cuts `keyshelf@6.0.0` cleanly.

The v6 cutover removed `packages/action` (`keyshelf-action`) and `packages/migrate` (`@keyshelf/migrate`), but the release-please config + manifest still referenced them and still pinned `keyshelf` at `5.4.0`.

## Changes

**`release-please-config.json`**
- Keep only `packages/cli` → `package-name: keyshelf`; drop the `packages/action` and `packages/migrate` entries.
- Remove `separate-pull-requests` and the `node-workspace` plugin — both are no-ops with a single package.
- Keep `include-component-in-tag: true`.

**`.release-please-manifest.json`**
- Reseed `packages/cli` to `6.0.0` (was `5.4.0`); drop the action/migrate baselines.

## Decision: `include-component-in-tag` / tag scheme

Kept `include-component-in-tag: true`, so the next release tags as `keyshelf-v6.0.0`. Reasoning:
- The current released package is tagged `keyshelf-v5.4.0`; the `keyshelf-v*` scheme has been in place since `keyshelf-v4.4.0`.
- Switching to plain `vX.Y.Z` would collide with the pre-4.4 plain-tag history (`v4.3.0`, `v4.2.1`, …) and break tag continuity.
- Keeping the component prefix preserves a clean, monotonic `keyshelf-v5.4.0` → `keyshelf-v6.0.0` progression.

## Validation

- Both JSON files are well-formed and retain their `$schema` reference.
- No leftover `keyshelf-action` / `@keyshelf/migrate` references in any release-please config.
- The `release-please` job in `ci.yml` still points at `release-please-config.json` + `.release-please-manifest.json` (valid paths, single package) — no CI rework needed.

## Out of scope (left untouched)

- `package-lock.json` still carries stale `packages/action` / `packages/migrate` entries (the dirs are gone on disk). That's lockfile/tooling state, not release-please config, so it's outside this issue's scope.

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnKDVDBMEALW2aaoNT5Xgm