### PR TITLE
Adopt keyshelf__-prefixed, __-separated gcp secret naming convention

### DIFF
--- a/docs/adr/0006-gcp-secret-manager-adapter.md
+++ b/docs/adr/0006-gcp-secret-manager-adapter.md
@@ -20,14 +20,25 @@ Concrete choices:
   the lazy-load complexity.
 
 - **Naming: one secret per key, by the fixed reference convention.** A key maps to
-  a Secret Manager _secret_ whose id is `{project}-{shelf}-{env}-{key}`, in the
-  provider's `projectId`. The `{project}-{shelf}-{env}` prefix (the adapter's
-  _namespace_) keeps the same key distinct across environments and shelves in a
-  shared backend. `write` returns that id, which is exactly what `set` resolves by
-  — so a convention write records a _bare_ `!secret`. An explicit
+  a Secret Manager _secret_ whose id is `keyshelf__{project}__{shelf}__{env}__{key}`,
+  in the provider's `projectId`. The `keyshelf__{project}__{shelf}__{env}` prefix
+  (the adapter's _namespace_) keeps the same key distinct across environments and
+  shelves in a shared backend. `write` returns that id, which is exactly what `set`
+  resolves by — so a convention write records a _bare_ `!secret`. An explicit
   `!secret { ref: NAME }` resolves a differently-named secret; a `NAME` that is a
   full `projects/.../secrets/...` resource path resolves a foreign secret in any
   project.
+
+  The `keyshelf__`-prefixed, `__`-separated form echoes keyshelf v5's styling
+  (v5 was `keyshelf__{project}__{env}__{key}`, no shelf) on the v6 component
+  structure. The double-underscore separator is more parse-robust than a single
+  `-` when project/shelf/env names themselves contain hyphens. GCP secret ids
+  allow `[a-zA-Z0-9_-]`, so the underscores are valid, and v6 keys are single
+  tokens matching `^[A-Z_][A-Z0-9_]*$` (never `/`-paths), so the composed id is
+  unambiguous. This is intentionally **not byte-compatible** with secrets v5
+  wrote: v6 inserts the `shelf` component, so a v6 convention name never collides
+  with a v5 one and does not auto-resolve v5 secrets — migration is handled
+  separately (#180).
 
 - **Value encoding: JSON string, mirroring `sops`.** Secret Manager payloads are
   raw bytes, but it **rejects an empty payload** — and the contract requires an
@@ -58,7 +69,7 @@ trades a slightly larger install for simpler, branch-free code; the asymmetry wi
 the optional `sops` packages is deliberate and rooted in sops being a native
 per-platform binary, which the SDK is not.
 
-One-secret-per-key with the fixed `{project}-{shelf}-{env}-{key}` convention is the
+One-secret-per-key with the fixed `keyshelf__{project}__{shelf}__{env}__{key}` convention is the
 same model `fake` already implements and `set` already resolves by, so the gcp
 adapter slots into the existing reference-adapter behaviour with no new wiring in
 callers. Carrying values as JSON strings reuses the proven sops trick and is the

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -37,7 +37,7 @@ providers:
 - A provider entry is a named map with an `adapter:` discriminator plus
   adapter-specific fields. Providers are project-global.
 - Reference adapters (e.g. `gcp`) name remote secrets by the **fixed** convention
-  `{project}-{shelf}-{env}-{key}`. No configurable template; the only override is
+  `keyshelf__{project}__{shelf}__{env}__{key}`. No configurable template; the only override is
   a per-key explicit reference. A missing required adapter field (e.g. `gcp`'s
   `projectId`) is a `MALFORMED_FILE`.
 

--- a/examples/04-secret-provider/.keyshelf/.fake-store.json
+++ b/examples/04-secret-provider/.keyshelf/.fake-store.json
@@ -1,4 +1,4 @@
 {
-  "example-secrets-api-production-DATABASE_PASSWORD": "s3cr3t-pw",
+  "keyshelf__example-secrets__api__production__DATABASE_PASSWORD": "s3cr3t-pw",
   "shared-github-token": "ghp_exampletoken000000000000000000000000"
 }

--- a/examples/04-secret-provider/.keyshelf/api/production.yaml
+++ b/examples/04-secret-provider/.keyshelf/api/production.yaml
@@ -1,8 +1,8 @@
 # DATABASE_URL is plaintext config, committed in the clear.
 #
 # DATABASE_PASSWORD is a bare `!secret`: resolved by convention. Its value lives in
-# the store under the composed name `{project}-{shelf}-{env}-{key}`
-# (example-secrets-api-production-DATABASE_PASSWORD), never in this file.
+# the store under the composed name `keyshelf__{project}__{shelf}__{env}__{key}`
+# (keyshelf__example-secrets__api__production__DATABASE_PASSWORD), never in this file.
 #
 # GITHUB_TOKEN uses an explicit reference: it points at a pre-existing/shared
 # secret by its stored name instead of the per-environment convention — useful for

--- a/examples/05-multi-shelf/.keyshelf/.fake-store.json
+++ b/examples/05-multi-shelf/.keyshelf/.fake-store.json
@@ -1,4 +1,4 @@
 {
-  "example-multishelf-web-service-staging-SESSION_SECRET": "web-session-secret",
-  "example-multishelf-worker-staging-SESSION_SECRET": "worker-session-secret"
+  "keyshelf__example-multishelf__web-service__staging__SESSION_SECRET": "web-session-secret",
+  "keyshelf__example-multishelf__worker__staging__SESSION_SECRET": "worker-session-secret"
 }

--- a/examples/05-multi-shelf/.keyshelf/config.yaml
+++ b/examples/05-multi-shelf/.keyshelf/config.yaml
@@ -2,7 +2,7 @@ project: example-multishelf
 
 # Providers are declared once and are project-global: both shelves below reference
 # the same `local` provider. The project name also namespaces secrets in shared
-# backends, composed as `{project}-{shelf}-{env}-{key}` — so the same key in two
+# backends, composed as `keyshelf__{project}__{shelf}__{env}__{key}` — so the same key in two
 # shelves stays distinct.
 providers:
   local:

--- a/package-lock.json
+++ b/package-lock.json
@@ -11173,22 +11173,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "packages/action": {
-      "name": "@keyshelf/action",
-      "version": "1.4.0",
-      "extraneous": true,
-      "license": "MIT",
-      "devDependencies": {
-        "@types/node": "^25.5.0",
-        "keyshelf": "file:../cli",
-        "tsup": "^8.5.1",
-        "typescript": "^6.0.3",
-        "vitest": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
     "packages/cli": {
       "name": "keyshelf",
       "version": "6.0.0",
@@ -11486,31 +11470,6 @@
         "jsdom": {
           "optional": true
         }
-      }
-    },
-    "packages/migrate": {
-      "name": "@keyshelf/migrate",
-      "version": "1.2.1",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "@google-cloud/secret-manager": "^6.1.1",
-        "commander": "^14.0.3",
-        "js-yaml": "^4.1.1"
-      },
-      "bin": {
-        "keyshelf-migrate": "dist/cli.js"
-      },
-      "devDependencies": {
-        "@types/js-yaml": "^4.0.9",
-        "@types/node": "^25.5.0",
-        "keyshelf": "file:../cli",
-        "tsup": "^8.5.1",
-        "typescript": "^6.0.3",
-        "vitest": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=18"
       }
     }
   }

--- a/packages/cli/src/adapters/adapter.ts
+++ b/packages/cli/src/adapters/adapter.ts
@@ -28,7 +28,7 @@ export interface Adapter {
    * Fetch a secret's plaintext value from the store.
    *
    * @param key  the environment key name. By convention it locates the value in
-   *   the store (the reference adapters compose it as `{project}-{shelf}-{env}-{key}`).
+   *   the store (the reference adapters compose it as `keyshelf__{project}__{shelf}__{env}__{key}`).
    * @param ref  the optional explicit reference payload from a
    *   `!secret { ref: ... }`, which overrides the convention to resolve a
    *   differently-named or foreign stored value. `undefined` means

--- a/packages/cli/src/adapters/fake.ts
+++ b/packages/cli/src/adapters/fake.ts
@@ -75,8 +75,9 @@ export function fileStore(filePath: string): FakeStore {
  * implements the two-method contract against a {@link FakeStore}.
  *
  * Naming faithfully mirrors the reference-adapter convention
- * (`{project}-{shelf}-{env}-{key}`, docs/reference.md): the `namespace` is the
- * `{project}-{shelf}-{env}` prefix, so the same key in two environments stays
+ * (`keyshelf__{project}__{shelf}__{env}__{key}`, docs/reference.md): the
+ * `namespace` is the `keyshelf__{project}__{shelf}__{env}` prefix, so the same
+ * key in two environments stays
  * distinct in a shared store. A `!secret` resolves by convention (under the key's
  * composed name) unless an explicit `ref` string overrides it with a foreign
  * stored name.

--- a/packages/cli/src/adapters/gcp.ts
+++ b/packages/cli/src/adapters/gcp.ts
@@ -11,9 +11,10 @@ import { conventionName, firstLine, refName } from "./shared.js";
  * the metadata server — so Keyshelf owns no credentials of its own.
  *
  * **Store.** One secret per key in the configured `projectId`, named by the fixed
- * reference convention `{project}-{shelf}-{env}-{key}` (docs/reference.md). The
- * `{project}-{shelf}-{env}` prefix is the adapter's `namespace`, so the same key
- * in two environments stays distinct in the shared backend. `location` selects
+ * reference convention `keyshelf__{project}__{shelf}__{env}__{key}`
+ * (docs/reference.md). The `keyshelf__{project}__{shelf}__{env}` prefix is the
+ * adapter's `namespace`, so the same key in two environments stays distinct in
+ * the shared backend. `location` selects
  * the replication policy: absent or `global` ⇒ automatic replication; any other
  * value ⇒ user-managed replication pinned to that single region.
  *

--- a/packages/cli/src/adapters/registry.ts
+++ b/packages/cli/src/adapters/registry.ts
@@ -9,9 +9,9 @@ import { SopsAdapter } from "./sops.js";
 /**
  * Everything an adapter needs to bind to a concrete environment's store. The
  * reference-adapter convention composes a remote secret's name from
- * `{project}-{shelf}-{env}-{key}` (docs/reference.md), so the project, shelf, and
- * environment names are part of the construction context, not just the provider
- * config.
+ * `keyshelf__{project}__{shelf}__{env}__{key}` (docs/reference.md), so the
+ * project, shelf, and environment names are part of the construction context,
+ * not just the provider config.
  */
 export interface AdapterContext {
   /** The project root directory (where `.keyshelf/` lives). */
@@ -71,13 +71,13 @@ export function createAdapter(provider: Provider, ctx: AdapterContext): Adapter 
       // Persist to a JSON file under the project so a value written in one
       // `keyshelf` process is resolvable by a separate process later (the E2E
       // suite spawns the real binary across invocations). The namespace mirrors
-      // the reference convention `{project}-{shelf}-{env}` so the same key in
-      // different environments stays distinct in the shared store.
+      // the reference convention `keyshelf__{project}__{shelf}__{env}` so the
+      // same key in different environments stays distinct in the shared store.
       const storePath =
         typeof provider.store === "string"
           ? path.resolve(ctx.projectDir, provider.store)
           : path.join(ctx.projectDir, FAKE_STORE_FILE);
-      const namespace = `${ctx.project}-${ctx.shelf}-${ctx.env}`;
+      const namespace = `keyshelf__${ctx.project}__${ctx.shelf}__${ctx.env}`;
       return new FakeAdapter(fileStore(storePath), namespace);
     }
 
@@ -90,13 +90,13 @@ export function createAdapter(provider: Provider, ctx: AdapterContext): Adapter 
 
     case "gcp": {
       // One secret per key in the provider's GCP project, named by the reference
-      // convention `{project}-{shelf}-{env}-{key}`; the namespace is the
-      // `{project}-{shelf}-{env}` prefix so the same key across environments
-      // stays distinct in the shared backend. `location` is an optional
-      // replication hint (absent/`global` ⇒ automatic).
+      // convention `keyshelf__{project}__{shelf}__{env}__{key}`; the namespace is
+      // the `keyshelf__{project}__{shelf}__{env}` prefix so the same key across
+      // environments stays distinct in the shared backend. `location` is an
+      // optional replication hint (absent/`global` ⇒ automatic).
       const projectId = requireStringField(provider, "projectId", ctx);
       const location = typeof provider.location === "string" ? provider.location : undefined;
-      const namespace = `${ctx.project}-${ctx.shelf}-${ctx.env}`;
+      const namespace = `keyshelf__${ctx.project}__${ctx.shelf}__${ctx.env}`;
       return new GcpAdapter({ projectId, namespace, location });
     }
 

--- a/packages/cli/src/adapters/shared.ts
+++ b/packages/cli/src/adapters/shared.ts
@@ -7,9 +7,9 @@ import { KeyshelfError } from "../errors.js";
  * is exactly what the adapter contract (ADR-0005) requires.
  */
 
-/** Compose the convention stored-name for a key: `{namespace}-{key}` (bare key when unnamespaced). */
+/** Compose the convention stored-name for a key: `{namespace}__{key}` (bare key when unnamespaced). */
 export function conventionName(namespace: string, key: string): string {
-  return namespace === "" ? key : `${namespace}-${key}`;
+  return namespace === "" ? key : `${namespace}__${key}`;
 }
 
 /**

--- a/packages/cli/src/commands/set.ts
+++ b/packages/cli/src/commands/set.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import * as readline from "node:readline/promises";
 import { parseDocument } from "yaml";
 import { createAdapter } from "../adapters/registry.js";
+import { conventionName } from "../adapters/shared.js";
 import { BaseCommand } from "../base-command.js";
 import { KeyshelfError } from "../errors.js";
 import { loadEnvironment } from "../loader.js";
@@ -140,9 +141,13 @@ export default class Set extends BaseCommand {
     });
     const ref = await adapter.write(key, value);
 
-    // The fake/reference convention names a secret `{project}-{shelf}-{env}-{key}`;
-    // a returned ref matching that resolves by convention (bare !secret).
-    const conventionRef = `${loaded.config.project}-${shelf}-${env}-${key}`;
+    // The fake/reference convention names a secret
+    // `keyshelf__{project}__{shelf}__{env}__{key}`; a returned ref matching that
+    // resolves by convention (bare !secret).
+    const conventionRef = conventionName(
+      `keyshelf__${loaded.config.project}__${shelf}__${env}`,
+      key
+    );
     setSecretRef(doc, key, secretRefForm(ref, conventionRef));
   }
 

--- a/packages/cli/test/e2e/run.e2e.test.ts
+++ b/packages/cli/test/e2e/run.e2e.test.ts
@@ -242,8 +242,8 @@ describe("keyshelf run <shelf>/<env> -- <cmd>", () => {
 
   it("resolves a !secret through the provider adapter by convention and injects it", async () => {
     await scaffold();
-    // Namespace mirrors the registry convention {project}-{shelf}-{env}.
-    await seedFakeStore({ "myapp-web-staging-EXTRA_SECRET": "s3cr3t-value" });
+    // Namespace mirrors the registry convention keyshelf__{project}__{shelf}__{env}.
+    await seedFakeStore({ keyshelf__myapp__web__staging__EXTRA_SECRET: "s3cr3t-value" });
     await write(
       ".keyshelf/web/staging.yaml",
       "provider: store\nkeys:\n  REGION: eu\n  EXTRA_SECRET: !secret\n"

--- a/packages/cli/test/e2e/set.e2e.test.ts
+++ b/packages/cli/test/e2e/set.e2e.test.ts
@@ -184,7 +184,7 @@ describe("keyshelf set <KEY> <shelf>/<env> --secret", () => {
 
     // The value lives in the fake store under the convention name.
     const store = JSON.parse(await read(".keyshelf/.fake-store.json"));
-    expect(store["myapp-web-staging-DATABASE_PASSWORD"]).toBe(secret);
+    expect(store["keyshelf__myapp__web__staging__DATABASE_PASSWORD"]).toBe(secret);
   });
 
   it("round-trips: set --secret then run resolves the stored value via fake", async () => {

--- a/packages/cli/test/e2e/validate.e2e.test.ts
+++ b/packages/cli/test/e2e/validate.e2e.test.ts
@@ -46,9 +46,9 @@ async function scaffold(): Promise<void> {
   await write(".keyshelf/web/staging.yaml", GOOD_ENV);
   // "valid means would run": the declared secret must be resolvable.
   await seedFakeStore({
-    "myapp-web-staging-DATABASE_PASSWORD": "pw",
-    "myapp-web-prod-DATABASE_PASSWORD": "pw",
-    "myapp-api-dev-TOKEN": "tok"
+    keyshelf__myapp__web__staging__DATABASE_PASSWORD: "pw",
+    keyshelf__myapp__web__prod__DATABASE_PASSWORD: "pw",
+    keyshelf__myapp__api__dev__TOKEN: "tok"
   });
 }
 
@@ -215,7 +215,7 @@ describe("keyshelf validate (whole project)", () => {
     await write(".keyshelf/api/schema.yaml", "keys:\n  TOKEN: !required\n");
     await write(".keyshelf/api/dev.yaml", "provider: store\nkeys:\n  TOKEN: !secret\n");
     // Store seeds web/staging's secret but NOT api/dev's TOKEN.
-    await seedFakeStore({ "myapp-web-staging-DATABASE_PASSWORD": "pw" });
+    await seedFakeStore({ keyshelf__myapp__web__staging__DATABASE_PASSWORD: "pw" });
 
     const { code, stdout } = await runKeyshelf(["validate", "--json"], { cwd });
     expect(code).not.toBe(0);

--- a/packages/cli/test/unit/gcp.test.ts
+++ b/packages/cli/test/unit/gcp.test.ts
@@ -66,7 +66,7 @@ function adapter(
 ): GcpAdapter {
   return new GcpAdapter({
     projectId: "test-proj",
-    namespace: opts?.namespace ?? "myapp-web-staging",
+    namespace: opts?.namespace ?? "keyshelf__myapp__web__staging",
     location: opts?.location,
     client
   });
@@ -74,10 +74,10 @@ function adapter(
 
 describe("GcpAdapter", () => {
   describe("naming convention", () => {
-    it("stores under {namespace}-{key} and returns that id from write", async () => {
+    it("stores under {namespace}__{key} and returns that id from write", async () => {
       const { client } = fakeClient();
       const ref = await adapter(client).write("DATABASE_PASSWORD", "sekret");
-      expect(ref).toBe("myapp-web-staging-DATABASE_PASSWORD");
+      expect(ref).toBe("keyshelf__myapp__web__staging__DATABASE_PASSWORD");
     });
 
     it("resolves a value written by convention", async () => {
@@ -89,8 +89,8 @@ describe("GcpAdapter", () => {
 
     it("keeps the same key in different namespaces distinct", async () => {
       const { client } = fakeClient();
-      const staging = adapter(client, { namespace: "myapp-web-staging" });
-      const prod = adapter(client, { namespace: "myapp-web-prod" });
+      const staging = adapter(client, { namespace: "keyshelf__myapp__web__staging" });
+      const prod = adapter(client, { namespace: "keyshelf__myapp__web__prod" });
       await staging.write("TOKEN", "staging-token");
       await prod.write("TOKEN", "prod-token");
       expect(await staging.resolve("TOKEN")).toBe("staging-token");

--- a/packages/cli/test/unit/set.test.ts
+++ b/packages/cli/test/unit/set.test.ts
@@ -8,22 +8,24 @@ import { secretRefForm, setConfigValue, setSecretRef } from "../../src/set.js";
 
 describe("secretRefForm", () => {
   it("is bare when the adapter ref equals the convention name", () => {
-    expect(secretRefForm("myapp-web-staging-DB", "myapp-web-staging-DB")).toEqual({ bare: true });
+    expect(
+      secretRefForm("keyshelf__myapp__web__staging__DB", "keyshelf__myapp__web__staging__DB")
+    ).toEqual({ bare: true });
   });
 
   it("is bare when the adapter returns undefined (convention-resolvable)", () => {
-    expect(secretRefForm(undefined, "myapp-web-staging-DB")).toEqual({ bare: true });
+    expect(secretRefForm(undefined, "keyshelf__myapp__web__staging__DB")).toEqual({ bare: true });
   });
 
   it("carries an explicit { ref } when the adapter ref is foreign", () => {
-    expect(secretRefForm("shared-db-url", "myapp-web-staging-DB")).toEqual({
+    expect(secretRefForm("shared-db-url", "keyshelf__myapp__web__staging__DB")).toEqual({
       bare: false,
       ref: "shared-db-url"
     });
   });
 
   it("carries an explicit { ref } when the adapter returns a non-string payload", () => {
-    expect(secretRefForm({ name: "x" }, "myapp-web-staging-DB")).toEqual({
+    expect(secretRefForm({ name: "x" }, "keyshelf__myapp__web__staging__DB")).toEqual({
       bare: false,
       ref: { name: "x" }
     });

--- a/skills/keyshelf/SKILL.md
+++ b/skills/keyshelf/SKILL.md
@@ -127,13 +127,13 @@ Conversely, a `!required` key with no value in some environment is a `MISSING_RE
 
 Reference adapters (e.g. `gcp`) name remote secrets by the **fixed** convention:
 
-```
-{project}-{shelf}-{env}-{key}
+```text
+keyshelf__{project}__{shelf}__{env}__{key}
 ```
 
-(verified in `concierge/src/commands/set.ts` and `concierge/src/adapters/gcp.ts`). So `web/staging`'s `DATABASE_PASSWORD` in project `myapp` is stored as `myapp-web-staging-DATABASE_PASSWORD`. There is no configurable template — the only override is a per-key explicit reference (`!secret { ref: ... }`, e.g. to point at a foreign or pre-existing secret). Implications:
+(verified in `concierge/src/commands/set.ts` and `concierge/src/adapters/gcp.ts`). So `web/staging`'s `DATABASE_PASSWORD` in project `myapp` is stored as `keyshelf__myapp__web__staging__DATABASE_PASSWORD`. There is no configurable template — the only override is a per-key explicit reference (`!secret { ref: ... }`, e.g. to point at a foreign or pre-existing secret). Implications:
 
-- The same key in two environments stays distinct in a shared backend (the `{project}-{shelf}-{env}` prefix is the namespace).
+- The same key in two environments stays distinct in a shared backend (the `keyshelf__{project}__{shelf}__{env}` prefix is the namespace).
 - Renaming the project, shelf, environment, or key changes the remote secret's name — the old value is **not** automatically migrated.
 - For sops, the store is the per-environment sibling file `{shelf}/{env}.secrets.yaml`; convention resolution there is simply by key name within that file.
 
@@ -148,7 +148,7 @@ If a managed key already exists in your shell environment, keyshelf's resolved v
 ## Adapters
 
 - **`sops`** — local, file-based encrypted secrets. The store is a committed, encrypted sibling file `{shelf}/{env}.secrets.yaml`. Keyshelf owns no crypto of its own: it shells out to a `sops` binary (bundled per-platform, with any `sops` on `PATH` as a fallback). Recipients are governed entirely by the project's native `.sops.yaml`, which keyshelf never writes or mutates. Hermetic — works in CI with no external service.
-- **`gcp`** — Google Cloud Secret Manager. One secret per key, named by the `{project}-{shelf}-{env}-{key}` convention in the provider's `projectId`. Authentication is Application Default Credentials (the SDK discovers them; keyshelf holds no credentials). `location` selects replication: absent/`global` ⇒ automatic; any other value ⇒ user-managed, pinned to that region.
+- **`gcp`** — Google Cloud Secret Manager. One secret per key, named by the `keyshelf__{project}__{shelf}__{env}__{key}` convention in the provider's `projectId`. Authentication is Application Default Credentials (the SDK discovers them; keyshelf holds no credentials). `location` selects replication: absent/`global` ⇒ automatic; any other value ⇒ user-managed, pinned to that region.
 - **`fake`** — an in-memory adapter for tests only. Don't reach for it in a real project.
 
 A missing backend prerequisite (e.g. the `sops` binary) surfaces as `ADAPTER_UNAVAILABLE`; a credential/decryption failure as `PROVIDER_AUTH`; a referenced secret absent from the store as `SECRET_NOT_FOUND`.


### PR DESCRIPTION
## What

Change the v6 reference-adapter (gcp/fake) secret naming convention from `{project}-{shelf}-{env}-{key}` to a keyshelf-prefixed, double-underscore form:

```text
keyshelf__{project}__{shelf}__{env}__{key}
```

e.g. `keyshelf__myapp__web__staging__DATABASE_PASSWORD`

## Why

Echoes keyshelf v5's `keyshelf__`-prefixed, `__`-separated style (v5 was `keyshelf__{project}__{env}__{key}`, no shelf) on the v6 component structure. The `__` separator is more parse-robust than a single `-` when project/shelf/env names contain hyphens (e.g. the `web-service` shelf in example 05). GCP secret ids allow `[a-zA-Z0-9_-]` and v6 keys are single tokens (`^[A-Z_][A-Z0-9_]*$`, never `/`-paths), so the composed id is unambiguous.

This is intentionally **NOT byte-compatible** with v5 secrets: v6 inserts the `shelf` component, so it does not auto-resolve secrets v5 wrote — migration is handled separately (#180).

## Changes

- **Code:** `shared.ts` `conventionName` joins with `__`; `registry.ts` (fake + gcp sites) namespace is `keyshelf__${project}__${shelf}__${env}`; `commands/set.ts` rebuilds the convention ref via `conventionName` so the separator stays single-sourced.
- **Docstrings:** `adapter.ts`, `fake.ts`, `gcp.ts`, `registry.ts`, `shared.ts`.
- **Tests:** unit (`gcp.test.ts`, `set.test.ts`) + e2e (`run`/`set`/`validate`) assert the new names — all green.
- **Docs:** `docs/reference.md`, `docs/adr/0006` (rationale + v5 non-compat note), `skills/keyshelf/SKILL.md`.
- **Examples:** 04 + 05 seeded `.fake-store.json` keys regenerated; both resolve via `keyshelf run`, `validate:examples` passes.
- **Housekeeping:** drop stale extraneous `packages/action` + `packages/migrate` entries from `package-lock.json` (lockfile otherwise unchanged — 41 deletions only).

## Verification

`npm run lint`, `format:check`, `build`, `npm test -w keyshelf` (183 passed), `npm run validate:examples` (all 5 valid) — all green. Manually confirmed example 04 (`api/production`) and example 05 (`web-service/staging` + `worker/staging`) resolve their secrets via `keyshelf run`.

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnKDVDBMEALW2aaoNT5Xgm