### PR TITLE
fix(release): reseed manifest to 5.4.0 + Release-As 6.0.0

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,3 @@
 {
-  "packages/cli": "6.0.0"
+  "packages/cli": "5.4.0"
 }


### PR DESCRIPTION
## What

Fixes release-please proposing **`keyshelf 7.0.0`** (PR #194) with a polluted, all-of-v5 changelog.

Root cause: #174 set `.release-please-manifest.json` to `6.0.0`, but `6.0.0` was never released (no `keyshelf-v6.0.0` tag). Without that boundary, release-please walked back past `keyshelf-v5.4.0`, found a historical (v4→v5) breaking change, and bumped `6.0.0 → 7.0.0`.

This PR:
1. Resets the manifest to **`5.4.0`** (the real last release) → release-please uses the `keyshelf-v5.4.0` tag as the changelog boundary.
2. Carries a **`Release-As: 6.0.0`** trailer (in the commit) → pins this release to exactly `6.0.0`.

After merge, release-please regenerates its PR (reusing the `…components--keyshelf` branch, superseding #194) as a clean **"release keyshelf 6.0.0"**, and on merge tags `keyshelf-v6.0.0` → publish.yml fires to `@next`.

> ⚠️ The `Release-As: 6.0.0` trailer must survive the squash merge — merge with that trailer in the squash commit body.

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnKDVDBMEALW2aaoNT5Xgm