### PR TITLE
fix(release): force keyshelf 6.0.0 via config release-as

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,8 @@
   "include-component-in-tag": true,
   "packages": {
     "packages/cli": {
-      "package-name": "keyshelf"
+      "package-name": "keyshelf",
+      "release-as": "6.0.0"
     }
   }
 }


### PR DESCRIPTION
## What

Follow-up to #196. The `Release-As: 6.0.0` commit trailer was ignored because it rode on a root-only commit and release-please's per-package path filter skipped it — so it proposed `keyshelf 5.5.0`.

This adds `"release-as": "6.0.0"` to the `packages/cli` config entry, which is read directly (not path-filtered) and reliably pins the release to **6.0.0**. Manifest stays at `5.4.0` so the changelog boundary is `keyshelf-v5.4.0` (clean, post-5.4.0 only).

> ⚠️ **Sticky:** `release-as` forces 6.0.0 on every run. Remove it immediately after the 6.0.0 release is cut (folds into the npm-publish setup), or 6.0.1+ releases will be blocked. Noted in the publishing memory.

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnKDVDBMEALW2aaoNT5Xgm