### PR TITLE
feat(set): author key references via set --ref / --ref-key

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -169,17 +169,51 @@ failures (a `!secret` that exists but cannot be fetched, bad creds) are **not**
 in scope for these static checks — they keep their `run`-time codes
 (`SECRET_NOT_FOUND`, `PROVIDER_AUTH`).
 
+### Authoring a `!ref` with `set --ref`
+
+So that every representation stays CLI-authorable (no hand-editing YAML), `set`
+writes a key reference directly:
+
+```
+keyshelf set <KEY> <shelf>/<stage> --ref <target-shelf>[/<target-stage>] [--ref-key <target-key>]
+```
+
+This is a **pure offline file mutation**: unlike `set --secret`, it reads no value
+from stdin, calls no adapter, and requires no provider credentials. It edits the
+consuming environment file in place (provider line, comments, and every other key
+survive), writing a `!ref` node that round-trips through the loader above.
+
+- `--ref <shelf>` → `!ref { shelf }` — same-name target, current stage.
+- `--ref <shelf>/<stage>` → adds an explicit `stage:` — `!ref { shelf, stage }`.
+- `--ref-key <target>` → adds a `key:` to rename the target — `!ref { shelf, key }`.
+  The `key:` is **omitted** when `<target>` equals the consuming `<KEY>` (a rename
+  to the same name is the same-name default, so it is not recorded).
+- `--ref` is mutually exclusive with `--secret`; `--ref-key` requires `--ref`.
+
+Examples:
+
+```
+# !ref { shelf: supabase }
+keyshelf set SUPABASE_SERVICE_ROLE_KEY backend/production --ref supabase
+
+# !ref { shelf: supabase, key: SERVICE_ROLE_KEY }
+keyshelf set DB_PASSWORD backend/production --ref supabase --ref-key SERVICE_ROLE_KEY
+
+# !ref { shelf: shared, stage: production }
+keyshelf set AUDIT_KEY backend/staging --ref shared/production
+```
+
 ## CLI surface (MVP)
 
 Built on **oclif**. The qualified environment `{shelf}/{stage}` is a positional
 argument.
 
-| Command                                             | Purpose                                                                                                                                                                                                                                               |
-| --------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `keyshelf init [--project <name>] [--shelf <name>]` | Scaffold `.keyshelf/` (non-interactive; project defaults to cwd name; creates `config.yaml` with a default `local` sops provider and a starter shelf — `--shelf`, default `app` — with an empty `schema.yaml`). Refuses to clobber without `--force`. |
-| `keyshelf set <KEY> <shelf>/<stage> [--secret]`     | Write a value. Read from stdin/prompt, never argv. `--secret` → store + write a `!secret` reference; plaintext → environment file. Key must already be in the shelf's schema; never mutates the schema.                                               |
-| `keyshelf run <shelf>/<stage> -- <cmd>`             | Resolve config + secrets into env vars, overlay the inherited environment, exec `<cmd>`. Fail-fast: aborts before exec if anything is unresolvable.                                                                                                   |
-| `keyshelf validate [<shelf>/<stage>]`               | Run the same closed-contract + resolution checks as `run`, execute nothing, emit structured results. Validates the whole project when the argument is omitted.                                                                                        |
+| Command                                                                                         | Purpose                                                                                                                                                                                                                                                                                                    |
+| ----------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `keyshelf init [--project <name>] [--shelf <name>]`                                             | Scaffold `.keyshelf/` (non-interactive; project defaults to cwd name; creates `config.yaml` with a default `local` sops provider and a starter shelf — `--shelf`, default `app` — with an empty `schema.yaml`). Refuses to clobber without `--force`.                                                      |
+| `keyshelf set <KEY> <shelf>/<stage> [--secret \| --ref <shelf>[/<stage>] [--ref-key <target>]]` | Write a value. Read from stdin/prompt, never argv. `--secret` → store + write a `!secret` reference; plaintext → environment file. `--ref` → author a `!ref` key reference (pure offline file edit, no value read, no provider call). Key must already be in the shelf's schema; never mutates the schema. |
+| `keyshelf run <shelf>/<stage> -- <cmd>`                                                         | Resolve config + secrets into env vars, overlay the inherited environment, exec `<cmd>`. Fail-fast: aborts before exec if anything is unresolvable.                                                                                                                                                        |
+| `keyshelf validate [<shelf>/<stage>]`                                                           | Run the same closed-contract + resolution checks as `run`, execute nothing, emit structured results. Validates the whole project when the argument is omitted.                                                                                                                                             |
 
 Conventions:
 

--- a/packages/cli/src/commands/set.ts
+++ b/packages/cli/src/commands/set.ts
@@ -86,17 +86,7 @@ export default class Set extends BaseCommand {
     // raw (byte-exact), and an empty stdin is NO_INPUT.
     const value = await this.readValue(key);
 
-    const projectDir = process.cwd();
-    // Loads config + schema + environment, surfacing NOT_INITIALIZED /
-    // SHELF_NOT_FOUND / SCHEMA_NOT_FOUND / ENVIRONMENT_NOT_FOUND / MALFORMED_FILE.
-    const loaded = await loadEnvironment(projectDir, shelf, stage);
-
-    this.assertDeclared(loaded.schema.keys, key, shelf, stage);
-
-    // Edit the existing environment file in place, preserving every other key,
-    // the provider line, and comments.
-    const file = path.join(projectDir, ".keyshelf", shelf, `${stage}.yaml`);
-    const doc = parseDocument(await readFile(file, "utf8"));
+    const { loaded, projectDir, file, doc } = await this.loadForEdit(shelf, stage, key);
 
     if (flags.secret) {
       await this.writeSecret(loaded, projectDir, shelf, stage, key, value, doc);
@@ -144,13 +134,8 @@ export default class Set extends BaseCommand {
       reference.key = refKey;
     }
 
-    const projectDir = process.cwd();
-    // No provider/config beyond what loadEnvironment reads — no adapter is created.
-    const loaded = await loadEnvironment(projectDir, shelf, stage);
-    this.assertDeclared(loaded.schema.keys, key, shelf, stage);
-
-    const file = path.join(projectDir, ".keyshelf", shelf, `${stage}.yaml`);
-    const doc = parseDocument(await readFile(file, "utf8"));
+    // No provider/config beyond what loadForEdit reads — no adapter is created.
+    const { file, doc } = await this.loadForEdit(shelf, stage, key);
     setKeyReference(doc, key, reference);
     await writeFile(file, doc.toString(), "utf8");
 
@@ -165,6 +150,34 @@ export default class Set extends BaseCommand {
     }
 
     return result;
+  }
+
+  /**
+   * Prepare an in-place edit of `{shelf}/{stage}.yaml`: load config + schema +
+   * environment (surfacing NOT_INITIALIZED / SHELF_NOT_FOUND / SCHEMA_NOT_FOUND /
+   * ENVIRONMENT_NOT_FOUND / MALFORMED_FILE), assert the key is schema-declared
+   * (set never declares keys), and open the environment document for surgical
+   * mutation. Returns the loaded model plus the file path and parsed document so
+   * the caller can mutate and write it back, preserving every other key, the
+   * provider line, and comments.
+   */
+  private async loadForEdit(
+    shelf: string,
+    stage: string,
+    key: string
+  ): Promise<{
+    loaded: Awaited<ReturnType<typeof loadEnvironment>>;
+    projectDir: string;
+    file: string;
+    doc: ReturnType<typeof parseDocument>;
+  }> {
+    const projectDir = process.cwd();
+    const loaded = await loadEnvironment(projectDir, shelf, stage);
+    this.assertDeclared(loaded.schema.keys, key, shelf, stage);
+
+    const file = path.join(projectDir, ".keyshelf", shelf, `${stage}.yaml`);
+    const doc = parseDocument(await readFile(file, "utf8"));
+    return { loaded, projectDir, file, doc };
   }
 
   /** Reject a key not declared in the consuming shelf's schema — set never declares keys. */

--- a/packages/cli/src/commands/set.ts
+++ b/packages/cli/src/commands/set.ts
@@ -8,14 +8,17 @@ import { conventionName } from "../adapters/shared.js";
 import { BaseCommand } from "../base-command.js";
 import { KeyshelfError } from "../errors.js";
 import { loadEnvironment } from "../loader.js";
-import { secretRefForm, setConfigValue, setSecretRef } from "../set.js";
+import { secretRefForm, setConfigValue, setKeyReference, setSecretRef } from "../set.js";
 import { parseTarget } from "../target.js";
+import type { KeyReference } from "../model.js";
 
 /** The structured result of a successful `set`. */
 interface SetResult {
   key: string;
   environment: string;
   secret: boolean;
+  /** Whether a `!ref` key reference was authored (vs a value/secret written). */
+  ref: boolean;
 }
 
 /**
@@ -56,7 +59,17 @@ export default class Set extends BaseCommand {
   static flags = {
     secret: Flags.boolean({
       description: "Store the value via the provider and record only a !secret reference.",
-      default: false
+      default: false,
+      exclusive: ["ref"]
+    }),
+    ref: Flags.string({
+      description:
+        "Author a !ref key reference to <shelf>[/<stage>] (offline file edit; no value, no provider).",
+      exclusive: ["secret"]
+    }),
+    "ref-key": Flags.string({
+      description: "The target key name for a rename; omitted from the node when equal to <KEY>.",
+      dependsOn: ["ref"]
     })
   };
 
@@ -64,6 +77,10 @@ export default class Set extends BaseCommand {
     const { args, flags } = await this.parse(Set);
     const { shelf, stage } = parseTarget(args.target);
     const { key } = args;
+
+    if (flags.ref !== undefined) {
+      return this.authorReference(shelf, stage, key, flags.ref, flags["ref-key"]);
+    }
 
     // The value is never taken from argv. A TTY prompts; otherwise stdin is read
     // raw (byte-exact), and an empty stdin is NO_INPUT.
@@ -74,18 +91,7 @@ export default class Set extends BaseCommand {
     // SHELF_NOT_FOUND / SCHEMA_NOT_FOUND / ENVIRONMENT_NOT_FOUND / MALFORMED_FILE.
     const loaded = await loadEnvironment(projectDir, shelf, stage);
 
-    // The key must already exist in the shelf's schema — set never declares keys.
-    if (!Object.prototype.hasOwnProperty.call(loaded.schema.keys, key)) {
-      throw new KeyshelfError(
-        "UNKNOWN_KEY",
-        `Key '${key}' is not declared in the schema for shelf '${shelf}'.`,
-        {
-          key,
-          shelf,
-          environment: `${shelf}/${stage}`
-        }
-      );
-    }
+    this.assertDeclared(loaded.schema.keys, key, shelf, stage);
 
     // Edit the existing environment file in place, preserving every other key,
     // the provider line, and comments.
@@ -100,12 +106,85 @@ export default class Set extends BaseCommand {
 
     await writeFile(file, doc.toString(), "utf8");
 
-    const result: SetResult = { key, environment: `${shelf}/${stage}`, secret: flags.secret };
+    const result: SetResult = {
+      key,
+      environment: `${shelf}/${stage}`,
+      secret: flags.secret,
+      ref: false
+    };
     if (!this.jsonEnabled()) {
       this.log(`Set ${result.environment} ${key}${flags.secret ? " (secret)" : ""}.`);
     }
 
     return result;
+  }
+
+  /**
+   * Author a `!ref` key reference into the consuming environment file — a pure
+   * offline mutation (ADR-0007). No value is read from stdin and no provider's
+   * adapter is touched: a key reference points at where the value lives, it does
+   * not store one. The consuming key must still be declared in the consuming
+   * shelf's schema (set never declares keys), and the environment file must exist;
+   * both are checked by {@link loadEnvironment} + {@link assertDeclared}.
+   *
+   * `refSpec` is `<shelf>` or `<shelf>/<stage>`: a trailing `/<stage>` records an
+   * explicit `stage:`, otherwise the target resolves at the current stage. A
+   * `refKey` records a `key:` rename, except when it equals the consuming key (a
+   * same-name "rename" is the loader's default, so it is not written).
+   */
+  private async authorReference(
+    shelf: string,
+    stage: string,
+    key: string,
+    refSpec: string,
+    refKey: string | undefined
+  ): Promise<SetResult> {
+    const reference = parseRefSpec(refSpec);
+    if (refKey !== undefined && refKey !== key) {
+      reference.key = refKey;
+    }
+
+    const projectDir = process.cwd();
+    // No provider/config beyond what loadEnvironment reads — no adapter is created.
+    const loaded = await loadEnvironment(projectDir, shelf, stage);
+    this.assertDeclared(loaded.schema.keys, key, shelf, stage);
+
+    const file = path.join(projectDir, ".keyshelf", shelf, `${stage}.yaml`);
+    const doc = parseDocument(await readFile(file, "utf8"));
+    setKeyReference(doc, key, reference);
+    await writeFile(file, doc.toString(), "utf8");
+
+    const result: SetResult = {
+      key,
+      environment: `${shelf}/${stage}`,
+      secret: false,
+      ref: true
+    };
+    if (!this.jsonEnabled()) {
+      this.log(`Set ${result.environment} ${key} (ref -> ${refSpec}).`);
+    }
+
+    return result;
+  }
+
+  /** Reject a key not declared in the consuming shelf's schema — set never declares keys. */
+  private assertDeclared(
+    schemaKeys: Record<string, unknown>,
+    key: string,
+    shelf: string,
+    stage: string
+  ): void {
+    if (!Object.prototype.hasOwnProperty.call(schemaKeys, key)) {
+      throw new KeyshelfError(
+        "UNKNOWN_KEY",
+        `Key '${key}' is not declared in the schema for shelf '${shelf}'.`,
+        {
+          key,
+          shelf,
+          environment: `${shelf}/${stage}`
+        }
+      );
+    }
   }
 
   /**
@@ -179,6 +258,35 @@ export default class Set extends BaseCommand {
 
     return value;
   }
+}
+
+/**
+ * Parse a `--ref` spec into a {@link KeyReference}: `<shelf>` (current stage) or
+ * `<shelf>/<stage>` (explicit stage). A malformed spec — empty shelf, empty
+ * stage, or more than one `/` — is a `MALFORMED_FILE`, matching how
+ * {@link parseTarget} rejects a bad environment address. The `key` field is added
+ * by the caller for a rename; it is never derived from the spec.
+ */
+function parseRefSpec(spec: string): KeyReference {
+  const slash = spec.indexOf("/");
+  if (slash === -1) {
+    if (spec.length === 0) throw malformedRef(spec);
+    return { shelf: spec };
+  }
+
+  if (slash === 0 || slash === spec.length - 1 || spec.indexOf("/", slash + 1) !== -1) {
+    throw malformedRef(spec);
+  }
+
+  return { shelf: spec.slice(0, slash), stage: spec.slice(slash + 1) };
+}
+
+function malformedRef(spec: string): KeyshelfError {
+  return new KeyshelfError(
+    "MALFORMED_FILE",
+    `'${spec}' is not a valid --ref target; expected '<shelf>' or '<shelf>/<stage>'.`,
+    { reason: "expected '<shelf>' or '<shelf>/<stage>'", target: spec }
+  );
 }
 
 function noInput(key: string): KeyshelfError {

--- a/packages/cli/src/set.ts
+++ b/packages/cli/src/set.ts
@@ -1,4 +1,5 @@
 import { type Document, isMap, Scalar, YAMLMap } from "yaml";
+import type { KeyReference } from "./model.js";
 
 /**
  * The form a `!secret` reference takes in the environment file. The adapter's
@@ -78,4 +79,26 @@ export function setSecretRef(doc: Document, key: string, form: SecretRefForm): v
   const node = doc.createNode({ ref: form.ref }) as YAMLMap;
   node.tag = "!secret";
   map.set(key, node);
+}
+
+/**
+ * Record `KEY` as a `!ref` key reference under `keys:`, in place (ADR-0007) —
+ * never a value. Writes a tagged mapping `KEY: !ref { shelf, [key], [stage] }`
+ * that parses back through the loader's `!ref` handling. `shelf` is always
+ * written; `key` and `stage` are written only when present on `reference`, so the
+ * caller is responsible for omitting `key` when the target name equals the
+ * consuming key (same-name is the loader's default) and `stage` for the current
+ * stage. Overwrites any prior value, including a `!secret`, and preserves every
+ * other key and the `provider:` line.
+ */
+export function setKeyReference(doc: Document, key: string, reference: KeyReference): void {
+  // Build the payload in field order shelf → key → stage, omitting absent
+  // optionals so the written node carries only what the author specified.
+  const payload: Record<string, string> = { shelf: reference.shelf };
+  if (reference.key !== undefined) payload.key = reference.key;
+  if (reference.stage !== undefined) payload.stage = reference.stage;
+
+  const node = doc.createNode(payload) as YAMLMap;
+  node.tag = "!ref";
+  keysMap(doc).set(key, node);
 }

--- a/packages/cli/test/e2e/set-ref.e2e.test.ts
+++ b/packages/cli/test/e2e/set-ref.e2e.test.ts
@@ -1,0 +1,299 @@
+import { readFile, mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { parseDocument } from "yaml";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { makeTmpDir, removeDir, runKeyshelf } from "./helpers.js";
+
+/**
+ * Black-box E2E for authoring key references via `keyshelf set --ref` (ADR-0007,
+ * issue #204). Asserts the exact `!ref` node written for same-name, cross-stage,
+ * and rename authoring; that it is a pure offline file edit (no value read, no
+ * provider credentials, no backend write); and that an authored node round-trips
+ * — `set --ref` then `run` resolves the value through the target's provider.
+ */
+
+const PRINT = (name: string) => ["node", "-e", `process.stdout.write(String(process.env.${name}))`];
+
+async function write(cwd: string, rel: string, contents: string): Promise<void> {
+  const full = path.join(cwd, rel);
+  await mkdir(path.dirname(full), { recursive: true });
+  await writeFile(full, contents, "utf8");
+}
+
+async function read(cwd: string, rel: string): Promise<string> {
+  return readFile(path.join(cwd, rel), "utf8");
+}
+
+/** Read the parsed `!ref` payload of `key` from a consuming environment file. */
+async function refNode(cwd: string, rel: string, key: string): Promise<unknown> {
+  const doc = parseDocument(await read(cwd, rel));
+  const keys = doc.get("keys", true) as { get(k: string, keep: boolean): { toJSON(): unknown } };
+  return keys.get(key, true).toJSON();
+}
+
+describe("keyshelf set <KEY> <shelf>/<stage> --ref", () => {
+  let cwd: string;
+
+  beforeEach(async () => {
+    cwd = await makeTmpDir();
+    // A canonical shelf (holds real secrets) and a mapping shelf with no provider
+    // of its own — only config + !ref need no provider (ADR-0007).
+    await write(
+      cwd,
+      ".keyshelf/config.yaml",
+      "project: myapp\nproviders:\n  local:\n    adapter: fake\n"
+    );
+    await write(
+      cwd,
+      ".keyshelf/shared/schema.yaml",
+      "keys:\n  SUPABASE_SERVICE_ROLE_KEY: !required\n  SERVICE_ROLE_KEY: !required\n  AUDIT_KEY: !required\n"
+    );
+    await write(
+      cwd,
+      ".keyshelf/web/schema.yaml",
+      "keys:\n  SUPABASE_SERVICE_ROLE_KEY: !required\n  DB_PASSWORD: !required\n  AUDIT_KEY: !required\n  UNKNOWN_TO_SCHEMA: !optional\n"
+    );
+  });
+
+  afterEach(async () => {
+    await removeDir(cwd);
+  });
+
+  it("writes !ref { shelf } for a same-name, current-stage reference", async () => {
+    await write(
+      cwd,
+      ".keyshelf/web/production.yaml",
+      "provider: local\nkeys:\n  AUDIT_KEY: keep\n"
+    );
+    const { code, stdout } = await runKeyshelf(
+      ["set", "SUPABASE_SERVICE_ROLE_KEY", "web/production", "--ref", "supabase", "--json"],
+      { cwd }
+    );
+    expect(code, stdout).toBe(0);
+    expect(JSON.parse(stdout)).toMatchObject({
+      key: "SUPABASE_SERVICE_ROLE_KEY",
+      environment: "web/production",
+      ref: true
+    });
+
+    expect(
+      await refNode(cwd, ".keyshelf/web/production.yaml", "SUPABASE_SERVICE_ROLE_KEY")
+    ).toEqual({
+      shelf: "supabase"
+    });
+    // In-place edit: the provider line and other keys survive, value is a !ref.
+    const text = await read(cwd, ".keyshelf/web/production.yaml");
+    expect(text).toContain("provider: local");
+    expect(text).toContain("AUDIT_KEY: keep");
+    expect(text).toContain("!ref");
+  });
+
+  it("writes an explicit stage: for --ref <shelf>/<stage>", async () => {
+    await write(cwd, ".keyshelf/web/staging.yaml", "provider: local\nkeys:\n  DB_PASSWORD: x\n");
+    const { code } = await runKeyshelf(
+      ["set", "AUDIT_KEY", "web/staging", "--ref", "shared/production"],
+      { cwd }
+    );
+    expect(code).toBe(0);
+    expect(await refNode(cwd, ".keyshelf/web/staging.yaml", "AUDIT_KEY")).toEqual({
+      shelf: "shared",
+      stage: "production"
+    });
+  });
+
+  it("writes a key: for a rename with --ref-key", async () => {
+    await write(cwd, ".keyshelf/web/staging.yaml", "provider: local\nkeys:\n  AUDIT_KEY: x\n");
+    const { code } = await runKeyshelf(
+      ["set", "DB_PASSWORD", "web/staging", "--ref", "supabase", "--ref-key", "SERVICE_ROLE_KEY"],
+      { cwd }
+    );
+    expect(code).toBe(0);
+    expect(await refNode(cwd, ".keyshelf/web/staging.yaml", "DB_PASSWORD")).toEqual({
+      shelf: "supabase",
+      key: "SERVICE_ROLE_KEY"
+    });
+  });
+
+  it("omits key: when --ref-key equals the consuming key (same-name)", async () => {
+    await write(cwd, ".keyshelf/web/staging.yaml", "provider: local\nkeys:\n  AUDIT_KEY: x\n");
+    const { code } = await runKeyshelf(
+      [
+        "set",
+        "SUPABASE_SERVICE_ROLE_KEY",
+        "web/staging",
+        "--ref",
+        "supabase",
+        "--ref-key",
+        "SUPABASE_SERVICE_ROLE_KEY"
+      ],
+      { cwd }
+    );
+    expect(code).toBe(0);
+    expect(await refNode(cwd, ".keyshelf/web/staging.yaml", "SUPABASE_SERVICE_ROLE_KEY")).toEqual({
+      shelf: "supabase"
+    });
+  });
+
+  it("is a pure offline edit: no stdin read, no backend write, no credentials", async () => {
+    // The consuming env names a provider whose adapter is unregistered. set --secret
+    // would create that adapter and fail ADAPTER_UNAVAILABLE; set --ref must not —
+    // it authors a pointer, never touching the provider or reading stdin.
+    await write(
+      cwd,
+      ".keyshelf/config.yaml",
+      "project: myapp\nproviders:\n  local:\n    adapter: fake\n  bogus:\n    adapter: no-such-adapter\n"
+    );
+    await write(cwd, ".keyshelf/web/staging.yaml", "provider: bogus\nkeys:\n  DB_PASSWORD: x\n");
+    const { code, stdout } = await runKeyshelf(
+      ["set", "AUDIT_KEY", "web/staging", "--ref", "shared", "--json"],
+      { cwd } // note: no `input` — set --ref reads nothing from stdin
+    );
+    expect(code, stdout).toBe(0);
+    expect(await refNode(cwd, ".keyshelf/web/staging.yaml", "AUDIT_KEY")).toEqual({
+      shelf: "shared"
+    });
+    // No fake store file is created — nothing was written to any backend.
+    const text = await read(cwd, ".keyshelf/web/staging.yaml");
+    expect(text).toContain("provider: bogus");
+  });
+
+  it("rejects a key not in the consuming shelf's schema with UNKNOWN_KEY", async () => {
+    await write(cwd, ".keyshelf/web/staging.yaml", "provider: local\nkeys:\n  DB_PASSWORD: x\n");
+    const { code, stdout } = await runKeyshelf(
+      ["set", "NOPE", "web/staging", "--ref", "shared", "--json"],
+      { cwd }
+    );
+    expect(code).not.toBe(0);
+    expect(JSON.parse(stdout).error.code).toBe("UNKNOWN_KEY");
+  });
+
+  it("rejects --ref together with --secret", async () => {
+    await write(cwd, ".keyshelf/web/staging.yaml", "provider: local\nkeys:\n  DB_PASSWORD: x\n");
+    const { code } = await runKeyshelf(
+      ["set", "AUDIT_KEY", "web/staging", "--ref", "shared", "--secret"],
+      { cwd, input: "x" }
+    );
+    expect(code).not.toBe(0);
+  });
+
+  it("rejects --ref-key without --ref", async () => {
+    await write(cwd, ".keyshelf/web/staging.yaml", "provider: local\nkeys:\n  DB_PASSWORD: x\n");
+    const { code } = await runKeyshelf(["set", "AUDIT_KEY", "web/staging", "--ref-key", "OTHER"], {
+      cwd,
+      input: "x"
+    });
+    expect(code).not.toBe(0);
+  });
+});
+
+describe("set --ref round-trips: authored reference resolves at run", () => {
+  let cwd: string;
+
+  beforeEach(async () => {
+    cwd = await makeTmpDir();
+    await write(
+      cwd,
+      ".keyshelf/config.yaml",
+      "project: myapp\nproviders:\n  local:\n    adapter: fake\n"
+    );
+  });
+
+  afterEach(async () => {
+    await removeDir(cwd);
+  });
+
+  it("same-name: set --ref then run resolves the canonical value", async () => {
+    await write(cwd, ".keyshelf/shared/schema.yaml", "keys:\n  DATABASE_PASSWORD: !required\n");
+    await write(
+      cwd,
+      ".keyshelf/shared/staging.yaml",
+      "provider: local\nkeys:\n  DATABASE_PASSWORD: !secret\n"
+    );
+    await write(cwd, ".keyshelf/web/schema.yaml", "keys:\n  DATABASE_PASSWORD: !required\n");
+    await write(
+      cwd,
+      ".keyshelf/web/staging.yaml",
+      "provider: local\nkeys:\n  DATABASE_PASSWORD: placeholder\n"
+    );
+
+    const store = await runKeyshelf(["set", "DATABASE_PASSWORD", "shared/staging", "--secret"], {
+      cwd,
+      input: "declared-once"
+    });
+    expect(store.code, store.stderr).toBe(0);
+
+    const author = await runKeyshelf(
+      ["set", "DATABASE_PASSWORD", "web/staging", "--ref", "shared"],
+      { cwd }
+    );
+    expect(author.code, author.stderr).toBe(0);
+
+    const run = await runKeyshelf(["run", "web/staging", "--", ...PRINT("DATABASE_PASSWORD")], {
+      cwd
+    });
+    expect(run.code, run.stderr).toBe(0);
+    expect(run.stdout).toBe("declared-once");
+  });
+
+  it("rename: set --ref --ref-key then run resolves the differently-named target", async () => {
+    await write(cwd, ".keyshelf/shared/schema.yaml", "keys:\n  SERVICE_ROLE_KEY: !required\n");
+    await write(
+      cwd,
+      ".keyshelf/shared/staging.yaml",
+      "provider: local\nkeys:\n  SERVICE_ROLE_KEY: !secret\n"
+    );
+    await write(cwd, ".keyshelf/web/schema.yaml", "keys:\n  DB_PASSWORD: !required\n");
+    await write(
+      cwd,
+      ".keyshelf/web/staging.yaml",
+      "provider: local\nkeys:\n  DB_PASSWORD: placeholder\n"
+    );
+
+    const store = await runKeyshelf(["set", "SERVICE_ROLE_KEY", "shared/staging", "--secret"], {
+      cwd,
+      input: "renamed-secret"
+    });
+    expect(store.code, store.stderr).toBe(0);
+
+    const author = await runKeyshelf(
+      ["set", "DB_PASSWORD", "web/staging", "--ref", "shared", "--ref-key", "SERVICE_ROLE_KEY"],
+      { cwd }
+    );
+    expect(author.code, author.stderr).toBe(0);
+
+    const run = await runKeyshelf(["run", "web/staging", "--", ...PRINT("DB_PASSWORD")], { cwd });
+    expect(run.code, run.stderr).toBe(0);
+    expect(run.stdout).toBe("renamed-secret");
+  });
+
+  it("cross-stage: set --ref <shelf>/<stage> then run resolves at the target stage", async () => {
+    await write(cwd, ".keyshelf/shared/schema.yaml", "keys:\n  AUDIT_KEY: !required\n");
+    await write(
+      cwd,
+      ".keyshelf/shared/production.yaml",
+      "provider: local\nkeys:\n  AUDIT_KEY: !secret\n"
+    );
+    await write(cwd, ".keyshelf/web/schema.yaml", "keys:\n  AUDIT_KEY: !required\n");
+    await write(
+      cwd,
+      ".keyshelf/web/staging.yaml",
+      "provider: local\nkeys:\n  AUDIT_KEY: placeholder\n"
+    );
+
+    const store = await runKeyshelf(["set", "AUDIT_KEY", "shared/production", "--secret"], {
+      cwd,
+      input: "prod-audit"
+    });
+    expect(store.code, store.stderr).toBe(0);
+
+    const author = await runKeyshelf(
+      ["set", "AUDIT_KEY", "web/staging", "--ref", "shared/production"],
+      { cwd }
+    );
+    expect(author.code, author.stderr).toBe(0);
+
+    const run = await runKeyshelf(["run", "web/staging", "--", ...PRINT("AUDIT_KEY")], { cwd });
+    expect(run.code, run.stderr).toBe(0);
+    expect(run.stdout).toBe("prod-audit");
+  });
+});

--- a/packages/cli/test/unit/set.test.ts
+++ b/packages/cli/test/unit/set.test.ts
@@ -4,12 +4,7 @@ import path from "node:path";
 import { parseDocument } from "yaml";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { loadEnvironment } from "../../src/loader.js";
-import {
-  secretRefForm,
-  setConfigValue,
-  setKeyReference,
-  setSecretRef
-} from "../../src/set.js";
+import { secretRefForm, setConfigValue, setKeyReference, setSecretRef } from "../../src/set.js";
 
 describe("secretRefForm", () => {
   it("is bare when the adapter ref equals the convention name", () => {
@@ -101,21 +96,31 @@ describe("setKeyReference", () => {
     expect(text).toContain("REGION: eu");
     expect(text).toContain("!ref");
     // The reparsed node carries only the shelf — no key:, no stage:.
-    const reparsed = parseDocument(text).get("keys", true) as { get(k: string, keep: boolean): { toJSON(): unknown } };
-    expect((reparsed.get("DB", true)).toJSON()).toEqual({ shelf: "shared" });
+    const reparsed = parseDocument(text).get("keys", true) as {
+      get(k: string, keep: boolean): { toJSON(): unknown };
+    };
+    expect(reparsed.get("DB", true).toJSON()).toEqual({ shelf: "shared" });
   });
 
   it("writes an explicit stage: when the reference crosses a stage", () => {
     const doc = parseDocument("provider: local\nkeys:\n  REGION: eu\n");
     setKeyReference(doc, "AUDIT_KEY", { shelf: "shared", stage: "production" });
-    const node = (parseDocument(doc.toString()).get("keys", true) as { get(k: string, keep: boolean): { toJSON(): unknown } }).get("AUDIT_KEY", true);
+    const node = (
+      parseDocument(doc.toString()).get("keys", true) as {
+        get(k: string, keep: boolean): { toJSON(): unknown };
+      }
+    ).get("AUDIT_KEY", true);
     expect(node.toJSON()).toEqual({ shelf: "shared", stage: "production" });
   });
 
   it("writes a key: for a rename target", () => {
     const doc = parseDocument("provider: local\nkeys:\n  REGION: eu\n");
     setKeyReference(doc, "DB_PASSWORD", { shelf: "supabase", key: "SERVICE_ROLE_KEY" });
-    const node = (parseDocument(doc.toString()).get("keys", true) as { get(k: string, keep: boolean): { toJSON(): unknown } }).get("DB_PASSWORD", true);
+    const node = (
+      parseDocument(doc.toString()).get("keys", true) as {
+        get(k: string, keep: boolean): { toJSON(): unknown };
+      }
+    ).get("DB_PASSWORD", true);
     expect(node.toJSON()).toEqual({ shelf: "supabase", key: "SERVICE_ROLE_KEY" });
   });
 

--- a/packages/cli/test/unit/set.test.ts
+++ b/packages/cli/test/unit/set.test.ts
@@ -4,7 +4,12 @@ import path from "node:path";
 import { parseDocument } from "yaml";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { loadEnvironment } from "../../src/loader.js";
-import { secretRefForm, setConfigValue, setSecretRef } from "../../src/set.js";
+import {
+  secretRefForm,
+  setConfigValue,
+  setKeyReference,
+  setSecretRef
+} from "../../src/set.js";
 
 describe("secretRefForm", () => {
   it("is bare when the adapter ref equals the convention name", () => {
@@ -88,6 +93,43 @@ describe("setSecretRef", () => {
   });
 });
 
+describe("setKeyReference", () => {
+  it("writes a bare !ref { shelf } for a same-name, current-stage reference", () => {
+    const doc = parseDocument("provider: local\nkeys:\n  REGION: eu\n");
+    setKeyReference(doc, "DB", { shelf: "shared" });
+    const text = doc.toString();
+    expect(text).toContain("REGION: eu");
+    expect(text).toContain("!ref");
+    // The reparsed node carries only the shelf — no key:, no stage:.
+    const reparsed = parseDocument(text).get("keys", true) as { get(k: string, keep: boolean): { toJSON(): unknown } };
+    expect((reparsed.get("DB", true)).toJSON()).toEqual({ shelf: "shared" });
+  });
+
+  it("writes an explicit stage: when the reference crosses a stage", () => {
+    const doc = parseDocument("provider: local\nkeys:\n  REGION: eu\n");
+    setKeyReference(doc, "AUDIT_KEY", { shelf: "shared", stage: "production" });
+    const node = (parseDocument(doc.toString()).get("keys", true) as { get(k: string, keep: boolean): { toJSON(): unknown } }).get("AUDIT_KEY", true);
+    expect(node.toJSON()).toEqual({ shelf: "shared", stage: "production" });
+  });
+
+  it("writes a key: for a rename target", () => {
+    const doc = parseDocument("provider: local\nkeys:\n  REGION: eu\n");
+    setKeyReference(doc, "DB_PASSWORD", { shelf: "supabase", key: "SERVICE_ROLE_KEY" });
+    const node = (parseDocument(doc.toString()).get("keys", true) as { get(k: string, keep: boolean): { toJSON(): unknown } }).get("DB_PASSWORD", true);
+    expect(node.toJSON()).toEqual({ shelf: "supabase", key: "SERVICE_ROLE_KEY" });
+  });
+
+  it("overwrites a prior !secret tag, preserving other keys and the provider", () => {
+    const doc = parseDocument("provider: local\nkeys:\n  REGION: eu\n  DB: !secret\n");
+    setKeyReference(doc, "DB", { shelf: "shared" });
+    const text = doc.toString();
+    expect(text).toContain("provider: local");
+    expect(text).toContain("REGION: eu");
+    expect(text).not.toContain("!secret");
+    expect(text).toContain("!ref");
+  });
+});
+
 // The written environment file must read back through the real loader into the
 // expected EnvironmentValue: plaintext config, bare secret, and explicit ref.
 describe("set output round-trips through loadEnvironment", () => {
@@ -138,5 +180,22 @@ describe("set output round-trips through loadEnvironment", () => {
     const loaded = await loadEnvironment(root, "web", "staging");
     expect(loaded.environment.keys.DB.kind).toBe("secret");
     expect(loaded.environment.keys.DB.ref).toMatchObject({ ref: "shared-db-url" });
+  });
+
+  it("yields a ref EnvironmentValue for a same-name key reference", async () => {
+    await writeEnvVia((doc) => setKeyReference(doc, "DB", { shelf: "shared" }));
+    const loaded = await loadEnvironment(root, "web", "staging");
+    expect(loaded.environment.keys.DB).toEqual({ kind: "ref", reference: { shelf: "shared" } });
+  });
+
+  it("yields a ref EnvironmentValue carrying key: and stage: when authored", async () => {
+    await writeEnvVia((doc) =>
+      setKeyReference(doc, "DB", { shelf: "shared", key: "SHARED_DB", stage: "production" })
+    );
+    const loaded = await loadEnvironment(root, "web", "staging");
+    expect(loaded.environment.keys.DB).toEqual({
+      kind: "ref",
+      reference: { shelf: "shared", key: "SHARED_DB", stage: "production" }
+    });
   });
 });


### PR DESCRIPTION
## What

Adds a CLI authoring path for key references (`!ref`), so every representation stays CLI-authorable — an agent can wire up a shared mapping without hand-editing YAML.

```
keyshelf set <KEY> <shelf>/<stage> --ref <shelf>[/<stage>] [--ref-key <target>]
```

This writes a `!ref` node into the consuming environment file. It is a **pure offline file mutation**: unlike `set --secret`, it reads no value from stdin, creates no adapter, and requires no provider credentials.

## Acceptance criteria

- [x] `set --ref <shelf>` writes a `!ref { shelf }` node (same-name, current stage)
- [x] `set --ref <shelf>/<stage>` writes a node with an explicit `stage:`
- [x] `--ref-key` writes a `key:` for renames; omitted when the target name equals the consuming key
- [x] No backend call and no provider credentials are required
- [x] The written node round-trips: a value authored via `set --ref` resolves correctly at `run` (#202)
- [x] E2E covers same-name, rename, and cross-stage authoring
- [x] `reference.md` documents the `set --ref` / `--ref-key` flags

## How

- `src/set.ts`: new `setKeyReference` YAML mutation, symmetric to `setSecretRef` — writes `!ref { shelf, [key], [stage] }`, omitting absent optionals so the loader applies its defaults.
- `src/commands/set.ts`: new `--ref` / `--ref-key` flags. `--ref` branches before any stdin read or adapter creation; `--ref-key` is dropped when it equals the consuming key. `--ref` is mutually exclusive with `--secret`; `--ref-key` requires `--ref` (enforced by oclif).
- Docs-first: `reference.md` `set` row + a new "Authoring a `!ref` with `set --ref`" subsection, then TDD against it.

## Tests

Full suite green (219 passed, +17 new). Local CI equivalents all pass: `lint`, `format:check`, `validate:examples`, `typecheck`, `build`, `test`.

Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WNuH2UnrNMdpdzTsatZ7ow