### PR TITLE
chore(release): drop sticky release-as 6.0.0 (merge AFTER #194)

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,8 +4,7 @@
   "include-component-in-tag": true,
   "packages": {
     "packages/cli": {
-      "package-name": "keyshelf",
-      "release-as": "6.0.0"
+      "package-name": "keyshelf"
     }
   }
 }


### PR DESCRIPTION
## ⚠️ DRAFT — merge ONLY after the v6.0.0 release (#194) is cut

`release-as: "6.0.0"` (added in #198) forces the initial v6 release. It's **sticky** — it pins every release-please run to 6.0.0. Once #194 (release keyshelf 6.0.0) is merged and `keyshelf-v6.0.0` is tagged, this removal lets 6.0.1 / 6.1.0 / etc. compute from conventional commits again.

**Ordering:** merging this *before* #194 would make release-please recompute #194 down to 5.5.0 (manifest is still 5.4.0 until #194 lands). Kept as a draft until #194 is merged.

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnKDVDBMEALW2aaoNT5Xgm