### PR TITLE
fix(publish): add repository to platform packages for provenance (E422)

### DIFF
--- a/packages/cli/scripts/lib/platforms.ts
+++ b/packages/cli/scripts/lib/platforms.ts
@@ -61,6 +61,12 @@ export interface PlatformPackageJson {
   readonly cpu: [string];
   readonly files: ["bin"];
   readonly engines: { node: string };
+  /**
+   * Must be present and match the keyshelf repo: npm rejects a `--provenance`
+   * publish (E422) unless `repository.url` matches the GitHub repo derived from
+   * the OIDC provenance statement.
+   */
+  readonly repository: { type: "git"; url: string };
   readonly dependencies?: never;
   readonly optionalDependencies?: never;
 }
@@ -96,7 +102,8 @@ export function platformPackageJson(key: PlatformKey, manifest: SopsManifest): P
     os: [os],
     cpu: [cpu],
     files: ["bin"],
-    engines: { node: ">=18" }
+    engines: { node: ">=18" },
+    repository: { type: "git", url: "https://github.com/pantoninho/keyshelf" }
   };
 }
 

--- a/packages/cli/test/unit/platforms.test.ts
+++ b/packages/cli/test/unit/platforms.test.ts
@@ -59,6 +59,15 @@ describe("platformPackageJson", () => {
     }
   });
 
+  it("declares the keyshelf repository (required for --provenance; empty url => npm E422)", () => {
+    for (const key of platforms) {
+      expect(platformPackageJson(key, manifest).repository, key).toEqual({
+        type: "git",
+        url: "https://github.com/pantoninho/keyshelf"
+      });
+    }
+  });
+
   it("redistributes sops, so its license is MPL-2.0 (not keyshelf MIT)", () => {
     for (const key of platforms) {
       expect(platformPackageJson(key, manifest).license, key).toBe("MPL-2.0");


### PR DESCRIPTION
## What

The first `keyshelf-v6.0.0` publish failed at the first platform package:

\`\`\`
npm error code E422 — Error verifying sigstore provenance bundle:
package.json: "repository.url" is "", expected to match
"https://github.com/pantoninho/keyshelf" from provenance
\`\`\`

`npm publish --provenance` requires the package's `repository.url` to match the repo from the OIDC provenance. The generated `@keyshelf/sops-*` package.json had **no `repository` field**. **Nothing was published** (`set -euo pipefail` halted at package 1).

Adds `repository: { type: "git", url: "https://github.com/pantoninho/keyshelf" }` to `platformPackageJson` + its type, with a unit test. Verified locally: `build`, `test`, `platforms:build` green; generated package.json now carries the field.

## Recovery (after merge)

`keyshelf-v6.0.0` was tagged but never published, so the tag will be re-pointed to this fix commit and the publish re-dispatched.

Closes #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnKDVDBMEALW2aaoNT5Xgm