### PR TITLE
fix(publish): ./packages/cli path + idempotent skip-if-published

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -84,13 +84,29 @@ jobs:
           NPM_CONFIG_PROVENANCE: "true"
         run: |
           set -euo pipefail
+          # Paths are prefixed with `./` deliberately: npm parses a bare
+          # `owner/repo`-shaped arg (e.g. `packages/cli`) as a GitHub shorthand
+          # and tries to git-fetch it. `./` forces local-folder resolution.
+          # Each publish is idempotent (skip if the version is already on npm) so
+          # a partial publish can be safely re-run without 403s.
+          SOPS_VERSION="$(node -p "require('./sops-version.json').sopsVersion")"
           for key in linux-x64 linux-arm64 darwin-x64 darwin-arm64 win32-x64; do
-            echo "Publishing @keyshelf/sops-${key} …"
-            npm publish "packages/cli/platforms/sops-${key}" --provenance --access public
+            pkg="@keyshelf/sops-${key}"
+            if npm view "${pkg}@${SOPS_VERSION}" version >/dev/null 2>&1; then
+              echo "${pkg}@${SOPS_VERSION} already published — skipping"
+            else
+              echo "Publishing ${pkg} …"
+              npm publish "./packages/cli/platforms/sops-${key}" --provenance --access public
+            fi
           done
-          echo "Publishing keyshelf (dist-tag: next) …"
-          # v6 ships under the `next` dist-tag — `latest` stays on 5.x until a
-          # deliberate promotion (`npm dist-tag add keyshelf@<ver> latest`).
-          # npm publish defaults to `latest` regardless of version, so this is
-          # explicit. Flip `--tag next` here when promoting v6 to `latest`.
-          npm publish "packages/cli" --provenance --access public --tag next
+          CLI_VERSION="$(node -p "require('./packages/cli/package.json').version")"
+          if npm view "keyshelf@${CLI_VERSION}" version >/dev/null 2>&1; then
+            echo "keyshelf@${CLI_VERSION} already published — skipping"
+          else
+            # v6 ships under the `next` dist-tag — `latest` stays on 5.x until a
+            # deliberate promotion (`npm dist-tag add keyshelf@<ver> latest`).
+            # npm publish defaults to `latest` regardless of version, so `--tag
+            # next` is explicit. Flip it when promoting v6 to `latest`.
+            echo "Publishing keyshelf@${CLI_VERSION} (dist-tag: next) …"
+            npm publish "./packages/cli" --provenance --access public --tag next
+          fi


### PR DESCRIPTION
## What

The v6.0.0 publish got all 5 `@keyshelf/sops-*` packages out, then failed on the cli:

\`\`\`
npm error code 128 — git ls-remote ssh://git@github.com/packages/cli.git
\`\`\`

`npm publish "packages/cli"` is parsed as a GitHub shorthand (`github:packages/cli`) and git-fetched. Prefix with `./` to force local-folder resolution.

Also makes each publish **idempotent** (`npm view` + skip if the version is already on npm), so the partial publish (5 platform packages already live) can be re-run without 403s.

## Recovery after merge
Re-point `keyshelf-v6.0.0` to this commit and re-dispatch: the 5 platform packages are skipped (already published), the cli publishes to `@next`.

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnKDVDBMEALW2aaoNT5Xgm