### PR TITLE
fix(publish): correct sops-version.json path in idempotency guard

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -89,7 +89,7 @@ jobs:
           # and tries to git-fetch it. `./` forces local-folder resolution.
           # Each publish is idempotent (skip if the version is already on npm) so
           # a partial publish can be safely re-run without 403s.
-          SOPS_VERSION="$(node -p "require('./sops-version.json').sopsVersion")"
+          SOPS_VERSION="$(node -p "require('./packages/cli/sops-version.json').sopsVersion")"
           for key in linux-x64 linux-arm64 darwin-x64 darwin-arm64 win32-x64; do
             pkg="@keyshelf/sops-${key}"
             if npm view "${pkg}@${SOPS_VERSION}" version >/dev/null 2>&1; then


### PR DESCRIPTION
The idempotency guard added in #218 read `./sops-version.json` from the repo root, but it lives at `packages/cli/sops-version.json` — so the publish step failed with `Cannot find module './sops-version.json'` (after `npm ci` correctly passed, confirming the #220 lockfile fix). One-line path fix.

(The Tier-1 `ADAPTER_UNAVAILABLE` test failure on CI is a separate, known issue — the bare install now pulls the published optional platform dep; fix incoming.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnKDVDBMEALW2aaoNT5Xgm