### PR TITLE
test(platforms): keep published @keyshelf/sops-* out of Tier-1 installs

### DIFF
--- a/packages/cli/test/platforms/tier1-no-registry.test.ts
+++ b/packages/cli/test/platforms/tier1-no-registry.test.ts
@@ -97,8 +97,12 @@ e2e("Tier 1: file:-installed bundled binary drives a real keyshelf run", () => {
       ),
       "utf8"
     );
-    // Install only the file: tarballs; never reach the public registry for these.
-    await execFileAsync("npm", ["install", "--no-audit", "--no-fund"], {
+    // Install only the file: tarballs; never reach the public registry for
+    // these. `--omit=optional` keeps keyshelf's now-published `@keyshelf/sops-*`
+    // optionalDependencies out of the install, so each leg sees exactly the sops
+    // sources it sets up (the file: platform tarball and/or PATH) and nothing
+    // leaks in from the registry.
+    await execFileAsync("npm", ["install", "--no-audit", "--no-fund", "--omit=optional"], {
       cwd: dir,
       maxBuffer: 64 * 1024 * 1024
     });


### PR DESCRIPTION
## What

Now that the `@keyshelf/sops-*` platform packages are published, the Tier-1 "bare" installs (keyshelf only) pulled the host platform package in as an `optionalDependency` from the registry. So the `surfaces ADAPTER_UNAVAILABLE when neither bundled package nor PATH sops resolves` leg found the bundled binary, keyshelf succeeded, and the test failed (`expected +0 not to be +0`).

Adds `--omit=optional` to `installProject`, so each leg sees exactly the sops sources it sets up (the `file:` tarball and/or PATH) — matching the "Tier 1, no registry" intent. The positive test installs the platform package as a direct `file:` dep, so it's unaffected.

Verified locally: all 5 Tier-1 tests pass (including the previously-failing one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnKDVDBMEALW2aaoNT5Xgm