### PR TITLE
docs(sops): correct stale 'platform packages unpublished' comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,12 @@ jobs:
           node-version: 20
           cache: npm
 
-      # The hermetic sops conformance + E2E matrix needs a real sops + age on the
-      # runner (the bundled per-platform packages are not yet published, so the
-      # adapter finds sops via its PATH fallback). Pinned for reproducibility.
+      # age is needed by the sops fixtures (they generate age keys; the bundled
+      # @keyshelf/sops-* packages ship only sops, not age). sops is installed for
+      # the Tier-1 "PATH fallback" test, which deliberately runs with no bundled
+      # package and asserts the resolver falls back to a PATH sops. The
+      # conformance + E2E matrix itself now resolves the bundled per-platform
+      # binary that `npm ci` installs for this host. Pinned for reproducibility.
       - name: Install sops + age
         run: |
           SOPS_VERSION=v3.13.1

--- a/packages/cli/src/adapters/sops-binary.ts
+++ b/packages/cli/src/adapters/sops-binary.ts
@@ -11,8 +11,7 @@ import { KeyshelfError } from "../errors.js";
  * per `{platform}-{arch}` (`@keyshelf/sops-linux-x64`, `@keyshelf/sops-darwin-arm64`,
  * …) carrying just that platform's binary — so a single `npm i -g keyshelf`
  * brings a working sops with nothing else to install. Any `sops` on `PATH` is the
- * fallback, which also makes a hermetic CI runner (where a pinned real sops is
- * installed) Just Work without publishing the platform packages.
+ * fallback, which covers hosts/contexts without the bundled package installed.
  *
  * Resolution order:
  *   1. an explicit override (`KEYSHELF_SOPS_BIN`) — used by tests to point at a
@@ -24,9 +23,10 @@ import { KeyshelfError } from "../errors.js";
  * structured `ADAPTER_UNAVAILABLE` with a message that names the platform package
  * and the PATH fallback.
  *
- * NB: publishing the `@keyshelf/sops-*` platform packages to the registry is out
- * of scope for the MVP — the lookup logic and `optionalDependencies` wiring exist,
- * but until they ship the PATH fallback is what is actually exercised.
+ * The `@keyshelf/sops-*` platform packages are published to the registry (since
+ * keyshelf 6.0.0), so the bundled package (step 2) is the primary path for a
+ * normal install; the PATH fallback (step 3) covers hosts without it and is
+ * exercised directly by the Tier-1 "PATH fallback" test.
  */
 export function resolveSopsBinary(): string {
   const override = process.env.KEYSHELF_SOPS_BIN;


### PR DESCRIPTION
Follow-up to the v6 publish. The `@keyshelf/sops-*` packages are now published, so two comments were stale:

- `ci.yml` — the sops/age install comment claimed the matrix needs PATH sops because the bundled packages aren't published. Now the conformance + E2E matrix uses the bundled binary (`npm ci` installs the host package); the **sops** install remains only for the Tier-1 "PATH fallback" test, and **age** for fixture key generation.
- `sops-binary.ts` — dropped the "publishing … is out of scope for the MVP / until they ship the PATH fallback is what is actually exercised" note; the bundled package is now the primary path.

Comment-only, no behavior change. (We confirmed the install is **not** removable — the Tier-1 fallback leg genuinely needs a PATH sops.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnKDVDBMEALW2aaoNT5Xgm