### PR TITLE
ci(release): auto-dispatch publish on keyshelf release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,9 +96,30 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      # Required so this job can dispatch the Publish workflow (gh workflow run)
+      # when a release is cut. Without actions:write the dispatch API 403s.
+      actions: write
     steps:
       - uses: googleapis/release-please-action@v5
         id: release
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      # Auto-publish on release. release-please pushes the keyshelf-v* tag with the
+      # default GITHUB_TOKEN, and GitHub suppresses the push→workflow cascade from
+      # GITHUB_TOKEN — so the Publish workflow's `push: tags` trigger never fires on
+      # a release. workflow_dispatch is an explicit exception to that recursion
+      # guard, so dispatching it here DOES start a run. We dispatch against the new
+      # tag ref so the publish step's `startsWith(github.ref, 'refs/tags/keyshelf-v')`
+      # guard stays satisfied. Gated on the release-please "release created" output
+      # for the keyshelf package (manifest path packages/cli); when no release is
+      # created (the common case — just maintaining the release PR) this step is
+      # skipped and nothing is dispatched. Output keys are path-prefixed for a
+      # manifest config and the path contains a slash, so bracket access is required.
+      - name: Dispatch Publish workflow for the new release tag
+        if: ${{ steps.release.outputs['packages/cli--release_created'] }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ steps.release.outputs['packages/cli--tag_name'] }}
+        run: gh workflow run publish.yml --ref "$TAG_NAME"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,12 +14,18 @@ name: Publish
 # there is no `push: branches` / `pull_request` trigger, so this workflow cannot
 # even start from a PR merge.
 #
-# NOTE: release-please creates the `keyshelf-v*` tag using the default
-# `GITHUB_TOKEN`, and GitHub suppresses workflow-event cascades from that token —
-# so the tag push does NOT auto-trigger this workflow. After a release PR merges,
-# kick off the publish manually with:
+# NOTE: publishing is now AUTOMATIC on release. release-please creates the
+# `keyshelf-v*` tag using the default `GITHUB_TOKEN`, and GitHub suppresses
+# workflow-event cascades from that token — so the tag *push* does NOT auto-trigger
+# this workflow. Instead, the `release-please` job in ci.yml dispatches this
+# workflow (`gh workflow run publish.yml --ref <tag>`) when — and only when — a
+# `keyshelf` release is created; `workflow_dispatch` is exempt from the
+# GITHUB_TOKEN recursion guard, so that dispatch starts a real run. Dispatching on
+# the tag ref keeps the publish step's `startsWith(github.ref, …)` guard true.
+#
+# Manual dispatch remains the fallback (e.g. to re-run a publish, or if the
+# automatic dispatch ever fails):
 #     gh workflow run publish.yml --ref keyshelf-v<x.y.z>
-# (the tag ref keeps the publish step's `startsWith(github.ref, …)` guard true).
 
 on:
   push:


### PR DESCRIPTION
## What

Closes #231.

Makes publishing **automatic on release**. Previously the two halves of release automation were disconnected: release-please pushes the `keyshelf-v*` tag with the default `GITHUB_TOKEN`, and GitHub suppresses the `push`→workflow cascade from `GITHUB_TOKEN`, so the Publish workflow's `push: tags` trigger never fired on a release. Each release needed a human `gh workflow run publish.yml --ref keyshelf-v<x.y.z>`.

## Approach (Option 2 — chain from the release-please job)

No PAT / App token introduced. The `release-please` job now dispatches the Publish workflow itself:

- **`actions: write`** added to the `release-please` job (it had `contents: write` + `pull-requests: write`) — required for the workflow-dispatch API.
- New step, gated on the release-please "release created" output for the keyshelf package, runs `gh workflow run publish.yml --ref "$TAG_NAME"` where `TAG_NAME` is the released tag-name output.
- Uses the default `secrets.GITHUB_TOKEN`. `workflow_dispatch` is an explicit exception to the `GITHUB_TOKEN` recursion guard, so the dispatched run *does* start (only the implicit `push` cascade is suppressed).
- Dispatching on the **tag ref** keeps the publish step's existing `startsWith(github.ref, 'refs/tags/keyshelf-v')` guard satisfied. The `NPM_TOKEN` step-guard and all integrity gates in publish.yml are unchanged.
- When release-please creates **no** release (the common case — just maintaining the release PR), `packages/cli--release_created` is falsy, the step is skipped, and nothing is dispatched.
- Updated the stale publish.yml NOTE (from #230) to say publishing is now automatic, keeping manual dispatch documented as the fallback.

## Output-key verification

The output keys were confirmed against `googleapis/release-please-action@v5`'s README (the pinned version this workflow uses), not guessed:

- This is a **manifest config** (`config-file` + `manifest-file`, package path `packages/cli`, package-name `keyshelf`), so outputs are **path-prefixed** with the `<path>--<name>` form: `packages/cli--release_created` and `packages/cli--tag_name`.
- Because the path contains a `/`, the README requires **bracket property access with single quotes** inside the `${{ }}`: `steps.release.outputs['packages/cli--release_created']`. The implementation uses exactly that form for both the `if:` gate and the `TAG_NAME` env.

## Verification — what was and wasn't checked locally

Verified locally:
- `actionlint .github/workflows/ci.yml .github/workflows/publish.yml` → OK.
- `npm run format:check` (prettier) and `npm run lint` (eslint) → green (the cheap quality lane that gates every PR).
- Output key names + bracket-access syntax confirmed against the release-please-action@v5 README.
- Trigger/guard reasoning: dispatch is gated on `release_created`; ref is the `keyshelf-v*` tag so the publish step's tag-ref guard holds; `NPM_TOKEN` step-guard and integrity gates untouched.

**Could not be verified locally:** the live end-to-end auto-dispatch cannot be proven without an actual release-please release-PR merge, which only happens on a real release. This PR does **not** fake a live-trigger verification. The first real release after this merges is the true end-to-end check.

## Out of scope (unchanged)

No PAT/App token; no `latest` dist-tag promotion (stays manual); no change to how `@keyshelf/sops-*` packages are built/verified; no release-please versioning/config changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkFJSUVjXhaJ6Rh8snG67s