### PR TITLE
feat(gcp)!: store secret values raw for native Secret Manager interop

### DIFF
--- a/docs/adr/0005-adapter-conformance-testing.md
+++ b/docs/adr/0005-adapter-conformance-testing.md
@@ -22,7 +22,10 @@ Both suites bake in two cross-cutting dimensions every adapter must satisfy:
   `PROVIDER_AUTH`, sops absent → `ADAPTER_UNAVAILABLE`, etc.), uniformly.
 - **Value fidelity** — write/resolve round-trips are byte-exact for adversarial
   values: newlines, trailing whitespace, `=`, quotes, unicode, multi-KB blobs,
-  empty string.
+  and the empty string. A backend that cannot represent an empty value declares
+  `supportsEmptyValue: false` on its harness and must instead reject it with
+  `ADAPTER_ERROR` — the one sanctioned per-backend divergence (the `gcp` adapter,
+  ADR-0006).
 
 The matrix:
 

--- a/docs/adr/0006-gcp-secret-manager-adapter.md
+++ b/docs/adr/0006-gcp-secret-manager-adapter.md
@@ -40,13 +40,31 @@ Concrete choices:
   with a v5 one and does not auto-resolve v5 secrets — migration is handled
   separately (#180).
 
-- **Value encoding: JSON string, mirroring `sops`.** Secret Manager payloads are
-  raw bytes, but it **rejects an empty payload** — and the contract requires an
-  empty string to round-trip byte-exactly. So every value is carried as
-  `JSON.stringify(value)` on `write` and `JSON.parse`d on `resolve`, exactly as
-  the sops adapter does. An empty string becomes the two-byte `""`; all
-  adversarial values (newlines, whitespace, quotes, unicode, multi-KB) round-trip
-  byte-exactly.
+- **Value encoding: raw bytes (the payload _is_ the value).** `write` stores
+  `Buffer.from(value, "utf8")` and `resolve` returns the bytes verbatim. Secret
+  Manager stores an opaque byte blob, so raw bytes round-trip byte-exactly for
+  every value (newlines, whitespace, quotes, unicode, multi-KB) with no envelope.
+  Storing the literal value is what lets **native consumers** — Cloud Run secret
+  mounts, `gcloud`, Terraform data sources, other services — read the secret
+  directly, which is the whole point of putting it in a _shared_ backend.
+
+  > **Superseded.** This adapter originally carried values as `JSON.stringify(value)`,
+  > mirroring `sops`. That was reversed (#233): the envelope poisoned every native
+  > consumer (they received `"value"` with literal quotes) and broke the
+  > foreign-secret feature below (a hand-created secret holds raw bytes, so
+  > `JSON.parse` threw `ADAPTER_ERROR`). The envelope was solving only the empty-
+  > string edge case — raw UTF-8 already round-trips everything else — at a cost
+  > that defeats the reason to choose Secret Manager. Unlike `sops` (which still
+  > needs the envelope to survive YAML's implicit typing, and has no native
+  > external consumer), `gcp` keeps values raw.
+
+  The one value with no raw representation is the **empty string**: Secret Manager
+  rejects an empty payload, and an empty secret has no native form to mount
+  anyway. So `write` **rejects an empty value** with `ADAPTER_ERROR` up front,
+  rather than smuggle it through an envelope no native consumer could read. This
+  is the adapter contract's single sanctioned divergence from the uniform
+  empty-string round-trip (ADR-0005); the conformance harness marks it with
+  `supportsEmptyValue: false`.
 
 - **Versions: write adds, resolve reads `latest`.** Each `write` adds a new secret
   version; `resolve` accesses the `latest` version, so a repeated write overwrites
@@ -72,9 +90,12 @@ per-platform binary, which the SDK is not.
 One-secret-per-key with the fixed `keyshelf__{project}__{shelf}__{stage}__{key}` convention is the
 same model `fake` already implements and `set` already resolves by, so the gcp
 adapter slots into the existing reference-adapter behaviour with no new wiring in
-callers. Carrying values as JSON strings reuses the proven sops trick and is the
-cleanest way to satisfy both byte-fidelity and Secret Manager's no-empty-payload
-rule with one mechanism.
+callers. Storing the raw value keeps the payload identical to what any native GCP
+consumer expects, so the secret Keyshelf writes is the secret Cloud Run mounts —
+no decode step, no `JSON.parse` that a foreign secret would fail. The empty
+string is the only value Secret Manager cannot hold, and an empty secret is a
+smell with no native representation, so rejecting it is a cleaner contract than an
+envelope that breaks every other reader.
 
 ## Consequences
 
@@ -88,10 +109,15 @@ credentials are configured. Per-PR signal still rests on the hermetic `fake` +
 error mapping) which is unit-tested hermetically against an in-memory client
 double (`test/unit/gcp.test.ts`).
 
-The adapter assumes it owns the secrets under its namespace; values written
-outside Keyshelf that are not JSON strings surface as `ADAPTER_ERROR` on resolve.
-Old secret versions accumulate (Keyshelf never destroys them); lifecycle/rotation
-of superseded versions is left to the backend's own policies.
+Because values are stored raw, a foreign or hand-created secret resolves
+correctly through `!secret { ref: ... }` — its literal bytes are the value, with
+no envelope to parse (this is the bug the JSON-string scheme caused, now fixed).
+Secrets Keyshelf writes are also directly mountable into Cloud Run and readable
+by `gcloud`/Terraform without unwrapping. The tradeoff: the gcp adapter cannot
+store an empty value (rejected on `write`), the one place it diverges from the
+otherwise-uniform value contract. Old secret versions accumulate (Keyshelf never
+destroys them); lifecycle/rotation of superseded versions is left to the
+backend's own policies.
 
 ## Running the gated suite locally
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -305,7 +305,10 @@ ADR-0005 for rationale.
   Both enforce two cross-cutting dimensions: **error-code mapping** (every adapter
   maps the same conditions to the same codes above) and **value fidelity**
   (byte-exact round-trip of adversarial values — newlines, whitespace, `=`,
-  quotes, unicode, multi-KB, empty).
+  quotes, unicode, multi-KB, and the empty string). A backend that cannot hold an
+  empty value (the `gcp` adapter — Secret Manager rejects empty payloads) instead
+  rejects it with `ADAPTER_ERROR`; this is the contract's one sanctioned
+  per-backend divergence.
 
 Matrix execution:
 

--- a/packages/cli/src/adapters/adapter.ts
+++ b/packages/cli/src/adapters/adapter.ts
@@ -18,7 +18,10 @@ import type { KeyshelfError } from "../errors.js";
  * - map other backend op failures to `ADAPTER_ERROR`;
  * - round-trip values byte-exactly (write then resolve yields the same bytes,
  *   including embedded newlines, surrounding whitespace, `=`, quotes, unicode,
- *   multi-KB blobs, and the empty string).
+ *   and multi-KB blobs). The empty string round-trips too, with one sanctioned
+ *   exception: a backend that cannot represent an empty value (the gcp adapter —
+ *   Secret Manager rejects empty payloads, ADR-0006) instead rejects it on
+ *   `write` with `ADAPTER_ERROR`.
  *
  * These obligations are proven by the shared adapter-contract conformance suite
  * (ADR-0005), which every adapter runs by supplying a harness.

--- a/packages/cli/src/adapters/gcp.ts
+++ b/packages/cli/src/adapters/gcp.ts
@@ -18,13 +18,21 @@ import { conventionName, firstLine, refName } from "./shared.js";
  * the replication policy: absent or `global` ⇒ automatic replication; any other
  * value ⇒ user-managed replication pinned to that single region.
  *
- * **Value encoding.** Secret Manager payloads are raw bytes but reject an *empty*
- * payload, and the contract demands an empty string round-trip byte-exactly. So,
- * exactly as the sops adapter does, every value is carried as a JSON string:
- * `write` stores `JSON.stringify(value)` and `resolve` `JSON.parse`s it back. An
- * empty string becomes the two-byte `""`, and the write→resolve round-trip stays
- * byte-exact for adversarial values (newlines, whitespace, quotes, unicode,
- * multi-KB blobs).
+ * **Value encoding.** The value is stored as its raw UTF-8 bytes —
+ * `write` writes `Buffer.from(value, "utf8")` and `resolve` returns the bytes
+ * verbatim. Unlike the sops adapter (which carries a JSON string to survive
+ * YAML's implicit typing), Secret Manager stores an opaque byte blob, so raw
+ * bytes round-trip byte-exactly for every value — newlines, whitespace, quotes,
+ * unicode, multi-KB blobs — with no envelope. Storing the literal value is what
+ * lets *native* consumers (Cloud Run secret mounts, `gcloud`, Terraform, other
+ * services) read the secret directly without unwrapping a JSON quote.
+ *
+ * The one value with no raw representation is the **empty string**: Secret
+ * Manager rejects an empty payload, and an empty payload has no native form to
+ * mount anyway. So `write` rejects an empty value with `ADAPTER_ERROR` rather
+ * than smuggle it through an envelope no native consumer could read. This is the
+ * single, deliberate divergence from the uniform empty-string round-trip the
+ * adapter contract otherwise requires (ADR-0005, ADR-0006).
  *
  * **Reference.** Convention resolution is by key name: `write(key, value)` stores
  * under the composed secret id and returns that id, which equals the convention
@@ -32,6 +40,8 @@ import { conventionName, firstLine, refName } from "./shared.js";
  * `!secret { ref: NAME }` resolves a differently-named secret; a `NAME` that is a
  * full `projects/.../secrets/...` resource path resolves a foreign secret (any
  * project), otherwise it is a bare secret id in the configured `projectId`.
+ * Because values are stored raw, a foreign or hand-created secret (which holds
+ * its own literal bytes, not a JSON envelope) resolves correctly.
  *
  * **Error mapping** (uniform across adapters, ADR-0005):
  * - secret/version absent → `SECRET_NOT_FOUND`;
@@ -118,23 +128,33 @@ export class GcpAdapter implements Adapter {
       );
     }
 
-    // Values were stored via JSON.stringify; recover the exact original. `data`
-    // is bytes (a Buffer) for our writes, but the API may hand back a base64
-    // string in some transports — Buffer.from handles both via the right coding.
-    const json =
-      typeof data === "string"
-        ? Buffer.from(data, "base64").toString("utf8")
-        : Buffer.from(data).toString("utf8");
-    return decodeValue(json, name);
+    // The value is stored as its raw UTF-8 bytes, so the payload *is* the value.
+    // `data` is bytes (a Buffer) for our writes, but the API may hand back a
+    // base64 string in some transports — Buffer.from handles both via the right
+    // coding.
+    return typeof data === "string"
+      ? Buffer.from(data, "base64").toString("utf8")
+      : Buffer.from(data).toString("utf8");
   }
 
   async write(key: string, value: string): Promise<unknown> {
+    if (value === "") {
+      // Secret Manager rejects an empty payload, and an empty secret has no form
+      // a native consumer (Cloud Run mount, gcloud) could read. Rather than
+      // smuggle it through an envelope, refuse it up front with a clear message.
+      throw new KeyshelfError(
+        "ADAPTER_ERROR",
+        "The gcp adapter cannot store an empty value: Google Cloud Secret Manager rejects empty secret payloads.",
+        { key }
+      );
+    }
+
     const name = conventionName(this.namespace, key);
     await this.ensureSecret(name);
     try {
       await this.client.addSecretVersion({
         parent: this.secretResource(name),
-        payload: { data: Buffer.from(JSON.stringify(value), "utf8") }
+        payload: { data: Buffer.from(value, "utf8") }
       });
     } catch (error) {
       throw mapGcpError(error, { key, ref: name });
@@ -183,24 +203,6 @@ export class GcpAdapter implements Adapter {
 
     return `projects/${this.projectId}/secrets/${name}/versions/latest`;
   }
-}
-
-/** Parse a JSON-encoded stored value back to its plaintext, defensively. */
-function decodeValue(json: string, name: string): string {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(json);
-  } catch (error) {
-    throw new KeyshelfError(
-      "ADAPTER_ERROR",
-      `Secret '${name}' holds a value Keyshelf did not write: ${String(error)}`,
-      {
-        ref: name
-      }
-    );
-  }
-
-  return typeof parsed === "string" ? parsed : String(parsed);
 }
 
 /** A gRPC/GoogleError, narrowed to the fields we map on. */

--- a/packages/cli/test/conformance/adapter-contract.ts
+++ b/packages/cli/test/conformance/adapter-contract.ts
@@ -11,21 +11,32 @@ import { captureError } from "../support/capture-error.js";
 export interface AdapterHarness {
   /** A label for the test report (e.g. `'fake'`). */
   readonly name: string;
+  /**
+   * Whether the backend can store an empty string. Defaults to `true`. The gcp
+   * adapter sets this `false`: Secret Manager rejects an empty payload and an
+   * empty secret has no native form to mount, so it rejects empty values with
+   * `ADAPTER_ERROR` (ADR-0006). This is the contract's one sanctioned per-backend
+   * divergence in value fidelity.
+   */
+  readonly supportsEmptyValue?: boolean;
   /** Provision a fresh backend + adapter for a single test. */
   setup(): Promise<{ adapter: Adapter }>;
   /** Tear down whatever {@link setup} provisioned. */
   teardown(): Promise<void>;
 }
 
-/** Adversarial values that must round-trip byte-exactly through any adapter. */
+/**
+ * Adversarial values that must round-trip byte-exactly through any adapter. The
+ * empty string is handled separately because not every backend can represent it
+ * (see {@link AdapterHarness.supportsEmptyValue}).
+ */
 const ADVERSARIAL_VALUES: ReadonlyArray<readonly [label: string, value: string]> = [
   ["embedded newlines", "line1\nline2\nline3"],
   ["trailing/leading whitespace", "  padded value \t"],
   ["equals signs", "postgres://h?a=b=c&d=e"],
   ["single and double quotes", `it's a "quoted" 'value'`],
   ["unicode", "café — 日本語 — 🔐 — Ω"],
-  ["multi-KB blob", "x".repeat(8192)],
-  ["empty string", ""]
+  ["multi-KB blob", "x".repeat(8192)]
 ];
 
 /**
@@ -66,6 +77,18 @@ export function runAdapterContractSuite(harness: AdapterHarness): void {
           await adapter.write("FIDELITY_KEY", value);
           const resolved = await adapter.resolve("FIDELITY_KEY");
           expect(resolved).toBe(value);
+        });
+      }
+
+      if (harness.supportsEmptyValue ?? true) {
+        it("round-trips the empty string", async () => {
+          await adapter.write("FIDELITY_KEY", "");
+          expect(await adapter.resolve("FIDELITY_KEY")).toBe("");
+        });
+      } else {
+        it("rejects an empty value with ADAPTER_ERROR", async () => {
+          const error = await captureError(() => adapter.write("FIDELITY_KEY", ""));
+          expect(error.code).toBe("ADAPTER_ERROR");
         });
       }
 

--- a/packages/cli/test/conformance/gcp.contract.test.ts
+++ b/packages/cli/test/conformance/gcp.contract.test.ts
@@ -24,6 +24,9 @@ if (testProject) {
 
   runAdapterContractSuite({
     name: "gcp",
+    // Secret Manager rejects an empty payload and an empty secret has no native
+    // form to mount, so the gcp adapter refuses empty values (ADR-0006).
+    supportsEmptyValue: false,
     async setup() {
       counter += 1;
       namespace = `${runPrefix}-${counter}`;

--- a/packages/cli/test/unit/gcp.test.ts
+++ b/packages/cli/test/unit/gcp.test.ts
@@ -48,7 +48,13 @@ function fakeClient() {
     }
   };
 
-  return { client, createCalls };
+  // Plant a secret directly in the backend (bypassing the adapter) so a test can
+  // model a foreign or hand-created secret whose bytes Keyshelf never wrote.
+  function seed(id: string, bytes: Buffer): void {
+    secrets.set(id, { replication: { automatic: {} }, versions: [bytes] });
+  }
+
+  return { client, createCalls, seed };
 }
 
 /** A client whose every call rejects with the given error — for error mapping. */
@@ -104,6 +110,16 @@ describe("GcpAdapter", () => {
       expect(await a.resolve("A_DIFFERENT_KEY", ref)).toBe("foreign-value");
     });
 
+    it("resolves a foreign/hand-created secret holding raw (non-JSON) bytes", async () => {
+      // A secret Keyshelf never wrote holds its literal value, not a JSON
+      // envelope. Raw storage must read it back verbatim — the JSON-envelope
+      // scheme used to reject this as ADAPTER_ERROR (ADR-0006).
+      const { client, seed } = fakeClient();
+      seed("foreign-token", Buffer.from("raw-token-no-quotes", "utf8"));
+      const a = adapter(client);
+      expect(await a.resolve("ANY_KEY", { ref: "foreign-token" })).toBe("raw-token-no-quotes");
+    });
+
     it("overwrites with the latest version on a repeated write", async () => {
       const { client } = fakeClient();
       const a = adapter(client);
@@ -120,8 +136,7 @@ describe("GcpAdapter", () => {
       ["equals signs", "postgres://h?a=b=c&d=e"],
       ["quotes", `it's a "quoted" 'value'`],
       ["unicode", "café — 日本語 — 🔐 — Ω"],
-      ["multi-KB blob", "x".repeat(8192)],
-      ["empty string", ""]
+      ["multi-KB blob", "x".repeat(8192)]
     ];
 
     for (const [label, value] of cases) {
@@ -133,13 +148,28 @@ describe("GcpAdapter", () => {
       });
     }
 
-    it("stores an empty string as a non-empty payload (Secret Manager rejects empty)", async () => {
+    it("stores the raw value verbatim, with no JSON envelope (native-mountable)", async () => {
+      // The payload bytes must BE the value, so Cloud Run / gcloud read it
+      // without unwrapping a JSON quote.
       const { client } = fakeClient();
-      // The fake captures the raw bytes; JSON.stringify('') is `""`, two bytes.
-      const a = adapter(client);
-      await a.write("EMPTY", "");
-      // Resolving proves the bytes were a valid non-empty JSON-encoded empty string.
-      expect(await a.resolve("EMPTY")).toBe("");
+      const captured: Buffer[] = [];
+      const spy: SecretsClient = {
+        ...client,
+        async addSecretVersion(request) {
+          captured.push(request.payload.data);
+          return client.addSecretVersion(request);
+        }
+      };
+      await adapter(spy).write("TOKEN", "plain-value");
+      expect(captured[0].toString("utf8")).toBe("plain-value");
+    });
+
+    it("rejects an empty value with ADAPTER_ERROR (Secret Manager forbids empty payloads)", async () => {
+      const { client, createCalls } = fakeClient();
+      const error = await captureError(() => adapter(client).write("EMPTY", ""));
+      expect(error.code).toBe("ADAPTER_ERROR");
+      // It refuses up front — no secret container is ever created.
+      expect(createCalls).toHaveLength(0);
     });
   });
 


### PR DESCRIPTION
## What

The `gcp` adapter stored every value through a JSON envelope (`JSON.stringify` on `write`, `JSON.parse` on `resolve`), mirroring `sops`. This PR switches it to store **raw UTF-8 bytes** — the payload now *is* the value.

## Why

On a *shared* cloud backend, the envelope defeats the point of using Secret Manager:

- **Native consumers got garbage.** Cloud Run secret mounts, `gcloud`, and Terraform read the payload verbatim, so they received `"value"` with literal quotes. This made native Cloud Run secret mounting of keyshelf-written secrets impossible.
- **Foreign secrets were broken.** A hand-created or foreign secret (`!secret { ref: ... }`) holds raw bytes, so `JSON.parse` threw `ADAPTER_ERROR: holds a value Keyshelf did not write` — a limitation explicitly documented in ADR-0006, now fixed.

The envelope was only ever solving the empty-string edge case; raw UTF-8 already round-trips everything else (newlines, whitespace, quotes, unicode, multi-KB blobs) byte-exactly.

`sops` keeps its JSON envelope — it still needs it to survive YAML's implicit typing (the "Norway problem"), and has no native external consumer to break. The asymmetry is intentional.

## Behavior change

- Secrets keyshelf writes are now **directly mountable into Cloud Run** and readable by `gcloud`/Terraform without unwrapping.
- Foreign/hand-created secrets now resolve correctly.
- ⚠️ **The empty string is no longer storable** by the gcp adapter. Secret Manager rejects empty payloads and an empty secret has no native form to mount, so `write` rejects it up front with `ADAPTER_ERROR`. This is the adapter contract's single sanctioned divergence from the uniform empty-string round-trip (harness flag `supportsEmptyValue: false`).

### BREAKING CHANGE

gcp secrets are stored as raw bytes, not JSON strings. Secrets written by a prior keyshelf version must be re-`set`, and empty-string secret values are no longer accepted by the gcp adapter.

## Tests

- **Unit (hermetic, every PR):** raw-payload assertion (stored bytes are `plain-value`, not `"plain-value"`), empty-value rejection (with no orphan secret container created), and foreign raw-secret resolution.
- **Conformance (gated, real GCP, nightly):** the shared contract suite takes the rejection branch for gcp via `supportsEmptyValue: false`.

All hermetic suites green: typecheck, eslint, prettier, 288 tests passing (gated gcp conformance skips without creds).

## Docs

ADR-0006 value-encoding decision rewritten with a "Superseded" note; ADR-0005 and `reference.md` updated to document the sanctioned per-backend divergence; `Adapter` contract doc updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DLe5hes94wcL7cX9gJZsQN