### PR TITLE
feat(ls): surface adapter metadata (offline secret address)

### DIFF
--- a/docs/adr/0008-ls-is-offline-and-value-free.md
+++ b/docs/adr/0008-ls-is-offline-and-value-free.md
@@ -2,13 +2,23 @@
 
 ## Decision
 
-`keyshelf ls` is a pure offline read of the project's files. It never builds a
-provider and never touches a backend, and it never prints a key's **value** —
-neither a committed plaintext config nor a resolved secret. It reports **shape
-only**: which environments exist, and for each key its schema **presence**
-(`required` / `optional` / `default`) and its **status** in the listed
-environment (`config` / `secret` / `ref → target` / `default` / `missing` /
-`unset`).
+`keyshelf ls` is a pure offline read of the project's files. It never touches a
+backend, and it never prints a key's **value** — neither a committed plaintext
+config nor a resolved secret. It reports **shape only**: which environments
+exist, and for each key its schema **presence** (`required` / `optional` /
+`default`) and its **status** in the listed environment (`config` / `secret` /
+`ref → target` / `default` / `missing` / `unset`).
+
+`ls` **may** build a provider/adapter — but only to compute a key's storage
+**address** (e.g. a GCP Secret Manager resource path), never to resolve its
+value. This is safe because adapter construction and the adapter's `metadata()`
+method are offline and credential-free: the gcp client is constructed but never
+called, and `metadata()` is **synchronous** (its non-`Promise` return
+structurally forbids async I/O) and computed purely from already-parsed config
+plus the key/ref. An adapter that cannot derive an address without a network
+round-trip must not implement `metadata()` (the field is then omitted), and
+`metadata()` must never trigger a backend call. An address is not a value, so
+surfacing it does not breach the value-free rule.
 
 It has two modes:
 
@@ -48,6 +58,16 @@ and printing values (even just config) erases the shape/value line and edges
 toward leaking. If value display is ever wanted, it belongs behind an explicit,
 clearly-named opt-in flag — never the default — and secret values stay off the
 table regardless.
+
+A storage **address** is the sanctioned exception, and it follows exactly that
+rule. The address tells a user _where_ a secret lives (to find it in a console
+or grant IAM), never _what_ it is. It is carried for every secret key in the
+machine-consumption `--json` surface (which is already a structured,
+opt-in-by-flag output), and in the human table only behind the explicit
+`--metadata` flag — the default table stays lean. The load-bearing invariant is
+unchanged: computing an address is offline and credential-free, and the moment
+an adapter would need a network call to know an address, it omits it rather than
+fetch.
 
 Because `ls` never resolves, it cannot report whether a declared secret is
 _actually_ resolvable — a `!secret` shows as `secret` whether or not the backend

--- a/packages/cli/src/adapters/adapter.ts
+++ b/packages/cli/src/adapters/adapter.ts
@@ -4,6 +4,22 @@
 import type { KeyshelfError } from "../errors.js";
 
 /**
+ * The offline, backend-specific *address* of a stored key — never its value. Each
+ * adapter contributes its own variant, discriminated on `adapter`, so a consumer
+ * can locate the secret in the backend (a GCP console URL, an IAM grant target, a
+ * sops file path) without resolving it. This is pure config math: it is derivable
+ * from already-parsed config plus the key/ref, with zero network and zero
+ * credentials (ADR-0008).
+ *
+ * The shape is deliberately per-adapter rather than a flat string: a `gcp`
+ * resource path and a `sops` file+key are not the same kind of address, and a
+ * discriminated union lets each consumer destructure the one it expects.
+ */
+export type AdapterMetadata =
+  /** The full `projects/.../secrets/.../versions/latest` Secret Manager resource. */
+  { adapter: "gcp"; resource: string };
+
+/**
  * The sole seam for backend-specific behavior (ADR-0002). An adapter is the code
  * that talks to one type of backend (sops, gcp, the in-memory fake); a
  * {@link Provider} is a configured instance of one. Every adapter implements
@@ -52,4 +68,25 @@ export interface Adapter {
    *   foreign/explicit write returns the payload to embed under `{ ref: ... }`.
    */
   write(key: string, value: string): Promise<unknown>;
+
+  /**
+   * Compute this key's backend **address** — its storage location, never its
+   * value (ADR-0008). Optional: an adapter that cannot derive an address without
+   * a network round-trip must not implement this (so the field is simply omitted
+   * from the view), never fetch.
+   *
+   * **Contract (load-bearing):**
+   * - **Synchronous** — returns {@link AdapterMetadata}, not a `Promise`. The
+   *   non-promise signature structurally forbids async I/O: there is no awaitable
+   *   to hang a backend call on.
+   * - **Network-free and credential-free.** Computes purely from the
+   *   already-parsed config (captured at construction) plus the key/ref. It makes
+   *   no client calls and resolves no credentials.
+   *
+   * @param key  the environment key name (the convention location).
+   * @param ref  the optional explicit `!secret { ref: ... }` payload; `undefined`
+   *   means convention addressing.
+   * @returns the backend address for the key.
+   */
+  metadata?(key: string, ref?: unknown): AdapterMetadata;
 }

--- a/packages/cli/src/adapters/gcp.ts
+++ b/packages/cli/src/adapters/gcp.ts
@@ -1,6 +1,6 @@
 import { SecretManagerServiceClient } from "@google-cloud/secret-manager";
 import { KeyshelfError } from "../errors.js";
-import type { Adapter } from "./adapter.js";
+import type { Adapter, AdapterMetadata } from "./adapter.js";
 import { conventionName, firstLine, refName } from "./shared.js";
 
 /**
@@ -105,7 +105,7 @@ export class GcpAdapter implements Adapter {
   }
 
   async resolve(key: string, ref?: unknown): Promise<string> {
-    const name = ref === undefined ? conventionName(this.namespace, key) : refName("gcp", ref);
+    const name = this.storedName(key, ref);
     const version = this.versionResource(name);
     let response: AccessResponse;
     try {
@@ -164,6 +164,26 @@ export class GcpAdapter implements Adapter {
     // name `set` resolves by — returning it records a bare `!secret`, and a
     // foreign environment can reference it explicitly via `!secret { ref: name }`.
     return name;
+  }
+
+  /**
+   * The offline Secret Manager address of a key — the `.../versions/latest`
+   * resource `resolve` would read, computed by the same pure naming the adapter
+   * already does (convention or explicit ref) plus {@link versionResource}. No
+   * client call, no credentials (ADR-0008): the value is never fetched, only its
+   * location is composed.
+   */
+  metadata(key: string, ref?: unknown): AdapterMetadata {
+    return { adapter: "gcp", resource: this.versionResource(this.storedName(key, ref)) };
+  }
+
+  /**
+   * The stored secret name for a key: the convention `{namespace}__{key}` when no
+   * explicit ref is given, otherwise the coerced ref payload. Shared by `resolve`
+   * (which then accesses it) and `metadata` (which only addresses it).
+   */
+  private storedName(key: string, ref: unknown): string {
+    return ref === undefined ? conventionName(this.namespace, key) : refName("gcp", ref);
   }
 
   /** Create the secret container if it does not already exist (idempotent). */

--- a/packages/cli/src/adapters/registry.ts
+++ b/packages/cli/src/adapters/registry.ts
@@ -112,8 +112,14 @@ export function createAdapter(provider: Provider, ctx: AdapterContext): Adapter 
   }
 }
 
-/** Build the adapter for an environment, looking its provider up in its own config. */
-function adapterForEnvironment(projectDir: string, loaded: LoadedEnvironment): Adapter {
+/**
+ * Build the adapter for an environment, looking its provider up in its own
+ * config. Construction is offline and credential-free for every reference
+ * adapter (ADR-0008): the gcp client is constructed but never called until
+ * `resolve`/`write`, so `ls` can build an adapter solely to compute offline
+ * addresses via {@link Adapter.metadata}.
+ */
+export function adapterForEnvironment(projectDir: string, loaded: LoadedEnvironment): Adapter {
   const { shelf, name, provider: providerName } = loaded.environment;
   const provider = providerName === undefined ? undefined : loaded.config.providers[providerName];
   if (provider === undefined) {

--- a/packages/cli/src/commands/ls.ts
+++ b/packages/cli/src/commands/ls.ts
@@ -32,8 +32,11 @@ interface EnvironmentViewResult {
 }
 
 /**
- * `keyshelf ls` has two offline, value-free modes (ADR-0008). Both are pure file
- * reads — neither builds a provider, touches a backend, nor prints a key value.
+ * `keyshelf ls` has two offline, value-free modes (ADR-0008). Both are pure
+ * reads — they touch no backend and print no key value. The environment view may
+ * build the environment's adapter, but only to compute a key's offline backend
+ * **address** (never its value): adapter construction and `metadata()` are
+ * synchronous and credential-free, so this stays offline.
  *
  * - `keyshelf ls` (no argument) prints a project map: every shelf, its schema's
  *   key count, and the environments under it, as a tree.
@@ -41,6 +44,10 @@ interface EnvironmentViewResult {
  *   every declared key, in declaration order, annotated with its schema
  *   **presence** and this environment's **status** (`config` / `secret` /
  *   `ref → target` / `default` / `missing` / `unset`).
+ *
+ * Each secret key's offline backend address is carried in `--json` always, and
+ * shown in the human table only behind `--metadata` (the default table stays
+ * lean).
  *
  * Colour is applied semantically via {@link ux.colorize} and auto-disables on a
  * non-TTY and when `NO_COLOR` is set. Column alignment uses `string-width` so the
@@ -57,6 +64,7 @@ export default class Ls extends BaseCommand {
     "<%= config.bin %> ls",
     "<%= config.bin %> ls --json",
     "<%= config.bin %> ls backend/production",
+    "<%= config.bin %> ls backend/production --metadata",
     "<%= config.bin %> ls backend/production --json"
   ];
 

--- a/packages/cli/src/commands/ls.ts
+++ b/packages/cli/src/commands/ls.ts
@@ -1,9 +1,16 @@
-import { Args, ux } from "@oclif/core";
+import { Args, Flags, ux } from "@oclif/core";
 import stringWidth from "string-width";
+import { adapterForEnvironment } from "../adapters/registry.js";
 import { BaseCommand } from "../base-command.js";
 import { environmentKeyView, formatStatus, type KeyView } from "../env-view.js";
 import { loadEnvironment, loadProjectMap, type ProjectMap } from "../loader.js";
 import { parseTarget } from "../target.js";
+
+/** Render an {@link KeyView.metadata} address as a single-line table cell. */
+function metadataCell(view: KeyView): string {
+  if (view.metadata === undefined) return "";
+  return view.metadata.adapter === "gcp" ? view.metadata.resource : "";
+}
 
 /** One environment in the flat, environment-centric `--json` shape. */
 interface EnvironmentEntry {
@@ -60,15 +67,23 @@ export default class Ls extends BaseCommand {
     })
   };
 
+  static flags = {
+    metadata: Flags.boolean({
+      description:
+        "Show each secret key's offline backend address (e.g. its GCP Secret Manager resource) as an extra table column. Always present in --json.",
+      default: false
+    })
+  };
+
   async run(): Promise<ProjectMapResult | EnvironmentViewResult> {
-    const { args } = await this.parse(Ls);
+    const { args, flags } = await this.parse(Ls);
     const cwd = process.cwd();
 
     if (args.target === undefined) {
       return this.runProjectMap(cwd);
     }
 
-    return this.runEnvironmentView(cwd, args.target);
+    return this.runEnvironmentView(cwd, args.target, flags.metadata);
   }
 
   /** `keyshelf ls` — the whole-project map. */
@@ -83,13 +98,23 @@ export default class Ls extends BaseCommand {
   }
 
   /** `keyshelf ls <shelf>/<stage>` — one environment's key contract. */
-  private async runEnvironmentView(cwd: string, target: string): Promise<EnvironmentViewResult> {
+  private async runEnvironmentView(
+    cwd: string,
+    target: string,
+    showMetadata: boolean
+  ): Promise<EnvironmentViewResult> {
     const { shelf, stage } = parseTarget(target);
     const loaded = await loadEnvironment(cwd, shelf, stage);
-    const keys = environmentKeyView(loaded);
+    // Build the environment's adapter to compute offline secret addresses. This
+    // stays offline and credential-free: construction never reaches the backend,
+    // and metadata() is synchronous and network-free (ADR-0008). Adapter address
+    // metadata is always carried in --json; the human table shows it only behind
+    // --metadata.
+    const adapter = adapterForEnvironment(cwd, loaded);
+    const keys = environmentKeyView(loaded, adapter);
 
     if (!this.jsonEnabled()) {
-      this.renderKeyTable(keys);
+      this.renderKeyTable(keys, showMetadata);
     }
 
     return { shelf, stage, keys };
@@ -114,8 +139,13 @@ export default class Ls extends BaseCommand {
     }
   }
 
-  /** Print the borderless, column-aligned key table (non-JSON mode only). */
-  private renderKeyTable(keys: KeyView[]): void {
+  /**
+   * Print the borderless, column-aligned key table (non-JSON mode only). With
+   * `showMetadata`, append a METADATA column carrying each secret key's offline
+   * backend address (blank for keys with none); the default table omits it
+   * entirely so it stays lean.
+   */
+  private renderKeyTable(keys: KeyView[], showMetadata: boolean): void {
     if (keys.length === 0) {
       this.log("No keys declared.");
       return;
@@ -124,7 +154,8 @@ export default class Ls extends BaseCommand {
     const rows = keys.map((view) => ({
       key: view.key,
       presence: view.presence,
-      status: formatStatus(view, (color, text) => ux.colorize(color, text))
+      status: formatStatus(view, (color, text) => ux.colorize(color, text)),
+      metadata: metadataCell(view)
     }));
 
     // Column widths are measured on the *uncoloured* text (status here is plain,
@@ -132,15 +163,35 @@ export default class Ls extends BaseCommand {
     const keyWidth = columnWidth("KEY", rows, (r) => r.key);
     const presenceWidth = columnWidth("PRESENCE", rows, (r) => r.presence);
 
+    if (!showMetadata) {
+      this.log(
+        `${ux.colorize("bold", pad("KEY", keyWidth))}   ${ux.colorize(
+          "bold",
+          pad("PRESENCE", presenceWidth)
+        )}   ${ux.colorize("bold", "STATUS")}`
+      );
+      for (const row of rows) {
+        this.log(`${pad(row.key, keyWidth)}   ${pad(row.presence, presenceWidth)}   ${row.status}`);
+      }
+      return;
+    }
+
+    // STATUS carries glyphs/colour, so pad it on its uncoloured display width to
+    // keep the trailing METADATA column aligned.
+    const statusWidth = columnWidth("STATUS", rows, (r) => r.status);
     this.log(
       `${ux.colorize("bold", pad("KEY", keyWidth))}   ${ux.colorize(
         "bold",
         pad("PRESENCE", presenceWidth)
-      )}   ${ux.colorize("bold", "STATUS")}`
+      )}   ${ux.colorize("bold", pad("STATUS", statusWidth))}   ${ux.colorize("bold", "METADATA")}`
     );
-
     for (const row of rows) {
-      this.log(`${pad(row.key, keyWidth)}   ${pad(row.presence, presenceWidth)}   ${row.status}`);
+      this.log(
+        `${pad(row.key, keyWidth)}   ${pad(row.presence, presenceWidth)}   ${pad(
+          row.status,
+          statusWidth
+        )}   ${row.metadata}`
+      );
     }
   }
 }

--- a/packages/cli/src/env-view.ts
+++ b/packages/cli/src/env-view.ts
@@ -1,3 +1,4 @@
+import type { Adapter, AdapterMetadata } from "./adapters/adapter.js";
 import type { Environment, KeyReference, LoadedEnvironment, SchemaKey } from "./model.js";
 
 /** A key's schema presence requirement, surfaced in the environment key view. */
@@ -19,6 +20,13 @@ export interface KeyView {
   status: Status;
   /** Resolved `!ref` coordinates (defaults applied); present only for `ref` keys. */
   reference?: Required<KeyReference>;
+  /**
+   * The key's offline backend **address** (never its value), present only for
+   * `secret` keys when the environment's adapter implements
+   * {@link Adapter.metadata}. Computed without any network or credentials
+   * (ADR-0008).
+   */
+  metadata?: AdapterMetadata;
 }
 
 /**
@@ -31,10 +39,20 @@ export interface KeyView {
  * (target stage → the current stage, target key → the consuming key's own name)
  * so the target is reported without the reference being followed. No key value is
  * read or returned.
+ *
+ * When an `adapter` is supplied and implements {@link Adapter.metadata}, each
+ * `secret` key is annotated with its offline backend **address** (its storage
+ * location, never its value — ADR-0008). `metadata()` is synchronous and
+ * network-free, so this stays a pure, offline read. Only `secret` keys are
+ * addressed: a `!ref` key resolves through its *target* environment's provider,
+ * not this one's, so addressing it here would be misleading; config/default/
+ * unset/missing keys have no backend storage at all.
  */
-export function environmentKeyView(loaded: LoadedEnvironment): KeyView[] {
+export function environmentKeyView(loaded: LoadedEnvironment, adapter?: Adapter): KeyView[] {
   const { schema, environment } = loaded;
-  return Object.entries(schema.keys).map(([key, declared]) => keyView(key, declared, environment));
+  return Object.entries(schema.keys).map(([key, declared]) =>
+    keyView(key, declared, environment, adapter)
+  );
 }
 
 /** A key's schema presence requirement, derived from its declared kind. */
@@ -45,7 +63,12 @@ const PRESENCE_OF: Record<SchemaKey["kind"], Presence> = {
 };
 
 /** The view of one declared key against the environment that may (or may not) supply it. */
-function keyView(key: string, declared: SchemaKey, environment: Environment): KeyView {
+function keyView(
+  key: string,
+  declared: SchemaKey,
+  environment: Environment,
+  adapter?: Adapter
+): KeyView {
   const presence = PRESENCE_OF[declared.kind];
   const supplied = environment.keys[key];
 
@@ -63,7 +86,18 @@ function keyView(key: string, declared: SchemaKey, environment: Environment): Ke
     };
   }
 
-  return { key, presence, status: supplied.kind === "secret" ? "secret" : "config" };
+  if (supplied.kind === "secret") {
+    // Address the secret offline through the environment's own adapter, if it can
+    // (an adapter that can't compute an address without a network call omits
+    // metadata() — ADR-0008). The explicit `!secret { ref }` payload, if any,
+    // overrides the convention address.
+    const metadata = adapter?.metadata?.(key, supplied.ref);
+    return metadata === undefined
+      ? { key, presence, status: "secret" }
+      : { key, presence, status: "secret", metadata };
+  }
+
+  return { key, presence, status: "config" };
 }
 
 /** The status of a key the environment omits: default-backed, optional, or required. */

--- a/packages/cli/test/e2e/ls-env.e2e.test.ts
+++ b/packages/cli/test/e2e/ls-env.e2e.test.ts
@@ -176,3 +176,121 @@ describe("keyshelf ls <shelf>/<stage> (environment key view)", () => {
     expect(JSON.parse(stdout).error.code).toBe("MALFORMED_FILE");
   });
 });
+
+/**
+ * A project backed by the gcp adapter, which implements offline `metadata()`.
+ * No credentials are configured: `ls` must build the adapter and compute the
+ * Secret Manager address without ever reaching the network (ADR-0008).
+ */
+async function scaffoldGcp(): Promise<void> {
+  await write(
+    ".keyshelf/config.yaml",
+    `project: myapp
+providers:
+  cloud:
+    adapter: gcp
+    projectId: my-gcp-project
+`
+  );
+  await write(
+    ".keyshelf/backend/schema.yaml",
+    `keys:
+  DATABASE_PASSWORD: !required
+  SHARED_TOKEN: !required
+  LOG_LEVEL: info
+`
+  );
+  await write(
+    ".keyshelf/backend/production.yaml",
+    `provider: cloud
+keys:
+  DATABASE_PASSWORD: !secret
+  SHARED_TOKEN: !secret
+    ref: shared-secret
+  LOG_LEVEL: debug
+`
+  );
+}
+
+describe("keyshelf ls <shelf>/<stage> (adapter metadata, offline)", () => {
+  it("always includes the gcp address in --json for secret keys (omits it elsewhere)", async () => {
+    await scaffoldGcp();
+    const { code, stdout } = await runKeyshelf(["ls", "backend/production", "--json"], { cwd });
+    expect(code).toBe(0);
+    const result = JSON.parse(stdout);
+    expect(result.keys).toEqual([
+      {
+        key: "DATABASE_PASSWORD",
+        presence: "required",
+        status: "secret",
+        metadata: {
+          adapter: "gcp",
+          resource:
+            "projects/my-gcp-project/secrets/keyshelf__myapp__backend__production__DATABASE_PASSWORD/versions/latest"
+        }
+      },
+      {
+        key: "SHARED_TOKEN",
+        presence: "required",
+        status: "secret",
+        metadata: {
+          adapter: "gcp",
+          resource: "projects/my-gcp-project/secrets/shared-secret/versions/latest"
+        }
+      },
+      { key: "LOG_LEVEL", presence: "default", status: "config" }
+    ]);
+  });
+
+  it("shows a METADATA column behind --metadata; the default table omits it", async () => {
+    await scaffoldGcp();
+    const plain = await runKeyshelf(["ls", "backend/production"], { cwd });
+    expect(plain.code).toBe(0);
+    expect(plain.stdout).not.toContain("METADATA");
+    expect(plain.stdout).not.toContain("versions/latest");
+    expect(plain.stdout.split("\n")[0]).toMatch(/^KEY\s+PRESENCE\s+STATUS$/);
+
+    const withMeta = await runKeyshelf(["ls", "backend/production", "--metadata"], { cwd });
+    expect(withMeta.code).toBe(0);
+    expect(withMeta.stdout.split("\n")[0]).toMatch(/^KEY\s+PRESENCE\s+STATUS\s+METADATA$/);
+    expect(withMeta.stdout).toContain(
+      "projects/my-gcp-project/secrets/keyshelf__myapp__backend__production__DATABASE_PASSWORD/versions/latest"
+    );
+    expect(withMeta.stdout).toContain(
+      "projects/my-gcp-project/secrets/shared-secret/versions/latest"
+    );
+  });
+
+  it("remains fully offline with no GCP credentials available (no network)", async () => {
+    await scaffoldGcp();
+    // Point ADC at a non-existent file and disable any ambient project so a
+    // network/credential attempt would fail loudly. ls must still succeed.
+    const { code, stdout } = await runKeyshelf(["ls", "backend/production", "--json"], {
+      cwd,
+      env: {
+        GOOGLE_APPLICATION_CREDENTIALS: path.join(cwd, "does-not-exist.json"),
+        GCLOUD_PROJECT: "",
+        GOOGLE_CLOUD_PROJECT: ""
+      }
+    });
+    expect(code).toBe(0);
+    expect(JSON.parse(stdout).keys[0].metadata.adapter).toBe("gcp");
+  });
+
+  it("omits metadata for an adapter that does not implement it (sops --json)", async () => {
+    await scaffold();
+    const { code, stdout } = await runKeyshelf(["ls", "backend/production", "--json"], { cwd });
+    expect(code).toBe(0);
+    for (const key of JSON.parse(stdout).keys) {
+      expect(key.metadata).toBeUndefined();
+    }
+  });
+
+  it("--metadata leaves the table unchanged when no key has metadata (sops)", async () => {
+    await scaffold();
+    const { code, stdout } = await runKeyshelf(["ls", "backend/production", "--metadata"], { cwd });
+    expect(code).toBe(0);
+    // No adapter address to show, so the METADATA column stays empty (cells blank).
+    expect(stdout).not.toContain("versions/latest");
+  });
+});

--- a/packages/cli/test/unit/env-view.test.ts
+++ b/packages/cli/test/unit/env-view.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import type { Adapter, AdapterMetadata } from "../../src/adapters/adapter.js";
 import {
   environmentKeyView,
   formatStatus,
@@ -99,6 +100,89 @@ describe("environmentKeyView", () => {
 
   it("returns an empty array for a schema that declares no keys", () => {
     expect(environmentKeyView(loaded({}, {}))).toEqual([]);
+  });
+
+  describe("metadata (offline adapter address)", () => {
+    /** A stub adapter that records every metadata() call and echoes the key/ref. */
+    function stubAdapter(): Adapter & { calls: Array<{ key: string; ref?: unknown }> } {
+      const calls: Array<{ key: string; ref?: unknown }> = [];
+      return {
+        calls,
+        resolve: () => Promise.reject(new Error("must not resolve")),
+        write: () => Promise.reject(new Error("must not write")),
+        metadata(key, ref): AdapterMetadata {
+          calls.push({ key, ref });
+          return { adapter: "gcp", resource: `addr/${key}` };
+        }
+      };
+    }
+
+    it("attaches metadata to secret keys, passing the explicit !secret ref payload", () => {
+      const adapter = stubAdapter();
+      const view = environmentKeyView(
+        loaded(
+          { TOKEN: { kind: "required" }, OTHER: { kind: "required" } },
+          {
+            TOKEN: { kind: "secret" },
+            OTHER: { kind: "secret", ref: { ref: "shared-name" } }
+          }
+        ),
+        adapter
+      );
+      expect(view[0]).toEqual({
+        key: "TOKEN",
+        presence: "required",
+        status: "secret",
+        metadata: { adapter: "gcp", resource: "addr/TOKEN" }
+      });
+      expect(view[1].metadata).toEqual({ adapter: "gcp", resource: "addr/OTHER" });
+      expect(adapter.calls).toEqual([
+        { key: "TOKEN", ref: undefined },
+        { key: "OTHER", ref: { ref: "shared-name" } }
+      ]);
+    });
+
+    it("omits metadata for non-secret keys (config, default, ref, missing, unset)", () => {
+      const adapter = stubAdapter();
+      const view = environmentKeyView(
+        loaded(
+          {
+            CFG: { kind: "config", default: "x" },
+            DEF: { kind: "config", default: "x" },
+            REFK: { kind: "required" },
+            MISS: { kind: "required" },
+            OPT: { kind: "optional" }
+          },
+          {
+            CFG: { kind: "config", value: "y" },
+            REFK: { kind: "ref", reference: { shelf: "other" } }
+          }
+        ),
+        adapter
+      );
+      for (const v of view) expect(v.metadata).toBeUndefined();
+      // Only secret keys are addressed — none here, so the adapter is never called.
+      expect(adapter.calls).toEqual([]);
+    });
+
+    it("omits metadata when the adapter does not implement metadata()", () => {
+      const adapter: Adapter = {
+        resolve: () => Promise.reject(new Error("no")),
+        write: () => Promise.reject(new Error("no"))
+      };
+      const view = environmentKeyView(
+        loaded({ TOKEN: { kind: "required" } }, { TOKEN: { kind: "secret" } }),
+        adapter
+      );
+      expect(view[0].metadata).toBeUndefined();
+    });
+
+    it("omits metadata entirely when no adapter is supplied", () => {
+      const view = environmentKeyView(
+        loaded({ TOKEN: { kind: "required" } }, { TOKEN: { kind: "secret" } })
+      );
+      expect(view[0].metadata).toBeUndefined();
+    });
   });
 });
 

--- a/packages/cli/test/unit/gcp.test.ts
+++ b/packages/cli/test/unit/gcp.test.ts
@@ -129,6 +129,53 @@ describe("GcpAdapter", () => {
     });
   });
 
+  describe("metadata (offline address)", () => {
+    it("returns the full convention version resource for a bare key", () => {
+      const { client } = fakeClient();
+      const meta = adapter(client).metadata("DATABASE_PASSWORD");
+      expect(meta).toEqual({
+        adapter: "gcp",
+        resource:
+          "projects/test-proj/secrets/keyshelf__myapp__web__staging__DATABASE_PASSWORD/versions/latest"
+      });
+    });
+
+    it("addresses an explicit bare-id ref in the configured project", () => {
+      const { client } = fakeClient();
+      const meta = adapter(client).metadata("ANY_KEY", { ref: "shared-token" });
+      expect(meta).toEqual({
+        adapter: "gcp",
+        resource: "projects/test-proj/secrets/shared-token/versions/latest"
+      });
+    });
+
+    it("addresses a foreign full-resource ref verbatim, appending versions/latest", () => {
+      const { client } = fakeClient();
+      const meta = adapter(client).metadata("ANY_KEY", {
+        ref: "projects/other-proj/secrets/foreign"
+      });
+      expect(meta).toEqual({
+        adapter: "gcp",
+        resource: "projects/other-proj/secrets/foreign/versions/latest"
+      });
+    });
+
+    it("preserves a foreign full-resource ref that already pins a version", () => {
+      const { client } = fakeClient();
+      const meta = adapter(client).metadata("ANY_KEY", {
+        ref: "projects/other-proj/secrets/foreign/versions/3"
+      });
+      expect(meta.resource).toBe("projects/other-proj/secrets/foreign/versions/3");
+    });
+
+    it("computes the address with no backend call (offline)", () => {
+      // A client that rejects every call: metadata must never touch it.
+      const client = throwingClient(new Error("network must not be reached"));
+      const meta = adapter(client).metadata("KEY");
+      expect(meta.adapter).toBe("gcp");
+    });
+  });
+
   describe("value fidelity (byte-exact round-trip)", () => {
     const cases: ReadonlyArray<readonly [string, string]> = [
       ["embedded newlines", "line1\nline2\nline3"],


### PR DESCRIPTION
Closes #235

## What

Adds an optional, **offline** `metadata()` to the `Adapter` interface and surfaces its result in `keyshelf ls <shelf>/<stage>`, giving users the storage *address* of a secret (e.g. its GCP Secret Manager resource path) without resolving its *value*.

## Design

- **`Adapter.metadata?(key, ref?): AdapterMetadata`** — optional, **synchronous** (the non-`Promise` return structurally forbids async I/O), network- and credential-free. `AdapterMetadata` is a discriminated union on `adapter`; the only concrete variant today is `{ adapter: "gcp"; resource: string }`.
- **GCP** implements it by reusing the existing convention/ref naming plus the `versions/latest` resource composition, for both default-convention and explicit-`ref` keys. Fully offline — no client call.
- **`environmentKeyView(loaded, adapter?)`** now annotates each `secret` key with its address when the adapter provides one. `!ref` keys are intentionally left unaddressed (they resolve through the *target* environment's provider, not the consumer's); config/default/unset/missing keys have no backend storage.
- **`ls`** builds the environment's adapter (offline) and:
  - **`--json`: always** emits `metadata` for keys whose adapter provides it; omits it otherwise.
  - **Human table: behind `--metadata`** — adds a `METADATA` column; the default table is unchanged.

## Offline guarantee

`ls` stays fully offline and credential-free. Verified by e2e tests that run with a `gcp` provider but **no credentials** (ADC pointed at a non-existent file), by a unit test using a client that rejects every call, and by the sops case where `metadata()` is absent so the field is omitted.

## ADR-0008

Amended to permit building a provider/adapter **solely to compute storage addresses** — safe because construction and `metadata()` are offline and credential-free. The value-free + offline intent is unchanged; an address is not a value. `--metadata` is the human-table opt-in; `--json` carries it always.

## Tests

Full local CI-equivalent run green: `typecheck`, `lint`, `format:check`, `validate:examples`, `build`, `npm test -w keyshelf` (307 passed, 3 skipped — the infra-gated gcp conformance + tier2 suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RjDoYnFobvxUa7JtRcxCWT