### PR TITLE
fix(ci): pass --repo to publish dispatch so auto-publish works

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,9 +117,15 @@ jobs:
       # created (the common case — just maintaining the release PR) this step is
       # skipped and nothing is dispatched. Output keys are path-prefixed for a
       # manifest config and the path contains a slash, so bracket access is required.
+      # This job has no actions/checkout step, so there is no local git repo for
+      # `gh` to infer the target from — without an explicit repo it fails with
+      # `fatal: not a git repository` and the publish is silently never
+      # dispatched. Pass the repo explicitly (github.repository, e.g.
+      # `pantoninho/keyshelf`) via --repo so the dispatch works without a checkout.
       - name: Dispatch Publish workflow for the new release tag
         if: ${{ steps.release.outputs['packages/cli--release_created'] }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ steps.release.outputs['packages/cli--tag_name'] }}
-        run: gh workflow run publish.yml --ref "$TAG_NAME"
+          GH_REPO: ${{ github.repository }}
+        run: gh workflow run publish.yml --ref "$TAG_NAME" --repo "$GH_REPO"


### PR DESCRIPTION
## Problem

When a release is cut, the `release-please` job in `ci.yml` is supposed to auto-dispatch `publish.yml`. It doesn't work: the job has **no `actions/checkout` step**, so `gh workflow run` has no local git repository to infer the target from and fails:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
##[error]Process completed with exit code 1
```

The dispatch step errors → the job fails → `publish.yml` is never started. A cut release produces the `keyshelf-v*` tag and a GitHub release but **nothing reaches npm**.

This was caught live on the **6.1.1** release: tag + release were created, but the package had to be published via the documented manual fallback (`gh workflow run publish.yml --ref keyshelf-v6.1.1`).

## Fix

Pass the repository explicitly so `gh` doesn't need a checkout:

```yaml
env:
  GH_REPO: ${{ github.repository }}
run: gh workflow run publish.yml --ref "$TAG_NAME" --repo "$GH_REPO"
```

`github.repository` resolves to `pantoninho/keyshelf` at runtime. Minimal change — no new checkout step needed.

## Note

This only affects the dispatch path. Manual `gh workflow run publish.yml --ref keyshelf-v<x.y.z>` from a real checkout (the fallback) was, and remains, unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)