### PR TITLE
fix(run): forward termination signals to the wrapped child

### DIFF
--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -126,7 +126,33 @@ export default class Run extends BaseCommand {
     const status = await new Promise<number>((resolve, reject) => {
       const child = spawn(cmd, args, { stdio: "inherit", env: childEnv });
 
+      // Act as a well-mannered supervisor/init: relay termination signals sent to
+      // the keyshelf process *alone* (a process manager, `kill <pid>`, or a
+      // container platform like Cloud Run sending SIGTERM to PID 1) on to the
+      // child, which would otherwise never see them. Node cannot execve-replace
+      // the process, so spawn + explicit forwarding is the correct approach.
+      const forwarded: NodeJS.Signals[] = ["SIGTERM", "SIGINT", "SIGHUP", "SIGQUIT"];
+      const forward = (signal: NodeJS.Signals) => {
+        // Best-effort: the child may have already exited (ESRCH), or be unkillable;
+        // never let a failed relay crash keyshelf.
+        try {
+          if (child.pid !== undefined) child.kill(signal);
+        } catch {
+          // ignore — child already gone
+        }
+      };
+      const handlers = new Map<NodeJS.Signals, () => void>();
+      for (const signal of forwarded) {
+        const handler = () => forward(signal);
+        handlers.set(signal, handler);
+        process.on(signal, handler);
+      }
+      const removeHandlers = () => {
+        for (const [signal, handler] of handlers) process.removeListener(signal, handler);
+      };
+
       child.on("error", (error) => {
+        removeHandlers();
         reject(
           new KeyshelfError("EXEC_FAILED", `Could not start command '${cmd}': ${error.message}`, {
             command: cmd,
@@ -136,6 +162,9 @@ export default class Run extends BaseCommand {
       });
 
       child.on("exit", (code, signal) => {
+        // The child is reaped by the time `exit` fires; drop the signal handlers
+        // so a late signal does not target a recycled PID.
+        removeHandlers();
         // Propagate the wrapped command's status. A signal-terminated child maps
         // to the conventional 128 + signal number.
         resolve(signal === null ? (code ?? 0) : 128 + signalNumber(signal));

--- a/packages/cli/test/e2e/run.e2e.test.ts
+++ b/packages/cli/test/e2e/run.e2e.test.ts
@@ -1,5 +1,5 @@
-import { execFile } from "node:child_process";
-import { mkdir, writeFile } from "node:fs/promises";
+import { execFile, spawn } from "node:child_process";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
@@ -334,5 +334,98 @@ describe("keyshelf run <shelf>/<stage> -- <cmd>", () => {
     const { code, stdout } = await runKeyshelf(["run", "--help"], { cwd });
     expect(code).toBe(0);
     expect(stdout).toContain("run");
+  });
+
+  // Signal forwarding: a SIGTERM (or SIGINT/SIGHUP/SIGQUIT) sent to the keyshelf
+  // process alone — not the whole foreground process group — must be relayed to
+  // the wrapped child so it can shut down gracefully. This is the container
+  // entrypoint / supervised-process path, where the interactive Ctrl-C masking
+  // does not apply.
+  for (const signal of ["SIGTERM", "SIGINT", "SIGHUP", "SIGQUIT"] as const) {
+    it(`forwards ${signal} to the wrapped child so it can shut down gracefully`, async () => {
+      await scaffold();
+      const marker = path.join(cwd, `${signal}.marker`);
+      // The child traps the signal, writes a marker, and exits 0. A child that
+      // never received the signal would instead run for the full 30s and the
+      // test would time out / read no marker.
+      const childScript = [
+        `process.on(${JSON.stringify(signal)}, () => {`,
+        `  require('fs').writeFileSync(${JSON.stringify(marker)}, 'caught');`,
+        `  process.exit(0);`,
+        `});`,
+        // Signal readiness on stdout so the test sends the signal only once the
+        // handler is installed, then idle long enough to require forwarding.
+        `process.stdout.write('ready');`,
+        `setTimeout(() => process.exit(1), 30000);`
+      ].join("\n");
+
+      const child = spawn("node", [BIN, "run", "web/staging", "--", "node", "-e", childScript], {
+        cwd,
+        env: { ...process.env },
+        stdio: ["ignore", "pipe", "pipe"]
+      });
+
+      // Wait until the wrapped child has installed its handler and printed
+      // 'ready' on stdout (relayed through keyshelf's inherited stdio).
+      await new Promise<void>((resolve, reject) => {
+        let out = "";
+        child.stdout.on("data", (chunk: Buffer) => {
+          out += chunk.toString();
+          if (out.includes("ready")) resolve();
+        });
+        child.on("error", reject);
+        child.on("exit", () => {
+          if (!out.includes("ready")) reject(new Error("child exited before becoming ready"));
+        });
+      });
+
+      // Send the signal to the keyshelf process *alone*.
+      child.kill(signal);
+
+      const code = await new Promise<number>((resolve) => {
+        child.on("exit", (exitCode) => resolve(exitCode ?? -1));
+      });
+
+      // The wrapped child caught the signal and shut down gracefully.
+      expect(await readFile(marker, "utf8")).toBe("caught");
+      // keyshelf propagates the child's own exit status (0 here).
+      expect(code).toBe(0);
+    });
+  }
+
+  it("maps a signal-terminated child to 128 + signum after forwarding", async () => {
+    await scaffold();
+    // The child installs *no* handler, so the forwarded SIGTERM terminates it.
+    // keyshelf must report the conventional 128 + 15 = 143.
+    const child = spawn(
+      "node",
+      [
+        BIN,
+        "run",
+        "web/staging",
+        "--",
+        "node",
+        "-e",
+        "process.stdout.write('ready'); setTimeout(() => {}, 30000);"
+      ],
+      { cwd, env: { ...process.env }, stdio: ["ignore", "pipe", "pipe"] }
+    );
+
+    await new Promise<void>((resolve, reject) => {
+      let out = "";
+      child.stdout.on("data", (chunk: Buffer) => {
+        out += chunk.toString();
+        if (out.includes("ready")) resolve();
+      });
+      child.on("error", reject);
+    });
+
+    child.kill("SIGTERM");
+
+    const code = await new Promise<number>((resolve) => {
+      child.on("exit", (exitCode) => resolve(exitCode ?? -1));
+    });
+
+    expect(code).toBe(143);
   });
 });


### PR DESCRIPTION
## Summary

`keyshelf run <shelf>/<stage> -- <cmd>` spawned the wrapped command but never relayed signals delivered to the keyshelf process **alone** — so a `SIGTERM` from a process manager (`kill <pid>`) or a container platform (Cloud Run sends `SIGTERM` to PID 1 for graceful shutdown) was swallowed and the app was hard-killed without a graceful drain.

`exec()` now acts as a well-mannered supervisor/init:

- Forwards `SIGTERM`, `SIGINT`, `SIGHUP`, `SIGQUIT` to the child.
- Detaches the handlers on child exit (and on spawn error) so a late signal never targets a recycled PID; the child is reaped by the time `exit` fires.
- Forwarding is best-effort — an `ESRCH` (child already gone) never crashes keyshelf.
- Existing exit-code propagation, including the `128 + signum` mapping for signal-terminated children, is preserved.

## Tests

Regression tests in `run.e2e.test.ts` spawn `keyshelf run` as a child, wait for the wrapped node process to install its handler and print `ready`, then send the signal to the keyshelf process alone:

- One per signal (`SIGTERM`/`SIGINT`/`SIGHUP`/`SIGQUIT`): the child traps it, writes a marker, exits 0; the test asserts the marker + exit code 0.
- A child with **no** handler is terminated by the forwarded `SIGTERM`; the test asserts keyshelf reports `128 + 15 = 143`.

Full CLI suite green (312 passed, 3 skipped); lint, format:check, typecheck, validate:examples all pass locally.

Closes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WAfsC5zQK2m8qsvFWUYQxX