### PR TITLE
feat(sops): add ageKeyFile provider field to locate the age decryption identity

### DIFF
--- a/docs/adr/0002-secrets-live-in-adapter-stores.md
+++ b/docs/adr/0002-secrets-live-in-adapter-stores.md
@@ -38,3 +38,9 @@ Keyshelf does not manage sops recipients — adding or rotating who can decrypt 
 done by editing `.sops.yaml` and re-encrypting, outside keyshelf. `delete`,
 `list`, and `rotate` are not part of the adapter contract in the MVP; nothing in
 the `set`/`run` loop needs them.
+
+The "authentication is delegated to the backend's native mechanism" principle is
+narrowed, not broken, by ADR-0010: a `ageKeyFile` provider field lets keyshelf
+_locate_ the sops age identity per-environment and hand it to sops as
+`SOPS_AGE_KEY_FILE`. keyshelf still manages no keys and no recipients — it only
+sets sops's own env var. The "locate, don't manage" boundary lives there.

--- a/docs/adr/0010-sops-age-key-file-provider-field.md
+++ b/docs/adr/0010-sops-age-key-file-provider-field.md
@@ -1,0 +1,63 @@
+# Locating the sops age identity per-environment: the `ageKeyFile` provider field
+
+## Decision
+
+The sops provider config gains one optional field, `ageKeyFile`, pointing at an
+age identity file. When present, keyshelf resolves it relative to the project root
+and exports it to every `sops` invocation for that environment as
+`SOPS_AGE_KEY_FILE`. When absent, behavior is unchanged: sops uses the ambient
+`SOPS_AGE_KEY_FILE` and its other native key sources.
+
+```yaml
+providers:
+  local:
+    adapter: sops
+    ageKeyFile: ".keyshelf/age.key" # optional; resolved relative to the project root
+```
+
+This extends — and does not reshape — the two-method adapter contract (ADR-0002),
+the provider config model, or the conformance suites (ADR-0005). It is **additive,
+not breaking**: existing configs with no `ageKeyFile` resolve exactly as before.
+
+## Why
+
+ADR-0002 says, flatly, that "authentication is delegated to each backend's native
+credential mechanism" and that recipients "are governed by the project's native
+`.sops.yaml`, not by keyshelf." This ADR is the first config knob that touches
+sops authentication, so the boundary it draws is load-bearing and recorded here
+precisely:
+
+- **keyshelf locates; sops manages.** `ageKeyFile` only tells keyshelf _where the
+  key is_ so it can set sops's own `SOPS_AGE_KEY_FILE`. keyshelf never reads,
+  parses, derives, or rotates the key — all key handling stays inside sops. The
+  _mechanism_ is still fully delegated, exactly as ADR-0002 requires; only the
+  _location_ moves from ambient process env into per-environment config.
+- **Recipients are untouched.** This affects _who decrypts on this machine_, not
+  _who can decrypt_ (encryption recipients), which remain 100% governed by
+  `.sops.yaml`. So the load-bearing part of ADR-0002 — keyshelf does not manage
+  recipients — is preserved.
+- **Per-environment, not process-wide.** Because the adapter is rebuilt per
+  environment (`adapterForEnvironment`), different shelves/stages can name
+  different identity files — something a single ambient `SOPS_AGE_KEY_FILE` cannot
+  express. This is the concrete win over the env-var-only status quo: a project
+  whose environments decrypt under different age identities can declare that in
+  committed config instead of orchestrating env vars per `keyshelf run`.
+
+The field is named `ageKeyFile`, not a generic `identity`, on purpose:
+`SOPS_AGE_KEY_FILE` only governs **age** identities. PGP uses the gpg agent;
+KMS/GCP/Azure use cloud credentials. A generic name would over-promise coverage
+keyshelf does not provide. A future backend wanting its own auth-location knob
+adds its own explicitly-named field under the same "locate, don't manage"
+boundary.
+
+## Consequences
+
+- Wrong or missing key behavior is unchanged: sops failing to recover the data key
+  still maps to `PROVIDER_AUTH` via the adapter's existing error mapping
+  (ADR-0005). `ageKeyFile` adds no new error code.
+- The field is resolved relative to the project root, mirroring `store`; an
+  absolute path is honored as-is (`path.resolve`).
+- keyshelf still does not manage recipients, rotation, or any non-age sops key
+  source; those remain `.sops.yaml` / native-mechanism concerns (ADR-0002).
+- The conformance suite proves the field drives decryption end-to-end with **no
+  ambient `SOPS_AGE_KEY_FILE`**, so the delegation is exercised, not assumed.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -28,6 +28,9 @@ providers:
   local:
     adapter: sops # only required field for sops
     # store: "{shelf}/{stage}.secrets.yaml"   # optional layout override (default shown)
+    # ageKeyFile: ".keyshelf/age.key"         # optional; locates the age decryption identity
+    #                                         # (resolved relative to project root; ADR-0010).
+    #                                         # Absent ⇒ ambient SOPS_AGE_KEY_FILE / native sops sources.
   gcp-staging:
     adapter: gcp
     projectId: my-gcp-proj-stg # required; adapter fields never reuse `project`

--- a/package-lock.json
+++ b/package-lock.json
@@ -11141,7 +11141,7 @@
     },
     "packages/cli": {
       "name": "keyshelf",
-      "version": "6.3.0",
+      "version": "6.3.1",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/secret-manager": "^6.2.0",

--- a/packages/cli/src/adapters/registry.ts
+++ b/packages/cli/src/adapters/registry.ts
@@ -87,7 +87,17 @@ export function createAdapter(provider: Provider, ctx: AdapterContext): Adapter 
       // The store is a per-environment encrypted sibling file; recipients come
       // from the project's `.sops.yaml`, which sops discovers by walking up from
       // the store path — so the adapter runs sops with the project root as cwd.
-      return new SopsAdapter({ storePath: sopsStorePath(provider, ctx), cwd: ctx.projectDir });
+      // An optional `ageKeyFile` locates the decryption identity per-environment
+      // (ADR-0010); it is resolved relative to the project root, like `store`.
+      const ageKeyFile =
+        typeof provider.ageKeyFile === "string"
+          ? path.resolve(ctx.projectDir, provider.ageKeyFile)
+          : undefined;
+      return new SopsAdapter({
+        storePath: sopsStorePath(provider, ctx),
+        cwd: ctx.projectDir,
+        ageKeyFile
+      });
     }
 
     case "gcp": {

--- a/packages/cli/src/adapters/sops.ts
+++ b/packages/cli/src/adapters/sops.ts
@@ -31,6 +31,13 @@ const execFileAsync = promisify(execFile);
  * records a bare `!secret`. An explicit `!secret { ref: NAME }` resolves a
  * differently-named entry in the same store.
  *
+ * **Identity.** Encryption recipients are always the project's `.sops.yaml`'s
+ * concern (ADR-0002). The *decryption* identity is sops's own
+ * `SOPS_AGE_KEY_FILE` mechanism; an optional `ageKeyFile` provider field lets a
+ * project *locate* that age key per-environment (ADR-0010) — keyshelf only sets
+ * the env var, it never reads or manages the key. Absent, sops falls back to the
+ * ambient `SOPS_AGE_KEY_FILE` and its other native key sources.
+ *
  * **Error mapping** (uniform across adapters, ADR-0005):
  * - binary missing/unusable → `ADAPTER_UNAVAILABLE`;
  * - decryption-key/credential failure → `PROVIDER_AUTH`;
@@ -42,10 +49,13 @@ export class SopsAdapter implements Adapter {
   private readonly storePath: string;
   /** Directory sops runs in, so it discovers the project's `.sops.yaml`. */
   private readonly cwd: string;
+  /** Absolute path to an age identity, exported to sops as `SOPS_AGE_KEY_FILE`. */
+  private readonly ageKeyFile?: string;
 
-  constructor(opts: { storePath: string; cwd: string }) {
+  constructor(opts: { storePath: string; cwd: string; ageKeyFile?: string }) {
     this.storePath = opts.storePath;
     this.cwd = opts.cwd;
+    this.ageKeyFile = opts.ageKeyFile;
   }
 
   async resolve(key: string, ref?: unknown): Promise<string> {
@@ -138,9 +148,17 @@ export class SopsAdapter implements Adapter {
   /** Run sops, translating spawn/exit failures into the structured error codes. */
   private async sops(args: string[]): Promise<{ stdout: string; stderr: string }> {
     const bin = resolveSopsBinary();
+    // A configured `ageKeyFile` overlays sops's own `SOPS_AGE_KEY_FILE`; keyshelf
+    // sets the env var and lets sops do the key handling (ADR-0010). Absent, the
+    // ambient environment (and sops's other native sources) governs as before.
+    const env =
+      this.ageKeyFile === undefined
+        ? process.env
+        : { ...process.env, SOPS_AGE_KEY_FILE: this.ageKeyFile };
     try {
       const { stdout, stderr } = await execFileAsync(bin, args, {
         cwd: this.cwd,
+        env,
         maxBuffer: 64 * 1024 * 1024
       });
       return { stdout, stderr };

--- a/packages/cli/test/conformance/sops-age-key-file.contract.test.ts
+++ b/packages/cli/test/conformance/sops-age-key-file.contract.test.ts
@@ -1,0 +1,61 @@
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createAdapter } from "../../src/adapters/registry.js";
+import { KeyshelfError } from "../../src/errors.js";
+import { makeSopsFixture, sopsAvailable, type SopsFixture } from "./sops-fixture.js";
+
+// The `ageKeyFile` provider field (ADR-0010): keyshelf locates the sops age
+// identity per-environment, then delegates the mechanism by handing it to sops as
+// `SOPS_AGE_KEY_FILE`. These tests prove the field actually drives decryption —
+// with no ambient `SOPS_AGE_KEY_FILE` in the environment — and that the path is
+// resolved relative to the project root, exactly like `store`.
+//
+// Skips when no sops/age binary is resolvable, mirroring the contract suite.
+const d = sopsAvailable() ? describe : describe.skip;
+
+d("sops ageKeyFile provider field", () => {
+  let fixture: SopsFixture;
+  let savedEnv: string | undefined;
+
+  beforeEach(async () => {
+    fixture = await makeSopsFixture();
+    // The whole point of the field is to work *without* the ambient env var, so
+    // strip it for the duration and restore it after.
+    savedEnv = process.env.SOPS_AGE_KEY_FILE;
+    delete process.env.SOPS_AGE_KEY_FILE;
+  });
+
+  afterEach(async () => {
+    if (savedEnv === undefined) delete process.env.SOPS_AGE_KEY_FILE;
+    else process.env.SOPS_AGE_KEY_FILE = savedEnv;
+    await fixture.teardown();
+  });
+
+  it("round-trips with ageKeyFile resolved relative to the project root, no ambient key", async () => {
+    const ctx = { projectDir: fixture.dir, project: "myapp", shelf: "app", stage: "staging" };
+    // The fixture key lives under the project dir; reference it *relatively* so a
+    // successful resolve also proves the registry resolved it against projectDir.
+    const relKey = path.relative(fixture.dir, fixture.ageKeyFile);
+    const adapter = createAdapter({ adapter: "sops", ageKeyFile: relKey }, ctx);
+
+    await adapter.write("DATABASE_PASSWORD", "sekret");
+    expect(await adapter.resolve("DATABASE_PASSWORD")).toBe("sekret");
+  });
+
+  it("fails PROVIDER_AUTH when no ageKeyFile is configured and no ambient key exists", async () => {
+    const ctx = { projectDir: fixture.dir, project: "myapp", shelf: "app", stage: "staging" };
+    const adapter = createAdapter({ adapter: "sops" }, ctx);
+
+    // The store's data key can't be recovered without an identity: `write`'s
+    // `sops set` must decrypt to re-encrypt, so this is where it surfaces.
+    let thrown: unknown;
+    try {
+      await adapter.write("DATABASE_PASSWORD", "sekret");
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(KeyshelfError);
+    expect((thrown as KeyshelfError).code).toBe("PROVIDER_AUTH");
+  });
+});


### PR DESCRIPTION
## What

Adds an optional `ageKeyFile` field to the sops provider config. When present, keyshelf resolves it relative to the project root (like `store`) and exports it to every `sops` invocation for that environment as `SOPS_AGE_KEY_FILE`. Absent, behavior is unchanged.

```yaml
providers:
  local:
    adapter: sops
    ageKeyFile: ".keyshelf/age.key" # optional; resolved relative to project root
```

## Why

The sops adapter already delegates the *mechanism* of decryption to sops's own `SOPS_AGE_KEY_FILE`, but keyshelf had no way to *locate* that key — it relied entirely on the ambient env var, which can't vary per environment. Because the adapter is rebuilt per environment, `ageKeyFile` lets different shelves/stages decrypt under different age identities, declared in committed config instead of orchestrated as env vars per `keyshelf run`.

## Boundary: locate, don't manage

This is the first config knob that touches sops authentication, so it pokes ADR-0002's "authentication is delegated to each backend's native mechanism" principle. The carve-out (recorded in **ADR-0010**, with a forward-reference added to ADR-0002):

- keyshelf only *locates* the key and sets sops's own env var — it never reads, parses, derives, or rotates it. The mechanism stays fully delegated.
- **Encryption recipients are untouched** — still 100% governed by `.sops.yaml`. This only affects *who decrypts on this machine*.
- Named `ageKeyFile`, not generic `identity`, because `SOPS_AGE_KEY_FILE` only covers age — PGP/KMS/cloud use other mechanisms, and a generic name would over-promise.

## Tests

Written test-first (red → green). New conformance test proves the field drives decryption end-to-end **with the ambient `SOPS_AGE_KEY_FILE` stripped**, so it's the field — not leftover env — doing the work:
- positive: full write→resolve round-trip via a relative `ageKeyFile`, no ambient key;
- negative: no field + no ambient key → `PROVIDER_AUTH`.

Full suite: 342 passed / 3 pre-existing skips. Typecheck, eslint, prettier all clean.

> Note: `package-lock.json` has a one-line sync (6.3.0→6.3.1) — the 6.3.1 release commit left the lock stale; `npm install` corrected it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)