### PR TITLE
feat(sops): expand ~/ in ageKeyFile to the user's home directory

### DIFF
--- a/docs/adr/0010-sops-age-key-file-provider-field.md
+++ b/docs/adr/0010-sops-age-key-file-provider-field.md
@@ -56,7 +56,11 @@ boundary.
   still maps to `PROVIDER_AUTH` via the adapter's existing error mapping
   (ADR-0005). `ageKeyFile` adds no new error code.
 - The field is resolved relative to the project root, mirroring `store`; an
-  absolute path is honored as-is (`path.resolve`).
+  absolute path is honored as-is (`path.resolve`). A leading `~` or `~/` expands
+  to the user's home directory first — tilde expansion is a shell convenience that
+  `path.resolve` does not perform, so without it `~/key` would resolve literally to
+  `<projectDir>/~/key`. `~user` (another user's home) is left untouched, as that
+  needs a passwd lookup keyshelf does not do.
 - keyshelf still does not manage recipients, rotation, or any non-age sops key
   source; those remain `.sops.yaml` / native-mechanism concerns (ADR-0002).
 - The conformance suite proves the field drives decryption end-to-end with **no

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -29,7 +29,8 @@ providers:
     adapter: sops # only required field for sops
     # store: "{shelf}/{stage}.secrets.yaml"   # optional layout override (default shown)
     # ageKeyFile: ".keyshelf/age.key"         # optional; locates the age decryption identity
-    #                                         # (resolved relative to project root; ADR-0010).
+    #                                         # (relative to project root; ~ and ~/ expand to $HOME;
+    #                                         # absolute honored as-is; ADR-0010).
     #                                         # Absent ⇒ ambient SOPS_AGE_KEY_FILE / native sops sources.
   gcp-staging:
     adapter: gcp

--- a/packages/cli/src/adapters/registry.ts
+++ b/packages/cli/src/adapters/registry.ts
@@ -1,3 +1,4 @@
+import os from "node:os";
 import path from "node:path";
 import { KeyshelfError } from "../errors.js";
 import { loadEnvironment } from "../loader.js";
@@ -28,6 +29,20 @@ export interface AdapterContext {
 
 /** Where the file-backed fake store lives, relative to the project root. */
 const FAKE_STORE_FILE = path.join(".keyshelf", ".fake-store.json");
+
+/**
+ * Expand a leading `~` or `~/` in a config path to the user's home directory.
+ * Tilde expansion is a shell convenience, not a filesystem feature: `path.resolve`
+ * treats `~` as a literal segment, so an unexpanded `~/key` silently resolves to
+ * `<projectDir>/~/key` — a path that almost never exists, with a baffling error.
+ * Only a bare `~` or a `~/`-prefixed path is expanded; `~user` is left untouched,
+ * since resolving another user's home needs a passwd lookup keyshelf does not do.
+ */
+function expandHome(p: string): string {
+  if (p === "~") return os.homedir();
+  if (p.startsWith("~/") || p.startsWith("~\\")) return path.join(os.homedir(), p.slice(2));
+  return p;
+}
 
 /**
  * Read a required string field from a provider's config, or fail with a
@@ -88,10 +103,11 @@ export function createAdapter(provider: Provider, ctx: AdapterContext): Adapter 
       // from the project's `.sops.yaml`, which sops discovers by walking up from
       // the store path — so the adapter runs sops with the project root as cwd.
       // An optional `ageKeyFile` locates the decryption identity per-environment
-      // (ADR-0010); it is resolved relative to the project root, like `store`.
+      // (ADR-0010); a leading `~`/`~/` expands to the user's home, then it is
+      // resolved relative to the project root, like `store`.
       const ageKeyFile =
         typeof provider.ageKeyFile === "string"
-          ? path.resolve(ctx.projectDir, provider.ageKeyFile)
+          ? path.resolve(ctx.projectDir, expandHome(provider.ageKeyFile))
           : undefined;
       return new SopsAdapter({
         storePath: sopsStorePath(provider, ctx),

--- a/packages/cli/test/conformance/sops-age-key-file.contract.test.ts
+++ b/packages/cli/test/conformance/sops-age-key-file.contract.test.ts
@@ -42,6 +42,25 @@ d("sops ageKeyFile provider field", () => {
     expect(await adapter.resolve("DATABASE_PASSWORD")).toBe("sekret");
   });
 
+  it("expands a leading ~/ in ageKeyFile to the user's home directory", async () => {
+    const ctx = { projectDir: fixture.dir, project: "myapp", shelf: "app", stage: "staging" };
+    // Point HOME at the fixture dir so `~/age-key.txt` resolves to the fixture's
+    // key. A successful round-trip proves the tilde was expanded to $HOME, not
+    // resolved literally against projectDir (which would be `<dir>/~/age-key.txt`).
+    const savedHome = process.env.HOME;
+    process.env.HOME = fixture.dir;
+    try {
+      const tildeKey = `~/${path.relative(fixture.dir, fixture.ageKeyFile)}`;
+      const adapter = createAdapter({ adapter: "sops", ageKeyFile: tildeKey }, ctx);
+
+      await adapter.write("DATABASE_PASSWORD", "sekret");
+      expect(await adapter.resolve("DATABASE_PASSWORD")).toBe("sekret");
+    } finally {
+      if (savedHome === undefined) delete process.env.HOME;
+      else process.env.HOME = savedHome;
+    }
+  });
+
   it("fails PROVIDER_AUTH when no ageKeyFile is configured and no ambient key exists", async () => {
     const ctx = { projectDir: fixture.dir, project: "myapp", shelf: "app", stage: "staging" };
     const adapter = createAdapter({ adapter: "sops" }, ctx);


### PR DESCRIPTION
## What

Support tilde paths in the sops adapter's `ageKeyFile` provider field. A leading `~` or `~/` now expands to the user's home directory.

```yaml
providers:
  local:
    adapter: sops
    ageKeyFile: ~/.config/sops/age/keys.txt   # → $HOME/.config/sops/age/keys.txt
```

## Why

`path.resolve` treats `~` as a literal path segment, so an unexpanded `~/key` silently resolved to `<projectDir>/~/key` — a path that almost never exists, surfacing as a baffling sops failure. Users reach for `~/` instinctively for a key in their home dir, so silent misresolution is the worst outcome.

## Behavior

- Bare `~` and `~/`-prefixed paths expand to `os.homedir()`.
- `~user` (another user's home) is left untouched — resolving it needs a passwd lookup keyshelf does not do.
- Absolute and relative paths are unchanged. Additive, non-breaking.

## Tests

Added a conformance test that points `$HOME` at the fixture and uses `~/age-key.txt`, proving the tilde drives a real sops decrypt round-trip rather than resolving literally against the project root. Docs (ADR-0010, reference.md) updated.

`typecheck`, `eslint`, `prettier --check`, and the full cli suite (343 passed, 3 skipped) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaggABv2KfY1MxPB3vhkHY