### PR TITLE
fix(set): serialize a floating !secret as a bare tag, not `!secret null`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11141,7 +11141,7 @@
     },
     "packages/cli": {
       "name": "keyshelf",
-      "version": "6.5.0",
+      "version": "6.3.1",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/secret-manager": "^6.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11141,7 +11141,7 @@
     },
     "packages/cli": {
       "name": "keyshelf",
-      "version": "6.3.1",
+      "version": "6.5.0",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/secret-manager": "^6.2.0",

--- a/packages/cli/src/commands/set.ts
+++ b/packages/cli/src/commands/set.ts
@@ -8,7 +8,13 @@ import { conventionName, hasExplicitName, refName } from "../adapters/shared.js"
 import { BaseCommand } from "../base-command.js";
 import { KeyshelfError } from "../errors.js";
 import { loadEnvironment } from "../loader.js";
-import { secretRefForm, setConfigValue, setKeyReference, setSecretRef } from "../set.js";
+import {
+  secretRefForm,
+  serializeEnvDoc,
+  setConfigValue,
+  setKeyReference,
+  setSecretRef
+} from "../set.js";
 import { parseTarget } from "../target.js";
 import type { KeyReference } from "../model.js";
 
@@ -133,7 +139,7 @@ export default class Set extends BaseCommand {
       setConfigValue(doc, key, value);
     }
 
-    await writeFile(file, doc.toString(), "utf8");
+    await writeFile(file, serializeEnvDoc(doc), "utf8");
 
     const result: SetResult = {
       key,
@@ -188,7 +194,7 @@ export default class Set extends BaseCommand {
     );
     const name = hasExplicitName(existing.ref) ? refName("set", existing.ref) : conventionRef;
     setSecretRef(doc, key, secretRefForm(name, conventionRef, String(version)));
-    await writeFile(file, doc.toString(), "utf8");
+    await writeFile(file, serializeEnvDoc(doc), "utf8");
 
     const result: SetResult = {
       key,
@@ -232,7 +238,7 @@ export default class Set extends BaseCommand {
     // No provider/config beyond what loadForEdit reads — no adapter is created.
     const { file, doc } = await this.loadForEdit(shelf, stage, key);
     setKeyReference(doc, key, reference);
-    await writeFile(file, doc.toString(), "utf8");
+    await writeFile(file, serializeEnvDoc(doc), "utf8");
 
     const result: SetResult = {
       key,

--- a/packages/cli/src/set.ts
+++ b/packages/cli/src/set.ts
@@ -87,6 +87,13 @@ export function setSecretRef(doc: Document, key: string, form: SecretRefForm): v
   if (form.bare && form.version === undefined) {
     const scalar = new Scalar(null);
     scalar.tag = "!secret";
+    // Force an empty plain representation so `yaml` emits the tag with no `null`
+    // token (`!secret ` rather than `!secret null`), per issue #254. The yaml
+    // serializer still hardcodes a single space between a tag and its (empty)
+    // value, so the bare line lands as `!secret ` with one trailing space;
+    // serializeEnvDoc() trims that to a clean bare `!secret`.
+    scalar.source = "";
+    scalar.type = Scalar.PLAIN;
     map.set(key, scalar);
     return;
   }
@@ -98,6 +105,22 @@ export function setSecretRef(doc: Document, key: string, form: SecretRefForm): v
   const node = doc.createNode(payload) as YAMLMap;
   node.tag = "!secret";
   map.set(key, node);
+}
+
+/**
+ * Serialize an environment document to its on-disk YAML text. Use this instead
+ * of `doc.toString()` for any document that may carry a bare `!secret`.
+ *
+ * The `yaml` serializer hardcodes a single space between a tag and its value
+ * token, so a bare, value-less `!secret` (see {@link setSecretRef}) emits as
+ * `KEY: !secret ` with one trailing space. This trims that lone trailing space
+ * so a floating secret serializes as exactly `KEY: !secret` (issue #254). The
+ * pattern is anchored to a tag at end of line, so payload forms
+ * (`!secret`\n`    ref:`/`version:`) and any string value that merely contains
+ * the text `!secret` (which `yaml` quotes) are left untouched.
+ */
+export function serializeEnvDoc(doc: Document): string {
+  return doc.toString().replace(/^(\s*[\w.-]+: !secret) +$/gm, "$1");
 }
 
 /**

--- a/packages/cli/src/set.ts
+++ b/packages/cli/src/set.ts
@@ -114,13 +114,19 @@ export function setSecretRef(doc: Document, key: string, form: SecretRefForm): v
  * The `yaml` serializer hardcodes a single space between a tag and its value
  * token, so a bare, value-less `!secret` (see {@link setSecretRef}) emits as
  * `KEY: !secret ` with one trailing space. This trims that lone trailing space
- * so a floating secret serializes as exactly `KEY: !secret` (issue #254). The
- * pattern is anchored to a tag at end of line, so payload forms
- * (`!secret`\n`    ref:`/`version:`) and any string value that merely contains
- * the text `!secret` (which `yaml` quotes) are left untouched.
+ * so a floating secret serializes as exactly `KEY: !secret` (issue #254).
+ *
+ * The pattern anchors on the `: !secret` tag immediately followed by spaces at
+ * end of line (`(?=\r?$)`, so LF and CRLF both match, and a final line with no
+ * trailing newline is handled too) — independent of the key, so unusual keys
+ * (`API:KEY`, a quoted key with a space) are cleaned as well. Because it
+ * requires the tag to be trailed only by spaces, payload forms
+ * (`!secret`\n`    ref:`/`version:`), a tag followed by content (`!secret foo`),
+ * and any string value that merely contains the text `!secret` (which `yaml`
+ * quotes) are all left untouched.
  */
 export function serializeEnvDoc(doc: Document): string {
-  return doc.toString().replace(/^(\s*[\w.-]+: !secret) +$/gm, "$1");
+  return doc.toString().replace(/(: !secret) +(?=\r?$)/gm, "$1");
 }
 
 /**

--- a/packages/cli/test/e2e/set.e2e.test.ts
+++ b/packages/cli/test/e2e/set.e2e.test.ts
@@ -234,7 +234,9 @@ describe("keyshelf set <KEY> <shelf>/<stage> --secret", () => {
     expect(code).toBe(0);
     expect(JSON.parse(stdout).version).toBeUndefined();
     const env = await read(".keyshelf/web/staging.yaml");
-    expect(env).toContain("DATABASE_PASSWORD: !secret");
+    // Exactly a bare tag — no `null` token, no trailing whitespace (issue #254).
+    expect(env).toMatch(/^ {2}DATABASE_PASSWORD: !secret$/m);
+    expect(env).not.toContain("!secret null");
     expect(env).not.toContain("version");
   });
 
@@ -246,7 +248,9 @@ describe("keyshelf set <KEY> <shelf>/<stage> --secret", () => {
     );
     expect(code).toBe(0);
     const env = await read(".keyshelf/web/staging.yaml");
-    expect(env).toContain("!secret");
+    // Exactly a bare tag — no `null` token, no trailing whitespace (issue #254).
+    expect(env).toMatch(/^ {2}DATABASE_PASSWORD: !secret$/m);
+    expect(env).not.toContain("!secret null");
     expect(env).not.toContain("version");
   });
 

--- a/packages/cli/test/unit/set.test.ts
+++ b/packages/cli/test/unit/set.test.ts
@@ -4,7 +4,13 @@ import path from "node:path";
 import { parseDocument } from "yaml";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { loadEnvironment } from "../../src/loader.js";
-import { secretRefForm, setConfigValue, setKeyReference, setSecretRef } from "../../src/set.js";
+import {
+  secretRefForm,
+  serializeEnvDoc,
+  setConfigValue,
+  setKeyReference,
+  setSecretRef
+} from "../../src/set.js";
 
 describe("secretRefForm", () => {
   it("is bare when the adapter ref equals the convention name", () => {
@@ -96,9 +102,13 @@ describe("setSecretRef", () => {
   it("writes a bare !secret tag, never the value, preserving other keys", () => {
     const doc = parseDocument("provider: local\nkeys:\n  REGION: eu\n");
     setSecretRef(doc, "DB", { bare: true });
-    const text = doc.toString();
+    const text = serializeEnvDoc(doc);
     expect(text).toContain("REGION: eu");
-    expect(text).toContain("!secret");
+    // The bare floating secret must serialize as exactly `DB: !secret` — no
+    // explicit `null` token and no trailing whitespace (issue #254).
+    expect(text).toMatch(/^ {2}DB: !secret$/m);
+    expect(text).not.toContain("!secret null");
+    expect(text).not.toContain("!secret ");
     expect(text).not.toContain("s3cr3t");
   });
 

--- a/packages/cli/test/unit/set.test.ts
+++ b/packages/cli/test/unit/set.test.ts
@@ -144,6 +144,23 @@ describe("setSecretRef", () => {
     expect(node.tag).toBe("!secret");
     expect(node.toJSON()).toEqual({ ref: "shared-db-url", version: 9 });
   });
+
+  // serializeEnvDoc only strips the bare-secret trailing-space artifact; for every
+  // other form it must be a byte-for-byte no-op. This locks the invariant so a
+  // future loosened anchor can't silently corrupt mapping-form (or any) lines.
+  it("serializeEnvDoc is a no-op for non-bare !secret mapping forms", () => {
+    const ref = parseDocument("provider: local\nkeys:\n  REGION: eu\n");
+    setSecretRef(ref, "DB", { bare: false, ref: "shared-db-url" });
+    expect(serializeEnvDoc(ref)).toBe(ref.toString());
+
+    const version = parseDocument("provider: local\nkeys:\n  REGION: eu\n");
+    setSecretRef(version, "DB", { bare: true, version: 4 });
+    expect(serializeEnvDoc(version)).toBe(version.toString());
+
+    const both = parseDocument("provider: local\nkeys:\n  REGION: eu\n");
+    setSecretRef(both, "DB", { bare: false, ref: "shared-db-url", version: 9 });
+    expect(serializeEnvDoc(both)).toBe(both.toString());
+  });
 });
 
 describe("setKeyReference", () => {


### PR DESCRIPTION
## Summary

A floating, version-less `!secret` reference serialized as `KEY: !secret null` instead of the documented bare `KEY: !secret` (issue #254).

The bare branch of `setSecretRef` built a tagged **null** `Scalar`, which `yaml@2.9.0` renders with an explicit `null` token. The function's own doc comment already states the intended output is the bare form, so the serialization diverged from its documented contract.

## Fix

- Force an empty plain representation on the tagged scalar (`scalar.source = ""`, `scalar.type = Scalar.PLAIN`) so `yaml` emits the tag with no `null` token.
- The `yaml` serializer still hardcodes one space between a tag and its (empty) value, leaving `KEY: !secret ` with a lone trailing space. A new `serializeEnvDoc(doc)` helper trims exactly that artifact (regex anchored to a `!secret` tag at end-of-line), yielding a clean bare `KEY: !secret`. The `set` command's write paths now serialize through this helper.

Note: the brief's suggested `source=""`+`PLAIN` alone leaves a trailing space in `yaml@2.9.0`; the helper handles that to satisfy the "no trailing whitespace" criterion.

## Why the regex is safe

- Mapping forms (`!secret { ref }`, `{ version }`, `{ ref, version }`) render as `!secret\n    ref:`/`version:` — no trailing-tag line, so they're untouched.
- A string value that merely contains the text `!secret` is quoted by `yaml`, so the end-of-line anchor never matches it.

## Tests

- Unit `setSecretRef` bare test tightened from `.toContain("!secret")` to assert the **exact** line `^  DB: !secret$` and `not.toContain("!secret null")` / `not.toContain("!secret ")`. It serializes through `serializeEnvDoc` to mirror the real write path.
- Both floating-secret e2e cases tightened to assert the exact `DATABASE_PASSWORD: !secret` line through the real command + file write.
- Existing loader round-trip test (`yields a bare secret EnvironmentValue`) confirms the bare form still parses to `{ kind: "secret" }`.

## Local verification

`npm run lint`, `format:check`, `typecheck`, `build -w keyshelf`, `validate:examples`, and `npm test -w keyshelf` (343 passed) all green.

## Acceptance criteria

- [x] Floating version-less secret serializes to exactly `KEY: !secret` (no `null`, no trailing whitespace).
- [x] Bare form round-trips through the loader to `{ kind: "secret" }`.
- [x] `!secret { ref }`, `{ version }`, `{ ref, version }` forms unchanged.
- [x] Regression test asserts the exact serialized bare line.

Closes #254

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hhpqrg2SSeBYpqEK7zU1Ki