### PR TITLE
feat: run keyshelf from any subfolder of a project

### DIFF
--- a/packages/cli/src/commands/ls.ts
+++ b/packages/cli/src/commands/ls.ts
@@ -3,7 +3,7 @@ import stringWidth from "string-width";
 import { adapterForEnvironment } from "../adapters/registry.js";
 import { BaseCommand } from "../base-command.js";
 import { environmentKeyView, formatStatus, type KeyView } from "../env-view.js";
-import { loadEnvironment, loadProjectMap, type ProjectMap } from "../loader.js";
+import { findProjectDir, loadEnvironment, loadProjectMap, type ProjectMap } from "../loader.js";
 import { parseTarget } from "../target.js";
 
 /** Render an {@link KeyView.metadata} address as a single-line table cell. */
@@ -85,18 +85,20 @@ export default class Ls extends BaseCommand {
 
   async run(): Promise<ProjectMapResult | EnvironmentViewResult> {
     const { args, flags } = await this.parse(Ls);
-    const cwd = process.cwd();
+    // Discover the project root by walking up from the working directory, so
+    // `ls` works from any subfolder of a project.
+    const projectDir = await findProjectDir(process.cwd());
 
     if (args.target === undefined) {
-      return this.runProjectMap(cwd);
+      return this.runProjectMap(projectDir);
     }
 
-    return this.runEnvironmentView(cwd, args.target, flags.metadata);
+    return this.runEnvironmentView(projectDir, args.target, flags.metadata);
   }
 
   /** `keyshelf ls` — the whole-project map. */
-  private async runProjectMap(cwd: string): Promise<ProjectMapResult> {
-    const map = await loadProjectMap(cwd);
+  private async runProjectMap(projectDir: string): Promise<ProjectMapResult> {
+    const map = await loadProjectMap(projectDir);
 
     if (!this.jsonEnabled()) {
       this.renderTree(map);
@@ -107,18 +109,18 @@ export default class Ls extends BaseCommand {
 
   /** `keyshelf ls <shelf>/<stage>` — one environment's key contract. */
   private async runEnvironmentView(
-    cwd: string,
+    projectDir: string,
     target: string,
     showMetadata: boolean
   ): Promise<EnvironmentViewResult> {
     const { shelf, stage } = parseTarget(target);
-    const loaded = await loadEnvironment(cwd, shelf, stage);
+    const loaded = await loadEnvironment(projectDir, shelf, stage);
     // Build the environment's adapter to compute offline secret addresses. This
     // stays offline and credential-free: construction never reaches the backend,
     // and metadata() is synchronous and network-free (ADR-0008). Adapter address
     // metadata is always carried in --json; the human table shows it only behind
     // --metadata.
-    const adapter = adapterForEnvironment(cwd, loaded);
+    const adapter = adapterForEnvironment(projectDir, loaded);
     const keys = environmentKeyView(loaded, adapter);
 
     if (!this.jsonEnabled()) {

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -3,7 +3,7 @@ import { Args, Flags } from "@oclif/core";
 import { resolveDepsFor } from "../adapters/registry.js";
 import { BaseCommand } from "../base-command.js";
 import { KeyshelfError } from "../errors.js";
-import { loadEnvironment } from "../loader.js";
+import { findProjectDir, loadEnvironment } from "../loader.js";
 import { buildChildEnv, parseSet, resolveEnvironment } from "../resolve.js";
 import { parseTarget } from "../target.js";
 import { validateEnvironment } from "../validate.js";
@@ -68,8 +68,10 @@ export default class Run extends BaseCommand {
       sets[key] = value;
     }
 
-    // Fail-fast: load + structurally validate + resolve before exec.
-    const projectDir = process.cwd();
+    // Fail-fast: load + structurally validate + resolve before exec. The
+    // project root is discovered by walking up from the working directory, so
+    // `run` works from any subfolder of a project.
+    const projectDir = await findProjectDir(process.cwd());
     const loaded = await loadEnvironment(projectDir, shelf, stage);
     validateEnvironment(loaded);
 

--- a/packages/cli/src/commands/set.ts
+++ b/packages/cli/src/commands/set.ts
@@ -7,7 +7,7 @@ import { adapterForEnvironment } from "../adapters/registry.js";
 import { conventionName, hasExplicitName, refName } from "../adapters/shared.js";
 import { BaseCommand } from "../base-command.js";
 import { KeyshelfError } from "../errors.js";
-import { loadEnvironment } from "../loader.js";
+import { findProjectDir, loadEnvironment } from "../loader.js";
 import {
   secretRefForm,
   serializeEnvDoc,
@@ -272,7 +272,10 @@ export default class Set extends BaseCommand {
     file: string;
     doc: ReturnType<typeof parseDocument>;
   }> {
-    const projectDir = process.cwd();
+    // Discover the project root by walking up from the working directory, so
+    // `set` writes under the real project root — not `cwd/.keyshelf/...` — when
+    // invoked from a subfolder.
+    const projectDir = await findProjectDir(process.cwd());
     const loaded = await loadEnvironment(projectDir, shelf, stage);
     this.assertDeclared(loaded.schema.keys, key, shelf, stage);
 

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -2,7 +2,7 @@ import { Args } from "@oclif/core";
 import { resolveDepsFor } from "../adapters/registry.js";
 import { BaseCommand } from "../base-command.js";
 import { KeyshelfError } from "../errors.js";
-import { listEnvironments, loadEnvironment } from "../loader.js";
+import { findProjectDir, listEnvironments, loadEnvironment } from "../loader.js";
 import type { LoadedEnvironment } from "../model.js";
 import { resolveEnvironment } from "../resolve.js";
 import { parseTarget } from "../target.js";
@@ -97,19 +97,21 @@ export default class Validate extends BaseCommand {
 
   async run(): Promise<SingleResult | ProjectResult> {
     const { args } = await this.parse(Validate);
-    const cwd = process.cwd();
+    // Discover the project root by walking up from the working directory, so
+    // `validate` works from any subfolder of a project.
+    const projectDir = await findProjectDir(process.cwd());
 
     if (args.target === undefined) {
-      return this.validateProject(cwd);
+      return this.validateProject(projectDir);
     }
 
-    return this.validateSingle(cwd, args.target);
+    return this.validateSingle(projectDir, args.target);
   }
 
-  private async validateSingle(cwd: string, target: string): Promise<SingleResult> {
+  private async validateSingle(projectDir: string, target: string): Promise<SingleResult> {
     const { shelf, stage } = parseTarget(target);
-    const loaded = await loadEnvironment(cwd, shelf, stage);
-    await verify(cwd, loaded);
+    const loaded = await loadEnvironment(projectDir, shelf, stage);
+    await verify(projectDir, loaded);
 
     const environment = `${shelf}/${stage}`;
     if (!this.jsonEnabled()) {
@@ -119,14 +121,14 @@ export default class Validate extends BaseCommand {
     return { shelf, environment, valid: true };
   }
 
-  private async validateProject(cwd: string): Promise<ProjectResult> {
-    const refs = await listEnvironments(cwd);
+  private async validateProject(projectDir: string): Promise<ProjectResult> {
+    const refs = await listEnvironments(projectDir);
     refs.sort((a, b) => `${a.shelf}/${a.stage}`.localeCompare(`${b.shelf}/${b.stage}`));
 
     const results: EnvironmentResult[] = [];
     for (const ref of refs) {
       const environment = `${ref.shelf}/${ref.stage}`;
-      const error = await checkOne(cwd, ref.shelf, ref.stage);
+      const error = await checkOne(projectDir, ref.shelf, ref.stage);
       results.push(
         error ? { environment, valid: false, error: error.toJSON() } : { environment, valid: true }
       );

--- a/packages/cli/src/loader.ts
+++ b/packages/cli/src/loader.ts
@@ -18,13 +18,46 @@ const ROOT_DIR = ".keyshelf";
 const CONFIG_FILE = "config.yaml";
 const SCHEMA_FILE = "schema.yaml";
 
+/** Whether `dir` directly holds a `.keyshelf/config.yaml` (an initialized project root). */
+function hasProject(dir: string): boolean {
+  return existsSync(path.join(dir, ROOT_DIR, CONFIG_FILE));
+}
+
+/**
+ * Discover the project root by walking up from `startDir` toward the filesystem
+ * root, returning the nearest ancestor directory that holds
+ * `.keyshelf/config.yaml` — the way git/npm find their marker. This lets every
+ * read/write command run from any subfolder of a project. The traversal stops at
+ * the filesystem root; if no ancestor is initialized it throws `NOT_INITIALIZED`,
+ * stating that the working directory and its parents were searched.
+ *
+ * The discovered root replaces `process.cwd()` as the `projectDir` everywhere it
+ * flows (reads, `set` writes, adapter relative paths, dependency resolution), so
+ * everything anchors to the real project root rather than the raw cwd.
+ */
+export async function findProjectDir(startDir: string): Promise<string> {
+  let dir = path.resolve(startDir);
+  for (;;) {
+    if (hasProject(dir)) return dir;
+    const parent = path.dirname(dir);
+    if (parent === dir) break; // reached the filesystem root
+    dir = parent;
+  }
+
+  throw new KeyshelfError(
+    "NOT_INITIALIZED",
+    `No Keyshelf project found in '${startDir}' or any parent directory. Run 'keyshelf init' first.`,
+    { path: path.join(startDir, ROOT_DIR) }
+  );
+}
+
 /** Resolve the `.keyshelf` root for a project, asserting it is initialized. */
 function keyshelfRoot(projectDir: string): string {
   const root = path.join(projectDir, ROOT_DIR);
   if (!existsSync(path.join(root, CONFIG_FILE))) {
     throw new KeyshelfError(
       "NOT_INITIALIZED",
-      `No Keyshelf project found in '${projectDir}'. Run 'keyshelf init' first.`,
+      `No Keyshelf project found in '${projectDir}' or any parent directory. Run 'keyshelf init' first.`,
       {
         path: root
       }

--- a/packages/cli/test/e2e/subfolder.e2e.test.ts
+++ b/packages/cli/test/e2e/subfolder.e2e.test.ts
@@ -1,0 +1,123 @@
+import { existsSync } from "node:fs";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { parse } from "yaml";
+import { makeTmpDir, removeDir, runKeyshelf } from "./helpers.js";
+
+// A project root with a nested subfolder, so we can run keyshelf from deep
+// inside the tree and assert it discovers the same project root that running
+// from the root would (the way git/npm walk up to find their marker).
+let root: string;
+let nested: string;
+
+beforeEach(async () => {
+  root = await makeTmpDir();
+  nested = path.join(root, "services", "api", "src");
+  await mkdir(nested, { recursive: true });
+});
+
+afterEach(async () => {
+  await removeDir(root);
+});
+
+async function write(rel: string, contents: string): Promise<void> {
+  const full = path.join(root, rel);
+  await mkdir(path.dirname(full), { recursive: true });
+  await writeFile(full, contents, "utf8");
+}
+
+const CONFIG = `project: myapp
+providers:
+  store:
+    adapter: fake
+`;
+
+const SCHEMA = `keys:
+  LOG_LEVEL: info
+  REGION: !required
+`;
+
+const ENV = `provider: store
+keys:
+  REGION: eu-west-1
+`;
+
+async function scaffold(): Promise<void> {
+  await write(".keyshelf/config.yaml", CONFIG);
+  await write(".keyshelf/web/schema.yaml", SCHEMA);
+  await write(".keyshelf/web/staging.yaml", ENV);
+}
+
+describe("running keyshelf from a subfolder", () => {
+  it("ls produces identical output from the root and from a nested subfolder", async () => {
+    await scaffold();
+    const fromRoot = await runKeyshelf(["ls", "--json"], { cwd: root });
+    const fromNested = await runKeyshelf(["ls", "--json"], { cwd: nested });
+
+    expect(fromRoot.code).toBe(0);
+    expect(fromNested.code).toBe(0);
+    expect(JSON.parse(fromNested.stdout)).toEqual(JSON.parse(fromRoot.stdout));
+  });
+
+  it("validate resolves the same project root from a nested subfolder", async () => {
+    await scaffold();
+    const fromRoot = await runKeyshelf(["validate", "--json"], { cwd: root });
+    const fromNested = await runKeyshelf(["validate", "--json"], { cwd: nested });
+
+    expect(fromRoot.code).toBe(0);
+    expect(fromNested.code).toBe(0);
+    expect(JSON.parse(fromNested.stdout)).toEqual(JSON.parse(fromRoot.stdout));
+  });
+
+  it("run resolves config from a nested subfolder", async () => {
+    await scaffold();
+    const { code, stdout } = await runKeyshelf(
+      ["run", "web/staging", "--", "node", "-e", "process.stdout.write(process.env.REGION ?? '')"],
+      { cwd: nested }
+    );
+    expect(code).toBe(0);
+    expect(stdout).toContain("eu-west-1");
+  });
+
+  it("set writes under the discovered project root, not cwd/.keyshelf", async () => {
+    await scaffold();
+    const { code } = await runKeyshelf(["set", "LOG_LEVEL", "web/staging"], {
+      cwd: nested,
+      input: "trace"
+    });
+    expect(code).toBe(0);
+
+    // The write landed in the discovered project root...
+    const env = parse(await readFile(path.join(root, ".keyshelf", "web", "staging.yaml"), "utf8"));
+    expect(env.keys.LOG_LEVEL).toBe("trace");
+
+    // ...and never created a stray .keyshelf under the subfolder.
+    expect(existsSync(path.join(nested, ".keyshelf"))).toBe(false);
+  });
+
+  it("fails with NOT_INITIALIZED mentioning parents when run outside any project", async () => {
+    const outside = await makeTmpDir();
+    try {
+      const { code, stdout } = await runKeyshelf(["ls", "--json"], { cwd: outside });
+      expect(code).not.toBe(0);
+      const result = JSON.parse(stdout);
+      expect(result.error.code).toBe("NOT_INITIALIZED");
+      expect(result.error.message).toContain("parent");
+    } finally {
+      await removeDir(outside);
+    }
+  });
+
+  it("init still scaffolds in the current working directory, not the discovered ancestor", async () => {
+    await scaffold();
+    // init from the nested subfolder must NOT walk up to the existing root; it
+    // scaffolds a brand-new project right here in the subfolder.
+    const { code } = await runKeyshelf(["init", "--project", "sub"], { cwd: nested });
+    expect(code).toBe(0);
+
+    expect(existsSync(path.join(nested, ".keyshelf", "config.yaml"))).toBe(true);
+    const config = parse(await readFile(path.join(nested, ".keyshelf", "config.yaml"), "utf8"));
+    expect(config.project).toBe("sub");
+  });
+});

--- a/packages/cli/test/unit/loader.test.ts
+++ b/packages/cli/test/unit/loader.test.ts
@@ -3,7 +3,12 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { KeyshelfError } from "../../src/errors.js";
-import { listEnvironments, loadEnvironment, loadProjectMap } from "../../src/loader.js";
+import {
+  findProjectDir,
+  listEnvironments,
+  loadEnvironment,
+  loadProjectMap
+} from "../../src/loader.js";
 
 let root: string;
 
@@ -60,6 +65,46 @@ function expectCode(p: Promise<unknown>, code: string, fields?: Record<string, u
     }
   );
 }
+
+describe("findProjectDir", () => {
+  it("returns the start directory when it directly holds .keyshelf/config.yaml", async () => {
+    await scaffold();
+    expect(await findProjectDir(root)).toBe(root);
+  });
+
+  it("walks up from a nested subfolder to the nearest ancestor project root", async () => {
+    await scaffold();
+    const nested = path.join(root, "services", "api", "src");
+    await mkdir(nested, { recursive: true });
+    expect(await findProjectDir(nested)).toBe(root);
+  });
+
+  it("returns the nearest ancestor when projects are nested (stops at the first match)", async () => {
+    await scaffold();
+    const inner = path.join(root, "inner");
+    await mkdir(path.join(inner, ".keyshelf"), { recursive: true });
+    await writeFile(path.join(inner, ".keyshelf", "config.yaml"), CONFIG, "utf8");
+    const deep = path.join(inner, "src");
+    await mkdir(deep, { recursive: true });
+    expect(await findProjectDir(deep)).toBe(inner);
+  });
+
+  it("throws NOT_INITIALIZED when no ancestor holds a project, stopping at the filesystem root", async () => {
+    // root is a fresh tmp dir with no .keyshelf anywhere up to the fs root.
+    await expectCode(findProjectDir(root), "NOT_INITIALIZED");
+  });
+
+  it("mentions the start directory and its parents in the NOT_INITIALIZED message", async () => {
+    let err: KeyshelfError | undefined;
+    await findProjectDir(root).catch((e: KeyshelfError) => {
+      err = e;
+    });
+    expect(err).toBeInstanceOf(KeyshelfError);
+    expect(err!.code).toBe("NOT_INITIALIZED");
+    expect(err!.message).toContain(root);
+    expect(err!.message).toContain("parent");
+  });
+});
 
 describe("loadEnvironment", () => {
   it("loads config, schema, and environment into a model with filesystem-derived identity", async () => {


### PR DESCRIPTION
## What changed

keyshelf previously only worked when the working directory was the exact project root holding `.keyshelf/config.yaml`. Running any command from a subfolder failed with `NOT_INITIALIZED`, because `projectDir` was taken straight from `process.cwd()` and the `.keyshelf` lookup checked only that one directory.

This makes keyshelf discoverable from any subfolder, the way git/npm find their marker:

- **`findProjectDir(startDir)`** added to the loader: walks up toward the filesystem root and returns the nearest ancestor directory containing `.keyshelf/config.yaml`, stopping at the filesystem root and throwing `NOT_INITIALIZED` if none is found.
- The `NOT_INITIALIZED` message now states the working directory **and its parents** were searched: `No Keyshelf project found in '<cwd>' or any parent directory. Run 'keyshelf init' first.`
- Adopted in **`ls`, `validate`, `run`, and `set`** — each resolves the project root once and threads the discovered root through as `projectDir`, so reads, writes, adapter relative paths (sops files, age key files, fake store), and dependency resolution all anchor to the real project root. In particular, **`set` from a subfolder now writes under the discovered root**, not `cwd/.keyshelf/...`.
- **`init` is unchanged** — it still scaffolds `.keyshelf/` in the current working directory and never walks up to an existing ancestor project.

## How it was tested

- **Unit** (`test/unit/loader.test.ts`): `findProjectDir` returns the start dir when it holds a project, walks up from a nested subfolder, returns the nearest ancestor when projects are nested, stops at the filesystem root, and throws `NOT_INITIALIZED` mentioning parents.
- **E2E** (`test/e2e/subfolder.e2e.test.ts`, spawning the real binary): `ls`/`validate` produce identical output from the root and a nested subfolder; `run` resolves config from a subfolder; `set` from a subfolder writes under the discovered root and creates no stray `.keyshelf`; running outside any project fails with `NOT_INITIALIZED` mentioning parents; `init` from a subfolder scaffolds in-place rather than walking up.
- Full suite green: `build`, `typecheck`, `lint`, `format:check`, and `vitest run` (355 passed, 3 pre-existing skips).

Closes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QETe9xxstivBqo6AgFHqNt