### PR TITLE
chore: sync package-lock to keyshelf 6.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11141,7 +11141,7 @@
     },
     "packages/cli": {
       "name": "keyshelf",
-      "version": "6.3.1",
+      "version": "6.5.1",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/secret-manager": "^6.2.0",


### PR DESCRIPTION
The committed lockfile still pinned `packages/cli` at `6.3.1`, but release-please bumped the package to `6.5.1`. Regenerated via `npm install` to sync the lockfile's version reference.

Single-line change, no dependency churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QETe9xxstivBqo6AgFHqNt