### PR TITLE
refactor(loader): centralize shelf/stage path construction (#258) + ADR-0011

### DIFF
--- a/docs/adr/0011-environments-folder-and-adapter-owned-store-namespace.md
+++ b/docs/adr/0011-environments-folder-and-adapter-owned-store-namespace.md
@@ -1,0 +1,89 @@
+# Environments live in a reserved `environments/` folder; stores live outside core's namespace
+
+## Decision
+
+A shelf's environment files move into a dedicated `environments/` subfolder, and an
+adapter's store moves out of the folder core scans. The shelf layout becomes:
+
+```
+.keyshelf/{shelf}/
+  schema.yaml            # the shelf's contract        (core)
+  environments/          # the one folder core scans    (core)
+    production.yaml
+    staging.yaml
+  secrets/               # the sops adapter's default store (sops only)
+    production.yaml
+```
+
+Environment discovery is now a plain directory read of `.keyshelf/{shelf}/environments/*.yaml`
+with **no exclusion rule**: every `*.yaml` in that folder is an environment, its
+stage is its basename. There is no `isEnvironmentFile` predicate, no `schema.yaml`
+special-case (the schema is a sibling of `environments/`, not inside it), and no
+`.secrets.yaml` special-case.
+
+`environments/` is the **only** folder name core reserves. `secrets/` is not a core
+concept — it is merely the sops adapter's _default_ store directory, and the
+provider's `store:` template remains configurable. The store contract is now
+statable in one line: a store may live anywhere under the shelf **except inside
+`environments/`**. Because the store lives in its own directory, the
+`{stage}.secrets.yaml` suffix loses its only job (disambiguation within a shared
+directory) and the sops default simplifies to `secrets/{stage}.yaml`.
+
+## Why
+
+This supersedes the **layout** decided in ADR-0002 — the sibling
+`{shelf}/{stage}.secrets.yaml` store and the flat `{shelf}/{stage}.yaml`
+environment file — while leaving ADR-0002's reference model intact (secret values
+still live in adapter-owned stores; environment files still hold only `!secret`
+references).
+
+The flat layout forced core to discriminate, by filename, between three kinds of
+file sharing one directory. Discovery globbed `*.yaml` and excluded `schema.yaml`
+and `*.secrets.yaml`. That coupling was wrong in two concrete ways:
+
+- **A sops detail leaked into core.** `.secrets.yaml` is the sops adapter's store
+  convention, yet core hardcoded the suffix to avoid mis-enumerating store files
+  as environments. Core had no business knowing it.
+- **It mirrored a _configurable_ default as if it were a law.** The sops `store:`
+  template is overridable. A store configured as `{shelf}/{stage}.enc.yaml` lands a
+  `.yaml` file in the shelf directory that is neither `schema.yaml` nor
+  `*.secrets.yaml` — so core would have listed it as an environment. The exclusion
+  only happened to match the sops _default_.
+
+Giving environments their own folder makes the seam **structural** instead of
+lexical. The special case does not move into the adapter — it is deleted. Core
+scans one folder and trusts everything in it; the adapter owns its store namespace
+entirely. This is the cleanest expression of the boundary ADR-0002 already drew:
+core describes _what_ keys exist and where environments are; the adapter decides
+_how and where_ values are stored.
+
+A named `environments/` folder is also more discoverable than a suffix convention,
+which suits a tool meant to be navigable by humans and agents (CONTEXT.md): the
+folder says what it holds, rather than requiring the reader to infer that
+`production.yaml` is an environment but `production.secrets.yaml` is not.
+
+## Consequences
+
+- **`isEnvironmentFile` is removed.** Discovery (`listEnvironments` /
+  `listShelfEnvironments`) reads `environments/` directly. A missing or empty
+  `environments/` folder means zero environments, not an error.
+- **Stage names are no longer constrained.** Discrimination is by directory, not by
+  counting dots in a filename, so a stage name containing a dot is no longer
+  ambiguous with a store file.
+- **Path construction funnels through helpers.** The flat `{shelf}/{stage}.yaml`
+  assumption is replaced by `envFilePath(root, shelf, stage)` and
+  `shelfEnvDir(root, shelf)`; the sops default store path moves to
+  `secrets/{stage}.yaml` in the adapter registry. `init` scaffolds the new layout.
+- **Not a breaking release.** keyshelf's npm `latest` is the 5.x line; the 6.x line
+  ships only on the `next` pre-release tag. No stable consumer has the flat layout
+  on disk, so this lands as a `feat` on 6.x rather than a major bump. The only
+  affected parties are `next` adopters, who move their files from
+  `{shelf}/{stage}.yaml` into `{shelf}/environments/` and their sops stores into
+  `{shelf}/secrets/`; this is noted for them in the migration docs rather than
+  automated. Getting the layout right now — before 6.x is promoted to `latest` — is
+  what keeps it non-breaking; the same change after promotion would break stable
+  users.
+- **Conformance is unaffected in shape (ADR-0005).** The adapter contract
+  (`resolve`/`write`) does not change; only the default store path the registry
+  computes for sops moves. `ageKeyFile` (ADR-0010) is unaffected — it resolves
+  relative to the project root, independent of the store's location.

--- a/packages/cli/src/adapters/registry.ts
+++ b/packages/cli/src/adapters/registry.ts
@@ -61,16 +61,21 @@ function requireStringField(provider: Provider, field: string, ctx: AdapterConte
 }
 
 /**
- * The sops store's default layout: a per-environment sibling encrypted file
- * `.keyshelf/{shelf}/{stage}.secrets.yaml` (docs/reference.md, ADR-0002). A
- * provider may override the layout with a `store:` template using `{shelf}` and
- * `{stage}` placeholders, resolved relative to the project root.
+ * The sops store's default layout when a provider declares no `store:` template:
+ * a per-environment sibling encrypted file `.keyshelf/{shelf}/{stage}.secrets.yaml`
+ * (docs/reference.md, ADR-0002). Kept as a single template so the default's base
+ * directory is redirectable in one place (ADR-0011 moves it under `secrets/`).
+ */
+const SOPS_DEFAULT_STORE_TEMPLATE = path.join(".keyshelf", "{shelf}", "{stage}.secrets.yaml");
+
+/**
+ * Resolve a sops provider's store path for an environment. A provider may override
+ * the default with a `store:` template using `{shelf}` and `{stage}` placeholders,
+ * resolved relative to the project root.
  */
 function sopsStorePath(provider: Provider, ctx: AdapterContext): string {
   const template =
-    typeof provider.store === "string"
-      ? provider.store
-      : path.join(".keyshelf", "{shelf}", "{stage}.secrets.yaml");
+    typeof provider.store === "string" ? provider.store : SOPS_DEFAULT_STORE_TEMPLATE;
   const rel = template.replaceAll("{shelf}", ctx.shelf).replaceAll("{stage}", ctx.stage);
   return path.resolve(ctx.projectDir, rel);
 }

--- a/packages/cli/src/commands/set.ts
+++ b/packages/cli/src/commands/set.ts
@@ -8,6 +8,7 @@ import { conventionName, hasExplicitName, refName } from "../adapters/shared.js"
 import { BaseCommand } from "../base-command.js";
 import { KeyshelfError } from "../errors.js";
 import { findProjectDir, loadEnvironment } from "../loader.js";
+import { envFilePath, ROOT_DIR } from "../paths.js";
 import {
   secretRefForm,
   serializeEnvDoc,
@@ -279,7 +280,7 @@ export default class Set extends BaseCommand {
     const loaded = await loadEnvironment(projectDir, shelf, stage);
     this.assertDeclared(loaded.schema.keys, key, shelf, stage);
 
-    const file = path.join(projectDir, ".keyshelf", shelf, `${stage}.yaml`);
+    const file = envFilePath(path.join(projectDir, ROOT_DIR), shelf, stage);
     const doc = parseDocument(await readFile(file, "utf8"));
     return { loaded, projectDir, file, doc };
   }

--- a/packages/cli/src/loader.ts
+++ b/packages/cli/src/loader.ts
@@ -13,10 +13,15 @@ import type {
   Schema,
   SchemaKey
 } from "./model.js";
-
-const ROOT_DIR = ".keyshelf";
-const CONFIG_FILE = "config.yaml";
-const SCHEMA_FILE = "schema.yaml";
+import {
+  CONFIG_FILE,
+  envFilePath,
+  ROOT_DIR,
+  SCHEMA_FILE,
+  schemaFilePath,
+  shelfDir,
+  shelfEnvDir
+} from "./paths.js";
 
 /** Whether `dir` directly holds a `.keyshelf/config.yaml` (an initialized project root). */
 function hasProject(dir: string): boolean {
@@ -172,7 +177,7 @@ function readKeysMap<T>(
 }
 
 async function loadSchema(root: string, shelf: string): Promise<Schema> {
-  const file = path.join(root, shelf, SCHEMA_FILE);
+  const file = schemaFilePath(root, shelf);
   const doc = parse(await readFile(file, "utf8"), file);
 
   const keys = readKeysMap<SchemaKey>(doc, file, (node) => {
@@ -268,7 +273,7 @@ async function loadEnvironmentFile(
   shelf: string,
   name: string
 ): Promise<Environment> {
-  const file = path.join(root, shelf, `${name}.yaml`);
+  const file = envFilePath(root, shelf, name);
   const doc = parse(await readFile(file, "utf8"), file);
 
   const top = doc.contents;
@@ -344,18 +349,17 @@ export async function loadEnvironment(
   const root = keyshelfRoot(projectDir);
   const config = await loadConfig(root);
 
-  const shelfDir = path.join(root, shelf);
-  if (!existsSync(shelfDir)) {
+  if (!existsSync(shelfDir(root, shelf))) {
     throw new KeyshelfError("SHELF_NOT_FOUND", `Shelf '${shelf}' does not exist.`, { shelf });
   }
 
-  if (!existsSync(path.join(shelfDir, SCHEMA_FILE))) {
+  if (!existsSync(schemaFilePath(root, shelf))) {
     throw new KeyshelfError("SCHEMA_NOT_FOUND", `Shelf '${shelf}' has no ${SCHEMA_FILE}.`, {
       shelf
     });
   }
 
-  if (!existsSync(path.join(shelfDir, `${stage}.yaml`))) {
+  if (!existsSync(envFilePath(root, shelf, stage))) {
     throw new KeyshelfError(
       "ENVIRONMENT_NOT_FOUND",
       `Environment '${shelf}/${stage}' does not exist.`,
@@ -393,7 +397,7 @@ function isEnvironmentFile(name: string): boolean {
 
 /** The environments declared in a single shelf directory. */
 async function listShelfEnvironments(root: string, shelf: string): Promise<EnvironmentRef[]> {
-  const files = await readdir(path.join(root, shelf), { withFileTypes: true });
+  const files = await readdir(shelfEnvDir(root, shelf), { withFileTypes: true });
   return files
     .filter((file) => file.isFile() && isEnvironmentFile(file.name))
     .map((file) => ({ shelf, stage: file.name.slice(0, -".yaml".length) }));
@@ -448,7 +452,7 @@ export async function loadProjectMap(projectDir: string): Promise<ProjectMap> {
 
   const shelves: ShelfMap[] = [];
   for (const shelf of shelfNames) {
-    if (!existsSync(path.join(root, shelf, SCHEMA_FILE))) {
+    if (!existsSync(schemaFilePath(root, shelf))) {
       throw new KeyshelfError("SCHEMA_NOT_FOUND", `Shelf '${shelf}' has no ${SCHEMA_FILE}.`, {
         shelf
       });

--- a/packages/cli/src/paths.ts
+++ b/packages/cli/src/paths.ts
@@ -1,0 +1,41 @@
+import path from "node:path";
+
+/** The project-relative root directory holding all Keyshelf state. */
+export const ROOT_DIR = ".keyshelf";
+/** The project config file, at the root of {@link ROOT_DIR}. */
+export const CONFIG_FILE = "config.yaml";
+/** A shelf's schema file, at the root of its shelf directory. */
+export const SCHEMA_FILE = "schema.yaml";
+
+/**
+ * Every filesystem path that depends on the shelf/stage layout is built here, so
+ * the layout lives in exactly one place. The flat layout
+ * (`.keyshelf/{shelf}/{stage}.yaml`, schema and environments sharing the shelf
+ * directory) is encoded by {@link shelfEnvDir} returning the shelf directory
+ * itself; ADR-0011 redirects environments into an `environments/` subfolder by
+ * changing only that one helper.
+ */
+
+/** A shelf's directory: `.keyshelf/{shelf}`. */
+export function shelfDir(root: string, shelf: string): string {
+  return path.join(root, shelf);
+}
+
+/** A shelf's schema file: `.keyshelf/{shelf}/schema.yaml`. */
+export function schemaFilePath(root: string, shelf: string): string {
+  return path.join(shelfDir(root, shelf), SCHEMA_FILE);
+}
+
+/**
+ * The directory a shelf's environment files live in. Flat layout: the shelf
+ * directory itself (so it also holds `schema.yaml` and, by default, secret
+ * stores). This is the single seam ADR-0011 moves to an `environments/` subfolder.
+ */
+export function shelfEnvDir(root: string, shelf: string): string {
+  return shelfDir(root, shelf);
+}
+
+/** An environment file: `.keyshelf/{shelf}/{stage}.yaml` in the flat layout. */
+export function envFilePath(root: string, shelf: string, stage: string): string {
+  return path.join(shelfEnvDir(root, shelf), `${stage}.yaml`);
+}

--- a/packages/cli/test/unit/paths.test.ts
+++ b/packages/cli/test/unit/paths.test.ts
@@ -1,0 +1,24 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { envFilePath, schemaFilePath, shelfDir, shelfEnvDir } from "../../src/paths.js";
+
+const root = path.join("/proj", ".keyshelf");
+
+describe("layout path helpers", () => {
+  it("locates a shelf directory", () => {
+    expect(shelfDir(root, "api")).toBe(path.join("/proj", ".keyshelf", "api"));
+  });
+
+  it("locates a shelf's schema file at the shelf root", () => {
+    expect(schemaFilePath(root, "api")).toBe(path.join("/proj", ".keyshelf", "api", "schema.yaml"));
+  });
+
+  it("places environment files in the shelf directory (flat layout)", () => {
+    // Pins the current flat layout. ADR-0011 redirects this into an
+    // `environments/` subfolder — that change must update this expectation.
+    expect(shelfEnvDir(root, "api")).toBe(path.join("/proj", ".keyshelf", "api"));
+    expect(envFilePath(root, "api", "production")).toBe(
+      path.join("/proj", ".keyshelf", "api", "production.yaml")
+    );
+  });
+});


### PR DESCRIPTION
## What

Prefactor for the ADR-0011 layout change. Introduces `src/paths.ts` and routes every flat-layout path-construction site through it, with **no behavior change** — the on-disk layout stays flat (`.keyshelf/{shelf}/{stage}.yaml`).

- New `paths.ts`: `shelfDir`, `shelfEnvDir`, `schemaFilePath`, `envFilePath` + the `ROOT_DIR`/`CONFIG_FILE`/`SCHEMA_FILE` constants.
- `loader.ts` (discovery + load), `set.ts` (edit path) now build paths via these helpers — no remaining inline `{stage}.yaml` joins.
- Sops default store extracted into a single `SOPS_DEFAULT_STORE_TEMPLATE` constant so #260 can redirect it under `secrets/` in one line.
- `paths.test.ts` pins the current flat layout, so the #259/#260 cutover to `environments/` must consciously update it.

Also folds in **ADR-0011** (`docs/adr/0011-...`), which records the decision the follow-up issues implement (superseding the *layout* — not the reference model — of ADR-0002), per the agreed plan to land the ADR with this PR.

## Why

Core currently discriminates environment files from `schema.yaml` and `*.secrets.yaml` stores by filename in a shared directory — a sops detail leaked into core, and a mirror of a *configurable* default. Centralizing the layout here makes the subsequent cutover (#259 environments/, #260 secrets/) a one-line change per seam.

## Testing

- `npm run lint`, `npm run format:check` — clean
- `npm run typecheck` — clean
- `npm run validate:examples` — all 5 example projects valid
- `npm test -w keyshelf` — 358 passed, 3 skipped (env-gated), no behavior change

Closes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZvtLBxXwjC3uzWCVieBnh