### PR TITLE
feat(sops): move the default store into a secrets/ folder (#260)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ keyshelf run app/production -- node server.js
 ```
 
 After step 4, `.keyshelf/app/production.yaml` holds a `DATABASE_PASSWORD: !secret`
-reference (the encrypted value lives in `.keyshelf/app/production.secrets.yaml`),
+reference (the encrypted value lives in `.keyshelf/app/secrets/production.yaml`),
 and `keyshelf run` resolves it into `DATABASE_PASSWORD` in the child process's
 environment.
 
@@ -90,8 +90,9 @@ full flag surface, error codes, and resolution precedence.
 
 ## Adapters
 
-- **sops** — stores each environment's secrets in an encrypted sibling file
-  (`{shelf}/{stage}.secrets.yaml`), committed to the repo. Self-contained: the
+- **sops** — stores each environment's secrets in an encrypted file under the
+  shelf's `secrets/` directory (`{shelf}/secrets/{stage}.yaml`), committed to the
+  repo. Self-contained: the
   `sops` binary ships with keyshelf. See [ADR-0003](./docs/adr/0003-typescript-with-bundled-sops-binary.md).
 - **gcp** — stores each secret in Google Cloud Secret Manager, one secret per key
   under the deterministic name `keyshelf__{project}__{shelf}__{stage}__{key}`,

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -12,7 +12,8 @@ keyshelf v5? See [Migrating from v5](./migrating-from-v5.md).
 └── {shelf}/                        # one shelf per schema
     ├── schema.yaml                 # the shelf's closed validation contract
     ├── {stage}.yaml                # an environment implementing the shelf's schema
-    └── {stage}.secrets.yaml        # sops store for that environment (encrypted; committed)
+    └── secrets/
+        └── {stage}.yaml            # sops store for that environment (encrypted; committed)
 ```
 
 Identity is **filesystem-derived**: the shelf is its directory name, the
@@ -27,7 +28,7 @@ project: myapp # required; namespaces secrets in shared backends
 providers:
   local:
     adapter: sops # only required field for sops
-    # store: "{shelf}/{stage}.secrets.yaml"   # optional layout override (default shown)
+    # store: "{shelf}/secrets/{stage}.yaml"   # optional layout override (default shown)
     # ageKeyFile: ".keyshelf/age.key"         # optional; locates the age decryption identity
     #                                         # (relative to project root; ~ and ~/ expand to $HOME;
     #                                         # absolute honored as-is; ADR-0010).
@@ -92,7 +93,7 @@ keys:
   another.
 - Values are **strings** only.
 - Secret _values_ never appear here — only `!secret` references. Values live in
-  the adapter's store (sops: `{shelf}/{stage}.secrets.yaml`; gcp: the backend).
+  the adapter's store (sops: `{shelf}/secrets/{stage}.yaml`; gcp: the backend).
 - `!secret` payload shape is adapter-defined; bare = convention, optional explicit
   `{ ref: ... }` overrides.
 - **Version pinning (ADR-0009).** On a versioned backend (gcp), a `!secret` may pin

--- a/packages/cli/src/adapters/registry.ts
+++ b/packages/cli/src/adapters/registry.ts
@@ -62,18 +62,21 @@ function requireStringField(provider: Provider, field: string, ctx: AdapterConte
 
 /**
  * The sops store's default layout when a provider declares no `store:` template:
- * a per-environment sibling encrypted file `.keyshelf/{shelf}/{stage}.secrets.yaml`
- * (docs/reference.md, ADR-0002). Kept as a single template so the default's base
- * directory is redirectable in one place (ADR-0011 moves it under `secrets/`).
+ * a per-environment encrypted file in the shelf's own `secrets/` directory,
+ * `.keyshelf/{shelf}/secrets/{stage}.yaml` (ADR-0011). The store lives in its own
+ * directory — outside the `environments/` folder core scans — so the disambiguating
+ * `.secrets` filename suffix (ADR-0002) is no longer needed and is dropped.
+ * `secrets/` is purely this adapter's default; it is not a core concept, and the
+ * provider's `store:` template stays configurable.
  */
-const SOPS_DEFAULT_STORE_TEMPLATE = path.join(".keyshelf", "{shelf}", "{stage}.secrets.yaml");
+const SOPS_DEFAULT_STORE_TEMPLATE = path.join(".keyshelf", "{shelf}", "secrets", "{stage}.yaml");
 
 /**
  * Resolve a sops provider's store path for an environment. A provider may override
  * the default with a `store:` template using `{shelf}` and `{stage}` placeholders,
  * resolved relative to the project root.
  */
-function sopsStorePath(provider: Provider, ctx: AdapterContext): string {
+export function sopsStorePath(provider: Provider, ctx: AdapterContext): string {
   const template =
     typeof provider.store === "string" ? provider.store : SOPS_DEFAULT_STORE_TEMPLATE;
   const rel = template.replaceAll("{shelf}", ctx.shelf).replaceAll("{stage}", ctx.stage);
@@ -104,9 +107,10 @@ export function createAdapter(provider: Provider, ctx: AdapterContext): Adapter 
     }
 
     case "sops": {
-      // The store is a per-environment encrypted sibling file; recipients come
-      // from the project's `.sops.yaml`, which sops discovers by walking up from
-      // the store path — so the adapter runs sops with the project root as cwd.
+      // The store is a per-environment encrypted file in the shelf's `secrets/`
+      // directory (ADR-0011); recipients come from the project's `.sops.yaml`,
+      // which sops discovers by walking up from the store path — so the adapter
+      // runs sops with the project root as cwd.
       // An optional `ageKeyFile` locates the decryption identity per-environment
       // (ADR-0010); a leading `~`/`~/` expands to the user's home, then it is
       // resolved relative to the project root, like `store`.

--- a/packages/cli/src/adapters/sops.ts
+++ b/packages/cli/src/adapters/sops.ts
@@ -17,8 +17,10 @@ const execFileAsync = promisify(execFile);
  * fallback ({@link resolveSopsBinary}). Recipients are governed entirely by the
  * project's native `.sops.yaml`; Keyshelf never writes or mutates it.
  *
- * **Store.** A per-environment sibling encrypted file
- * `.keyshelf/{shelf}/{stage}.secrets.yaml`, committed and encrypted. It holds a
+ * **Store.** A per-environment encrypted file in the shelf's own `secrets/`
+ * directory, `.keyshelf/{shelf}/secrets/{stage}.yaml` by default (ADR-0011; the
+ * registry computes the path and a provider `store:` template can override it),
+ * committed and encrypted. It holds a
  * flat `key -> value` mapping. Because sops and YAML can mangle multiline and
  * whitespace-bearing scalars, every value is carried as a JSON string inside the
  * store: `write` uses `sops set` with `JSON.stringify(value)` and `resolve`

--- a/packages/cli/test/conformance/sops-fixture.ts
+++ b/packages/cli/test/conformance/sops-fixture.ts
@@ -29,7 +29,8 @@ function onPath(bin: string): boolean {
 /**
  * A hermetic sops backend for the conformance suites: a throwaway temp directory
  * holding a freshly-generated **age** keypair, a fixture `.sops.yaml` whose
- * creation rules point at that age recipient for `*.secrets.yaml`, and an
+ * creation rules point at that age recipient for stores under a `secrets/`
+ * directory (the sops default, ADR-0011), and an
  * isolated store directory. `SOPS_AGE_KEY_FILE` is set so sops can decrypt. Tear
  * down by removing the directory.
  *
@@ -50,12 +51,14 @@ export interface SopsFixture {
 
 /**
  * Create a hermetic sops backend. `pathRegex` governs which files the creation
- * rule matches (default: any `*.secrets.yaml`). The caller is responsible for
- * setting `process.env.SOPS_AGE_KEY_FILE` if it spawns sops in a child process;
- * for in-process adapter use, set it from {@link SopsFixture.ageKeyFile}.
+ * rule matches (default: any `*.yaml` under a `secrets/` directory, matching the
+ * sops default store layout `.keyshelf/{shelf}/secrets/{stage}.yaml`, ADR-0011).
+ * The caller is responsible for setting `process.env.SOPS_AGE_KEY_FILE` if it
+ * spawns sops in a child process; for in-process adapter use, set it from
+ * {@link SopsFixture.ageKeyFile}.
  */
 export async function makeSopsFixture(
-  pathRegex = String.raw`.*\.secrets\.yaml$`
+  pathRegex = String.raw`secrets/.*\.yaml$`
 ): Promise<SopsFixture> {
   const dir = await mkdtemp(path.join(os.tmpdir(), "keyshelf-sops-"));
   const ageKeyFile = path.join(dir, "age-key.txt");

--- a/packages/cli/test/conformance/sops.contract.test.ts
+++ b/packages/cli/test/conformance/sops.contract.test.ts
@@ -18,15 +18,16 @@ if (sopsAvailable()) {
 
   runAdapterContractSuite({
     name: "sops",
-    // sops does not version its store — a sibling encrypted file holds one value,
-    // already deploy-gated by being committed (ADR-0009). Pinning is N/A, so the
+    // sops does not version its store — an encrypted file in the shelf's
+    // `secrets/` directory holds one value, already deploy-gated by being
+    // committed (ADR-0009). Pinning is N/A, so the
     // pinning cases are skipped for sops.
     supportsVersionPinning: false,
     async setup() {
       fixture = await makeSopsFixture();
       // Decryption needs the fixture's throwaway age key in the environment.
       process.env.SOPS_AGE_KEY_FILE = fixture.ageKeyFile;
-      const storePath = path.join(fixture.dir, ".keyshelf", "app", "staging.secrets.yaml");
+      const storePath = path.join(fixture.dir, ".keyshelf", "app", "secrets", "staging.yaml");
       return { adapter: new SopsAdapter({ storePath, cwd: fixture.dir }) };
     },
     async teardown() {

--- a/packages/cli/test/e2e/sops.secret-roundtrip.e2e.test.ts
+++ b/packages/cli/test/e2e/sops.secret-roundtrip.e2e.test.ts
@@ -36,7 +36,7 @@ if (sopsAvailable()) {
       // from the store path to find it at the project root.
       await writeFile(
         path.join(dir, ".sops.yaml"),
-        `creation_rules:\n  - path_regex: .*\\.secrets\\.yaml$\n    age: ${match[1]}\n`,
+        `creation_rules:\n  - path_regex: secrets/.*\\.yaml$\n    age: ${match[1]}\n`,
         "utf8"
       );
     },
@@ -44,7 +44,7 @@ if (sopsAvailable()) {
       return { SOPS_AGE_KEY_FILE: ageKeyFile };
     },
     async inspectStore(dir) {
-      return readFile(path.join(dir, ".keyshelf", "app", "staging.secrets.yaml"), "utf8");
+      return readFile(path.join(dir, ".keyshelf", "app", "secrets", "staging.yaml"), "utf8");
     },
     expectEncrypted: true,
     async teardown() {

--- a/packages/cli/test/platforms/helpers.ts
+++ b/packages/cli/test/platforms/helpers.ts
@@ -150,7 +150,7 @@ export async function scaffoldSopsProject(dir: string): Promise<{ ageKeyFile: st
 
   await writeFile(
     path.join(dir, ".sops.yaml"),
-    `creation_rules:\n  - path_regex: .*\\.secrets\\.yaml$\n    age: ${recipient}\n`,
+    `creation_rules:\n  - path_regex: secrets/.*\\.yaml$\n    age: ${recipient}\n`,
     "utf8"
   );
 

--- a/packages/cli/test/unit/registry.test.ts
+++ b/packages/cli/test/unit/registry.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { createAdapter } from "../../src/adapters/registry.js";
+import { createAdapter, sopsStorePath } from "../../src/adapters/registry.js";
 import { KeyshelfError } from "../../src/errors.js";
 
 let dir: string;
@@ -39,6 +39,22 @@ describe("createAdapter", () => {
     await prod.write("TOKEN", "prod-token");
     expect(await staging.resolve("TOKEN")).toBe("staging-token");
     expect(await prod.resolve("TOKEN")).toBe("prod-token");
+  });
+
+  it("defaults a sops store to .keyshelf/{shelf}/secrets/{stage}.yaml under the project root", () => {
+    const resolved = sopsStorePath(
+      { adapter: "sops" },
+      { projectDir: dir, project: "myapp", shelf: "web", stage: "staging" }
+    );
+    expect(resolved).toBe(path.join(dir, ".keyshelf", "web", "secrets", "staging.yaml"));
+  });
+
+  it("lets a provider's store: template override the sops default", () => {
+    const resolved = sopsStorePath(
+      { adapter: "sops", store: path.join(".keyshelf", "{shelf}", "{stage}.enc.yaml") },
+      { projectDir: dir, project: "myapp", shelf: "web", stage: "staging" }
+    );
+    expect(resolved).toBe(path.join(dir, ".keyshelf", "web", "staging.enc.yaml"));
   });
 
   it("rejects an unknown adapter name with a structured ADAPTER_UNAVAILABLE error", () => {

--- a/packages/cli/test/unit/sops-binary.test.ts
+++ b/packages/cli/test/unit/sops-binary.test.ts
@@ -37,7 +37,7 @@ describe("sops adapter binary resolution", () => {
   it("maps a missing/unusable sops binary to ADAPTER_UNAVAILABLE at write time", async () => {
     process.env.KEYSHELF_SOPS_BIN = "/definitely/not/a/real/sops/binary";
     const adapter = new SopsAdapter({
-      storePath: path.join("/tmp", "x", "app", "staging.secrets.yaml"),
+      storePath: path.join("/tmp", "x", "app", "secrets", "staging.yaml"),
       cwd: "/tmp/x"
     });
     let thrown: unknown;


### PR DESCRIPTION
Implements ADR-0011 (the adapter-owned store namespace half of the layout change).

## What changed
- `SOPS_DEFAULT_STORE_TEMPLATE` in `packages/cli/src/adapters/registry.ts` moves from `.keyshelf/{shelf}/{stage}.secrets.yaml` to `.keyshelf/{shelf}/secrets/{stage}.yaml`. Because the store now lives in its own `secrets/` directory, the disambiguating `.secrets` filename suffix loses its only job and is dropped.
- `sopsStorePath` is exported and unit-tested: one test pins the new default, one proves a provider `store:` template still overrides it.
- sops fixtures migrated to the new default store location: the conformance fixture `path_regex` (`secrets/.*\.yaml$`), the conformance/e2e/platform-tier hardcoded store paths, and the `.sops.yaml` creation rules the e2e + platform suites scaffold.
- Docstrings and user docs (`README.md`, `docs/reference.md`, `sops.ts`) refreshed to the new default. ADR-0002's references to the old `{stage}.secrets.yaml` layout are left as historical record.

## Scope boundary
This is the store-namespace half of ADR-0011. The `environments/` folder move and the removal of core's `isEnvironmentFile` / `.secrets.yaml` exclusion in `loader.ts` are issue #259's scope and are intentionally untouched here. With the store now in a subdirectory, it is structurally invisible to the (still file-based) environment discovery, so no core change is needed for #260.

## Acceptance criteria
- [x] Default sops store path is `.keyshelf/{shelf}/secrets/{stage}.yaml`
- [x] A custom `store:` template still overrides the default
- [x] sops conformance suite and the secret-roundtrip e2e pass against the new default (run locally with real sops + age)
- [x] `ageKeyFile` behavior unchanged (its resolution logic is untouched; the ageKeyFile conformance suite passes against the new default store)
- [x] No core code references `secrets/` — it stays adapter-only

## Local gate
`lint`, `format:check`, `typecheck`, `validate:examples`, and `npm test -w keyshelf` (360 passed, 3 skipped — non-sops platform tiers) all green with sops + age installed.

Closes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZvtLBxXwjC3uzWCVieBnh