### PR TITLE
docs: update reference + next migration note for ADR-0011 layout (#261)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -72,10 +72,11 @@ The same key may be config in one environment and secret in another.
 _Avoid_: credential, password
 
 **Store**:
-Where an adapter physically persists secret values, always outside the
-environment file. For the sops adapter, a sibling encrypted file
-(`{shelf}/{stage}.secrets.yaml`); for a remote adapter (gcp), the backend itself.
-The environment file holds `!secret` references _into_ the store, never the values.
+Where an adapter physically persists secret values, always outside the shelf's
+`environments/` folder. For the sops adapter, an encrypted file in the shelf's
+`secrets/` directory (`{shelf}/secrets/{stage}.yaml`); for a remote adapter (gcp),
+the backend itself. The environment file holds `!secret` references _into_ the
+store, never the values.
 _Avoid_: vault, backend, storage
 
 **Reference**:

--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ keyshelf init --project myapp --shelf app
 echo "debug" | keyshelf set LOG_LEVEL app/production
 
 # 4. Set a secret. The value is read from stdin and stored encrypted in the
-#    sops sibling file — never written to the environment file in plaintext.
+#    sops store under the shelf's secrets/ folder — never written to the
+#    environment file in plaintext.
 echo "s3cr3t" | keyshelf set DATABASE_PASSWORD app/production --secret
 
 # 5. Validate the environment against its schema (offline; resolves no secrets).
@@ -216,8 +217,9 @@ echo "rotated" | keyshelf set DATABASE_PASSWORD backend/production --secret --fl
 keyshelf set DATABASE_PASSWORD backend/production --pin-latest
 ```
 
-Pinning is **N/A for sops** — its value lives in the committed encrypted sibling
-file and is already deploy-gated by construction. The mapping to Cloud Run is
+Pinning is **N/A for sops** — its value lives in the committed encrypted store
+file (under the shelf's `secrets/` folder) and is already deploy-gated by
+construction. The mapping to Cloud Run is
 direct: a pinned `!secret { version: N }` corresponds to `secretKeyRef.key: "N"`
 (or the wrapper resolving version `N`); a bare floating `!secret` corresponds to
 `secretKeyRef.key: latest` (or the wrapper resolving latest).

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -11,15 +11,41 @@ keyshelf v5? See [Migrating from v5](./migrating-from-v5.md).
 ├── config.yaml                     # project + providers (required)
 └── {shelf}/                        # one shelf per schema
     ├── schema.yaml                 # the shelf's closed validation contract
-    ├── {stage}.yaml                # an environment implementing the shelf's schema
-    └── secrets/
-        └── {stage}.yaml            # sops store for that environment (encrypted; committed)
+    ├── environments/               # the one folder core scans for environments
+    │   └── {stage}.yaml            # an environment implementing the shelf's schema
+    └── secrets/                    # sops adapter's default store (sops only)
+        └── {stage}.yaml            # store for that environment (encrypted; committed)
 ```
 
 Identity is **filesystem-derived**: the shelf is its directory name, the
-environment is its filename (the stage), the schema is the shelf's `schema.yaml`.
+environment is its filename under `environments/` (the stage), the schema is the
+shelf's `schema.yaml`.
 No `name:` or `schema:` fields anywhere. An environment is addressed as
 `{shelf}/{stage}` (e.g. `web-service/staging`).
+
+`environments/` is the **only** folder name core reserves: core reads it
+directly and treats every `*.yaml` inside it as an environment (no exclusion
+rule, no `isEnvironmentFile` predicate). `secrets/` is not a core concept — it is
+merely the sops adapter's _default_ store directory, and the provider's `store:`
+template stays configurable (ADR-0011). The store may live anywhere under the
+shelf **except inside `environments/`**.
+
+### Migrating a `next`-channel layout (6.x)
+
+This folder layout (ADR-0011) lands as a `feat` on the 6.x `next` pre-release
+line; the stable 5.x `latest` line is unaffected, so it is **non-breaking** and
+there is **no automated migration**. If you adopted an earlier 6.x `next` build
+with the previous flat layout, move two sets of files by hand, per shelf:
+
+- **Environment files** — move `{shelf}/{stage}.yaml` into
+  `{shelf}/environments/{stage}.yaml`.
+- **sops stores** — move `{shelf}/{stage}.secrets.yaml` into
+  `{shelf}/secrets/{stage}.yaml` (the `.secrets` suffix is dropped — within its
+  own `secrets/` folder it no longer needs to disambiguate from environment
+  files).
+
+If you overrode the sops `store:` template, update it to match (the new default
+is `{shelf}/secrets/{stage}.yaml`). No file _contents_ change — only their paths.
 
 ## config.yaml
 
@@ -104,8 +130,9 @@ keys:
   value becomes a committed env-file diff that gates rollout: the new value can't
   take effect until the manifest change ships. `version` is a positive integer; a
   non-integer or non-positive `version` is a `MALFORMED_FILE`. Pinning is **N/A for
-  sops** — its value lives in the committed sibling encrypted file, already
-  deploy-gated — and a `version` on a sops `!secret` is inert.
+  sops** — its value lives in the committed encrypted store file (under the
+  shelf's `secrets/` folder), already deploy-gated — and a `version` on a sops
+  `!secret` is inert.
 
 ## Key references (`!ref`)
 
@@ -171,7 +198,7 @@ runs six checks:
    rule (`UNKNOWN_KEY` otherwise). Supplying a `!ref` **discharges** a `!required`
    key, exactly as a config or `!secret` value would.
 2. Target shelf `S` exists — else `REFERENCE_NOT_FOUND`.
-3. Target stage exists, i.e. `S/{G}.yaml` is present — else `REFERENCE_NOT_FOUND`.
+3. Target stage exists, i.e. `S/environments/{G}.yaml` is present — else `REFERENCE_NOT_FOUND`.
 4. Target key `T` is declared in `S`'s schema — else `REFERENCE_NOT_FOUND`.
 5. `T` is **present** in the target environment — supplied there, or covered by a
    schema config default — else `REFERENCE_NOT_FOUND`.


### PR DESCRIPTION
Implements the docs portion of ADR-0011. The `environments/` folder (#259) and the sops `secrets/` store (#260) are already merged to main; this is an audit-and-fill-gaps pass over the remaining user-facing docs.

## Changes
- **docs/reference.md** — fix the File layout diagram (env files now under `environments/`, sops store under `secrets/`); add a paragraph documenting the reserved `environments/` folder and the configurable, adapter-owned store namespace; add a **next-channel (6.x) migration note** covering both moves; correct the `!ref` target-stage path to `S/environments/{G}.yaml`.
- **CONTEXT.md** — update the **Store** definition from the old sibling `{shelf}/{stage}.secrets.yaml` to `{shelf}/secrets/{stage}.yaml`.
- **README.md** — replace "sibling file" wording with the `secrets/` store folder in two spots.

ADR-0002 and the other ADRs are left as historical record; ADR-0011 supersedes the layout by reference.

## Acceptance criteria
- [x] `docs/reference.md` describes the `environments/` and `secrets/` layout
- [x] A migration note covers moving env files AND sops stores for `next` adopters (manual move, non-breaking, lands as a `feat` on 6.x `next`)
- [x] No remaining doc references describe the old flat layout as current
- [x] Domain vocabulary from `CONTEXT.md` used consistently

## Validation
Docs-only change. Ran the full gate locally: `lint`, `format:check`, `typecheck`, `validate:examples` all pass; `npm test -w keyshelf` → 361 passed, 3 skipped.

Closes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZvtLBxXwjC3uzWCVieBnh